### PR TITLE
add classes_ to FgMDM

### DIFF
--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -114,12 +114,6 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
             self.covmeans_ = [mean_covariance(X[y == l], metric=self.metric_mean,
                                     sample_weight=sample_weight[y == l])
                                         for l in self.classes_]
-            """
-            for l in self.classes_:
-                self.covmeans_.append(
-                    mean_covariance(X[y == l], metric=self.metric_mean,
-                                    sample_weight=sample_weight[y == l]))
-            """
         else:
             self.covmeans_ = Parallel(n_jobs=self.n_jobs)(
                 delayed(mean_covariance)(X[y == l], metric=self.metric_mean,
@@ -228,6 +222,11 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
         are used.
 
+    Attributes
+    ----------
+    classes_ : list
+        list of classes.
+
     See Also
     --------
     MDM
@@ -281,6 +280,7 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         self : FgMDM instance
             The FgMDM instance.
         """
+        self.classes_ = numpy.unique(y)
         self._mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
         self._fgda = FGDA(metric=self.metric_mean, tsupdate=self.tsupdate)
         cov = self._fgda.fit_transform(X, y)

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -280,11 +280,11 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         self : FgMDM instance
             The FgMDM instance.
         """
-        self.classes_ = numpy.unique(y)
         self._mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
         self._fgda = FGDA(metric=self.metric_mean, tsupdate=self.tsupdate)
         cov = self._fgda.fit_transform(X, y)
         self._mdm.fit(cov, y)
+        self.classes_ = self._mdm.classes_
         return self
 
     def predict(self, X):


### PR DESCRIPTION
The attribute `classes_` is required for ClassifierMixin, as indicated on this [scikit-learn page](https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator) on how to define your own estimator.

I also removed a dead code part.