### PR TITLE
Correct probas of MDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ The package aims at adopting the [Scikit-Learn](http://scikit-learn.org/stable/d
 
 # changelog
 
+### v0.2.X
+- Add example on SSVEP classification
+- Fix compatibility with scikit-learn v0.24
+- Correct probas of MDM
+
 ### v0.2.6
 - Updated for scikit-learn v0.22
 - Remove support for python 2.7

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,15 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release.
 
+v0.2.X (WIP)
+------------
+
+- Add example on SSVEP classification
+
+- Fix compatibility with scikit-learn v0.24
+
+- Correct probas of MDM
+
 v0.2.6 (March 2020)
 -------------------
 

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -192,7 +192,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         prob : ndarray, shape (n_trials, n_classes)
             the softmax probabilities for each class.
         """
-        return softmax(-self._predict_distances(X))
+        return softmax(-self._predict_distances(X)**2)
 
 
 class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):


### PR DESCRIPTION
When a Riemannian Gaussian distribution is used to model each class k=1... K, the probability density function is [Said2017](https://ieeexplore.ieee.org/abstract/document/7819552):
![mdm_likelihood](https://user-images.githubusercontent.com/5346669/114917990-dc7c1f80-9e26-11eb-82b8-e8272af5886a.png)
where ![mdm_bar_Sigma](https://user-images.githubusercontent.com/5346669/114918037-eaca3b80-9e26-11eb-8bad-e60b37209e94.png) is the center of the Riemannian Gaussian distribution of class k, ![mdm_sigma](https://user-images.githubusercontent.com/5346669/114918080-f61d6700-9e26-11eb-8835-e589084f9ced.png) encodes the dispersion of the distribution, and ![mdm_ksi](https://user-images.githubusercontent.com/5346669/114918112-ffa6cf00-9e26-11eb-8857-f94785dfd39f.png) is a normalization factor.

MDM assumes that: (i) all classes have identical dispersions ![mdm_sigma](https://user-images.githubusercontent.com/5346669/114918172-10efdb80-9e27-11eb-9df4-31b2b30a5dc1.png), and (ii) all classes are likelly (equal priors). 

Under these assumptions, Bayes' law of total probability gives the posterior:
![mdm_proba](https://user-images.githubusercontent.com/5346669/114918189-18af8000-9e27-11eb-808a-9d1362591c32.png)
using squared distances.
