### PR TITLE
Add a normalization function for covariance matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation Status](https://readthedocs.org/projects/pyriemann/badge/?version=latest)](http://pyriemann.readthedocs.io/en/latest/?badge=latest)
 [![Downloads](https://pepy.tech/badge/pot)](https://pepy.tech/project/pyriemann)
 
-pyriemann is a python package for covariance matrices manipulation and classification through riemannian geometry.
+pyRiemann is a python package for covariance matrices manipulation and classification through Riemannian geometry.
 
 The primary target is classification of multivariate biosignals, like EEG, MEG or EMG.
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -116,6 +116,17 @@ Utils function
 
 Utils functions are low level functions that implement most base components of Riemannian Geometry.
 
+Covariance preprocessing
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. _covariance_api:
+.. currentmodule:: pyriemann.utils.covariance
+
+.. autosummary::
+    :toctree: generated/
+
+    normalize
+
+
 Distances
 ~~~~~~~~~~~~~~~~~~~~~~
 .. _distance_api:

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -149,13 +149,13 @@ def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
 
 
 def normalize(X, norm):
-    """Normalize a set of matrices, using trace or determinant.
+    """Normalize a set of square matrices, using trace or determinant.
 
     Parameters
     ----------
     X : ndarray, shape (..., n, n)
-        The set of matrices, at least 2D ndarray. Matrices must be square for
-        trace-normalization, and invertible for determinant-normalization.
+        The set of square matrices, at least 2D ndarray. Matrices must be
+        invertible for determinant-normalization.
 
     norm : {"trace", "determinant"}
         The type of normalization.
@@ -171,13 +171,13 @@ def normalize(X, norm):
         raise ValueError('Matrices must be square')
 
     if norm == "trace":
-        num = numpy.trace(X, axis1=-2, axis2=-1)
+        denom = numpy.trace(X, axis1=-2, axis2=-1)
     elif norm  == "determinant":
-        num = numpy.abs(numpy.linalg.det(X)) ** (1 / X.shape[-1])
+        denom = numpy.abs(numpy.linalg.det(X)) ** (1 / X.shape[-1])
     else:
         raise ValueError("'%s' is not a supported normalization" % norm)
 
-    while num.ndim != X.ndim:
-        num = num[..., numpy.newaxis]
-    Xn = numpy.divide(X, num)
+    while denom.ndim != X.ndim:
+        denom = denom[..., numpy.newaxis]
+    Xn = X / denom
     return Xn

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -146,3 +146,38 @@ def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
             number_windows * normval)
 
     return numpy.abs(S)**2
+
+
+def normalize(X, norm):
+    """Normalize a set of matrices, using trace or determinant.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of matrices, at least 2D ndarray. Matrices must be square for
+        trace-normalization, and invertible for determinant-normalization.
+
+    norm : {"trace", "determinant"}
+        The type of normalization.
+
+    Returns
+    -------
+    Xn : ndarray, shape (..., n, n)
+        The set of normalized matrices, same dimensions as X.
+    """
+    if X.ndim < 2:
+        raise ValueError('Input must have at least 2 dimensions')
+    if X.shape[-2] != X.shape[-1]:
+        raise ValueError('Matrices must be square')
+
+    if norm == "trace":
+        num = numpy.trace(X, axis1=-2, axis2=-1)
+    elif norm  == "determinant":
+        num = numpy.abs(numpy.linalg.det(X)) ** (1 / X.shape[-1])
+    else:
+        raise ValueError("'%s' is not a supported normalization" % norm)
+
+    while num.ndim != X.ndim:
+        num = num[..., numpy.newaxis]
+    Xn = numpy.divide(X, num)
+    return Xn

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -4,7 +4,7 @@ from scipy.signal import coherence as coh_sp
 import pytest
 
 from pyriemann.utils.covariance import (covariances, covariances_EP, eegtocov,
-                                        cospectrum, coherence)
+                                        cospectrum, coherence, normalize)
 
 
 def test_covariances():
@@ -62,3 +62,24 @@ def test_covariances_coherence():
         window='hanning',
         detrend=False)
     assert_array_almost_equal(coh[0, 1], coh2[:-1], 0.1)
+
+
+def test_normalize():
+    """Test normalize"""
+    n_channels = 3
+    cov = eegtocov(np.random.randn(1000, n_channels))
+
+    covn = normalize(cov, "trace")
+    assert_array_almost_equal(np.ones(covn.shape[0]),
+                              np.trace(covn, axis1=-2, axis2=-1),
+                              1e-10)
+    covn = normalize(cov, "determinant")
+    assert_array_almost_equal(np.ones(covn.shape[0]),
+                              np.linalg.det(covn),
+                              1e-10)
+
+    with pytest.raises(ValueError): # not square
+        normalize(np.random.randn(10, n_channels, n_channels + 2), "trace")
+
+    with pytest.raises(ValueError): # invalid normalization type
+        normalize(cov, "abc")


### PR DESCRIPTION
Add a function for trace and determinant normalizations in `utils.covariance` module. Related to #90.