### PR TITLE
Documentation for covariance estimators

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -124,6 +124,7 @@ Covariance preprocessing
 .. autosummary::
     :toctree: generated/
 
+    covariances
     normalize
 
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -25,7 +25,8 @@ class Covariances(BaseEstimator, TransformerMixin):
     ----------
     estimator : string (default: 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-        For a complete list of estimator, see `utils.covariance`.
+        For the complete list of estimators, see parameter `estimator` of
+        :func:`pyriemann.utils.covariance.covariances`.
 
     See Also
     --------
@@ -106,7 +107,8 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         If None (default), all classes will be accounted.
     estimator : string (default: 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-        For a complete list of estimator, see `utils.covariance`.
+        For the complete list of estimators, see parameter `estimator` of
+        :func:`pyriemann.utils.covariance.covariances`.
     svd : int | None (default None)
         if not none, the prototype responses will be reduce using a svd using
         the number of components passed in svd.
@@ -225,7 +227,8 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         If None (default), all classes will be accounted.
     estimator : string (default: 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-        For a complete list of estimator, see `utils.covariance`.
+        For the complete list of estimators, see parameter `estimator` of
+        :func:`pyriemann.utils.covariance.covariances`.
     xdawn_estimator : string (default: 'scm')
         covariance matrix estimator for xdawn spatial filtering.
     baseline_cov : baseline_cov : array, shape(n_chan, n_chan) | None (default)
@@ -239,7 +242,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     References
     ----------
     [1] Barachant, A. "MEG decoding using Riemannian Geometry and Unsupervised
-        classification."
+    classification."
     """
 
     def __init__(self,
@@ -464,7 +467,8 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
         delays up to the given value. A list of int can be given.
     estimator : string (default: 'scm')
         covariance matrix estimator. For regularization consider 'lwf' or 'oas'
-        For a complete list of estimator, see `utils.covariance`.
+        For the complete list of estimators, see parameter `estimator` of
+        :func:`pyriemann.utils.covariance.covariances`.
 
     See Also
     --------

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -206,7 +206,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     Estimation of special form covariance matrix dedicated to ERP processing
     combined with Xdawn spatial filtering. This is similar to `ERPCovariances`
     but data are spatially filtered with `Xdawn`. A complete descrition of the
-    method is available in [1].
+    method is available in [1]_.
 
     The advantage of this estimation is to reduce dimensionality of the
     covariance matrices efficiently.
@@ -241,8 +241,8 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    [1] Barachant, A. "MEG decoding using Riemannian Geometry and Unsupervised
-    classification."
+    .. [1] Barachant, A. "MEG decoding using Riemannian Geometry and
+        Unsupervised classification", 2014
     """
 
     def __init__(self,

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -236,14 +236,14 @@ class BilinearFilter(BaseEstimator, TransformerMixin):
 class CSP(BilinearFilter):
     """Implementation of the CSP spatial Filtering with Covariance as input.
 
-    Implementation of the famous Common Spatial Pattern Algorithm, but with
-    covariance matrices as input. In addition, the implementation allow
-    different metric for the estimation of the class-related mean covariance
-    matrices, as described in [3].
+    Implementation of the famous Common Spatial Pattern algorithm [1]_ [2]_,
+    but with covariance matrices as input. In addition, the implementation
+    allows different metric for the estimation of the class-related mean
+    covariance matrices, as described in [3]_.
 
     This implementation support multiclass CSP by means of approximate joint
     diagonalization. In this case, the spatial filter selection is achieved
-    according to [4].
+    according to [4]_.
 
     Parameters
     ----------
@@ -269,21 +269,22 @@ class CSP(BilinearFilter):
 
     References
     ----------
-    [1] Zoltan J. Koles, Michael S. Lazar, Steven Z. Zhou. Spatial Patterns
-    Underlying Population Differences in the Background EEG. Brain Topography
-    2(4), 275-284, 1990.
+    .. [1] Zoltan J. Koles, Michael S. Lazar, Steven Z. Zhou. Spatial Patterns
+        Underlying Population Differences in the Background EEG. Brain
+        Topography 2(4), 275-284, 1990.
 
-    [2] Benjamin Blankertz, Ryota Tomioka, Steven Lemm, Motoaki Kawanabe,
-    Klaus-Robert Muller. Optimizing Spatial Filters for Robust EEG
-    Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56, 2008.
+    .. [2] Benjamin Blankertz, Ryota Tomioka, Steven Lemm, Motoaki Kawanabe,
+        Klaus-Robert Muller. Optimizing Spatial Filters for Robust EEG
+        Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56,
+        2008.
 
-    [3] A. Barachant, S. Bonnet, M. Congedo and C. Jutten, Common Spatial
-    Pattern revisited by Riemannian geometry, IEEE International Workshop on
-    Multimedia Signal Processing (MMSP), p. 472-476, 2010.
+    .. [3] A. Barachant, S. Bonnet, M. Congedo and C. Jutten, Common Spatial
+        Pattern revisited by Riemannian geometry, IEEE International Workshop
+        on Multimedia Signal Processing (MMSP), p. 472-476, 2010.
 
-    [4] Grosse-Wentrup, Moritz, and Martin Buss. "Multiclass common spatial
-    patterns and information theoretic feature extraction." Biomedical
-    Engineering, IEEE Transactions on 55, no. 8 (2008): 1991-2000.
+    .. [4] Grosse-Wentrup, Moritz, and Martin Buss. "Multiclass common spatial
+        patterns and information theoretic feature extraction." Biomedical
+        Engineering, IEEE Transactions on 55, no. 8 (2008): 1991-2000.
     """
 
     def __init__(self, nfilter=4, metric='euclid', log=True):
@@ -379,7 +380,7 @@ class CSP(BilinearFilter):
 class SPoC(CSP):
     """Implementation of the SPoC spatial filtering with Covariance as input.
 
-    Source Power Comodulation (SPoC) [1] allow to extract spatial filters and
+    Source Power Comodulation (SPoC) [1]_ allows to extract spatial filters and
     patterns by using a target (continuous) variable in the decomposition
     process in order to give preference to components whose power comodulates
     with the target variable.
@@ -416,10 +417,10 @@ class SPoC(CSP):
 
     References
     ----------
-    [1] Dahne, S., Meinecke, F. C., Haufe, S., Hohne, J., Tangermann, M.,
-    Muller, K. R., & Nikulin, V. V. (2014). SPoC: a novel framework for
-    relating the amplitude of neuronal oscillations to behaviorally relevant
-    parameters. NeuroImage, 86, 111-122.
+    .. [1] Dahne, S., Meinecke, F. C., Haufe, S., Hohne, J., Tangermann, M.,
+        Muller, K. R., & Nikulin, V. V. (2014). SPoC: a novel framework for
+        relating the amplitude of neuronal oscillations to behaviorally 
+        relevant parameters. NeuroImage, 86, 111-122.
     """
 
     def fit(self, X, y):

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -32,6 +32,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
     baseline_cov : array, shape(n_chan, n_chan) | None (default)
         Covariance matrix to which the average signals are compared. If None,
         the baseline covariance is computed across all trials and time samples.
+
     Attributes
     ----------
     filters_ : ndarray
@@ -53,6 +54,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
     [1] Rivet, B., Souloumiac, A., Attina, V., & Gibert, G. (2009). xDAWN
     algorithm to enhance evoked potentials: application to brain-computer
     interface. Biomedical Engineering, IEEE Transactions on, 56(8), 2035-2043.
+
     [2] Rivet, B., Cecotti, H., Souloumiac, A., Maby, E., & Mattout, J. (2011,
     August). Theoretical analysis of xDAWN algorithm: application to an
     efficient sensor selection in a P300 BCI. In Signal Processing Conference,
@@ -268,18 +270,20 @@ class CSP(BilinearFilter):
     References
     ----------
     [1] Zoltan J. Koles, Michael S. Lazar, Steven Z. Zhou. Spatial Patterns
-        Underlying Population Differences in the Background EEG. Brain
-        Topography 2(4), 275-284, 1990.
+    Underlying Population Differences in the Background EEG. Brain Topography
+    2(4), 275-284, 1990.
+
     [2] Benjamin Blankertz, Ryota Tomioka, Steven Lemm, Motoaki Kawanabe,
-        Klaus-Robert Muller. Optimizing Spatial Filters for Robust EEG
-        Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56,
-        2008.
+    Klaus-Robert Muller. Optimizing Spatial Filters for Robust EEG
+    Single-Trial Analysis. IEEE Signal Processing Magazine 25(1), 41-56, 2008.
+
     [3] A. Barachant, S. Bonnet, M. Congedo and C. Jutten, Common Spatial
-        Pattern revisited by Riemannian geometry, IEEE International Workshop
-        on Multimedia Signal Processing (MMSP), p. 472-476, 2010.
+    Pattern revisited by Riemannian geometry, IEEE International Workshop on
+    Multimedia Signal Processing (MMSP), p. 472-476, 2010.
+
     [4] Grosse-Wentrup, Moritz, and Martin Buss. "Multiclass common spatial
-        patterns and information theoretic feature extraction." Biomedical
-        Engineering, IEEE Transactions on 55, no. 8 (2008): 1991-2000.
+    patterns and information theoretic feature extraction." Biomedical
+    Engineering, IEEE Transactions on 55, no. 8 (2008): 1991-2000.
     """
 
     def __init__(self, nfilter=4, metric='euclid', log=True):
@@ -413,9 +417,9 @@ class SPoC(CSP):
     References
     ----------
     [1] Dahne, S., Meinecke, F. C., Haufe, S., Hohne, J., Tangermann, M.,
-        Muller, K. R., & Nikulin, V. V. (2014). SPoC: a novel framework for
-        relating the amplitude of neuronal oscillations to behaviorally
-        relevant parameters. NeuroImage, 86, 111-122.
+    Muller, K. R., & Nikulin, V. V. (2014). SPoC: a novel framework for
+    relating the amplitude of neuronal oscillations to behaviorally relevant
+    parameters. NeuroImage, 86, 111-122.
     """
 
     def fit(self, X, y):

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -3,29 +3,24 @@ from sklearn.covariance import oas, ledoit_wolf, fast_mcd, empirical_covariance
 
 # Mapping different estimator on the sklearn toolbox
 
-
 def _lwf(X):
     """Wrapper for sklearn ledoit wolf covariance estimator"""
     C, _ = ledoit_wolf(X.T)
     return C
-
 
 def _oas(X):
     """Wrapper for sklearn oas covariance estimator"""
     C, _ = oas(X.T)
     return C
 
-
 def _scm(X):
     """Wrapper for sklearn sample covariance estimator"""
     return empirical_covariance(X.T)
-
 
 def _mcd(X):
     """Wrapper for sklearn mcd covariance estimator"""
     _, C, _, _ = fast_mcd(X.T)
     return C
-
 
 def _check_est(est):
     """Check if a given estimator is valid"""
@@ -55,7 +50,32 @@ def _check_est(est):
 
 
 def covariances(X, estimator='cov'):
-    """Estimation of covariance matrix."""
+    """Estimation of covariance matrix.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_trials, n_channels, n_samples)
+        ndarray of trials.
+
+    estimator : {'cov', 'scm', 'lwf', 'oas', 'mcd', 'corr'} (default: 'scm')
+        covariance matrix estimator:
+
+        * 'cov' for numpy based covariance matrix, https://numpy.org/doc/stable/reference/generated/numpy.cov.html
+        * 'scm' for sample covariance matrix, https://scikit-learn.org/stable/modules/generated/sklearn.covariance.empirical_covariance.html
+        * 'lwf' for shrunk Ledoit-Wolf covariance matrix, https://scikit-learn.org/stable/modules/generated/sklearn.covariance.ledoit_wolf.html
+        * 'oas' for oracle approximating shrunk covariance matrix, https://scikit-learn.org/stable/modules/generated/sklearn.covariance.OAS.html
+        * 'mcd' for minimum covariance determinant matrix, https://scikit-learn.org/stable/modules/generated/sklearn.covariance.MinCovDet.html
+        * 'corr' for correlation coefficient matrix, https://numpy.org/doc/stable/reference/generated/numpy.corrcoef.html
+
+    Returns
+    -------
+    covmats : ndarray, shape (n_trials, n_channels, n_channels)
+        ndarray of covariance matrices.
+
+    References
+    ----------
+    .. [1] https://scikit-learn.org/stable/modules/covariance.html
+    """
     est = _check_est(estimator)
     Nt, Ne, Ns = X.shape
     covmats = numpy.zeros((Nt, Ne, Ne))


### PR DESCRIPTION
Classes `Covariance`, `ERPCovariances`, `XdawnCovariances`, `HankelCovariances` have a parameter `estimator`, with the same description "For a complete list of estimator, see utils.covariance." But module `utils.covariance` does not provide a documentation about supported estimators.

This PR solves #97, adding the documentation of function `utils.covariance.covariances`, and making cross-references to it.