### PR TITLE
Add cross_spectrum and fix cospectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The package aims at adopting the [Scikit-Learn](http://scikit-learn.org/stable/d
 - Correct probas of MDM
 - Add predict_proba for Potato, and an example on artifact detection
 - Add weights to Pham's AJD algorithm
+- Add cross_spectrum, fix cospectrum; coherence output is kept unchanged
 
 ### v0.2.6
 - Updated for scikit-learn v0.22

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -125,6 +125,7 @@ Covariance preprocessing
     :toctree: generated/
 
     covariances
+	cross_spectrum
     normalize
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -125,7 +125,9 @@ Covariance preprocessing
     :toctree: generated/
 
     covariances
-	cross_spectrum
+    cross_spectrum
+    cospectrum
+    coherence
     normalize
 
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,7 +20,7 @@ v0.2.7.dev
 
 - Add weights to Pham's AJD algorithm
 
-- Add cross_spectrum, fix cospectrum; coherence output is kept unchanged
+- Add :func:`pyriemann.utils.covariance.cross_spectrum`, fix :func:`pyriemann.utils.covariance.cospectrum`; :func:`pyriemann.utils.covariance.coherence` output is kept unchanged
 
 v0.2.6 (March 2020)
 -------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,8 @@ v0.2.7.dev
 
 - Add weights to Pham's AJD algorithm
 
+- Add cross_spectrum, fix cospectrum; coherence output is kept unchanged
+
 v0.2.6 (March 2020)
 -------------------
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -324,9 +324,9 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         The length of the FFT window used for spectral estimation.
     overlap : float (default 0.75)
         The percentage of overlap between window.
-    fmin : float | None , (default None)
+    fmin : float | None, (default None)
         The minimal frequency to be returned.
-    fmax : float | None , (default None)
+    fmax : float | None, (default None)
         The maximal frequency to be returned.
     fs : float | None, (default None)
         The sampling frequency of the signal.
@@ -417,9 +417,9 @@ class Coherences(CospCovariances):
         The lengt of the FFT window used for spectral estimation.
     overlap : float (default 0.75)
         The percentage of overlap between window.
-    fmin : float | None , (default None)
+    fmin : float | None, (default None)
         the minimal frequency to be returned.
-    fmax : float | None , (default None)
+    fmax : float | None, (default None)
         The maximal frequency to be returned.
     fs : float | None, (default None)
         The sampling frequency of the signal.

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -312,22 +312,29 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
 class CospCovariances(BaseEstimator, TransformerMixin):
     """Estimation of cospectral covariance matrix.
 
-    Covariance estimation in the frequency domain. this method will return a
-    4-d array with a covariance matrice estimation for each trial and in each
+    Co-spectral matrices are the real part of complex cross-spectral matrices
+    (see :func:`pyriemann.utils.covariance.cross_spectrum`), estimated as the
+    spectrum covariance in the frequency domain. This method returns a 4-d
+    array with a cospectral covariance matrice for each trial and in each
     frequency bin of the FFT.
 
     Parameters
     ----------
     window : int (default 128)
-        The lengt of the FFT window used for spectral estimation.
+        The length of the FFT window used for spectral estimation.
     overlap : float (default 0.75)
         The percentage of overlap between window.
     fmin : float | None , (default None)
-        the minimal frequency to be returned.
+        The minimal frequency to be returned.
     fmax : float | None , (default None)
         The maximal frequency to be returned.
     fs : float | None, (default None)
         The sampling frequency of the signal.
+
+    Attributes
+    ----------
+    freqs_ : ndarray, shape (n_freqs,)
+        If transformed, the frequencies associated to cospectra.
 
     See Also
     --------
@@ -354,7 +361,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         ----------
         X : ndarray, shape (n_trials, n_channels, n_samples)
             ndarray of trials.
-        y : ndarray shape (n_trials,)
+        y : ndarray, shape (n_trials,)
             labels corresponding to each trial, not used.
 
         Returns
@@ -374,7 +381,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_trials, n_channels, n_channels, n_freq)
+        covmats : ndarray, shape (n_trials, n_channels, n_channels, n_freqs)
             ndarray of covariance matrices for each trials and for each
             frequency bin.
         """
@@ -382,7 +389,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
         out = []
 
         for i in range(Nt):
-            S = cospectrum(
+            S, freqs = cospectrum(
                 X[i],
                 window=self.window,
                 overlap=self.overlap,
@@ -390,6 +397,7 @@ class CospCovariances(BaseEstimator, TransformerMixin):
                 fmax=self.fmax,
                 fs=self.fs)
             out.append(S)
+        self.freqs_ = freqs
 
         return numpy.array(out)
 
@@ -433,7 +441,7 @@ class Coherences(CospCovariances):
 
         Returns
         -------
-        covmats : ndarray, shape (n_trials, n_channels, n_channels, n_freq)
+        covmats : ndarray, shape (n_trials, n_channels, n_channels, n_freqs)
             ndarray of coherence matrices for each trials and for each
             frequency bin.
         """

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -115,16 +115,45 @@ def eegtocov(sig, window=128, overlapp=0.5, padding=True, estimator='cov'):
 
 def coherence(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     """Compute coherence."""
-    cosp = cospectrum(X, window, overlap, fmin, fmax, fs)
-    coh = numpy.zeros_like(cosp)
-    for f in range(cosp.shape[-1]):
-        psd = numpy.sqrt(numpy.diag(cosp[..., f]))
-        coh[..., f] = cosp[..., f] / numpy.outer(psd, psd)
+    S, _ = cross_spectrum(X, window, overlap, fmin, fmax, fs)
+    S2 = numpy.abs(S)**2 # squared cross-spectral modulus
+    coh = numpy.zeros_like(S2)
+    for f in range(S2.shape[-1]):
+        psd = numpy.sqrt(numpy.diag(S2[..., f]))
+        coh[..., f] = S2[..., f] / numpy.outer(psd, psd)
     return coh
 
 
-def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
-    """Compute Cospectrum."""
+def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
+    """Compute the complex cross-spectral matrices of a real signal X.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_trials, n_channels, n_samples)
+        ndarray of trials.
+    window : int (default 128)
+        The length of the FFT window used for spectral estimation.
+    overlap : float (default 0.75)
+        The percentage of overlap between window.
+    fmin : float | None, (default None)
+        The minimal frequency to be returned.
+    fmax : float | None, (default None)
+        The maximal frequency to be returned.
+    fs : float | None, (default None)
+        The sampling frequency of the signal.
+
+    Returns
+    -------
+    S : ndarray, shape (n_trials, n_channels, n_channels, n_freqs)
+        ndarray of cross-spectral matrices for each trials and for each
+        frequency bin.
+    freqs : ndarray, shape (n_freqs,)
+        The frequencies associated to cospectra.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Cross-spectrum
+    """
     Ne, Ns = X.shape
     number_freqs = int(window / 2)
 
@@ -151,21 +180,47 @@ def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
         fdata[window_ix, :, :] = numpy.fft.fft(
             cdata, n=window, axis=1)[:, 0:number_freqs]
 
-    # Adjust Frequency range to specified range (in case it is a parameter)
-    if fmin is not None:
+    # adjust frequency range to specified range (in case it is a parameter)
+    if fs is not None:
+        if fmin is None:
+            fmin = 0
+        if fmax is None:
+            fmax = fs / 2
+        if fmax <= fmin:
+            raise ValueError('Parameter fmax must be superior to fmin')
+        if 2.0 * fmax > fs: # check Nyquist-Shannon
+            raise ValueError('Parameter fmax must be inferior to fs/2')
         f = numpy.arange(0, 1, 1.0 / number_freqs) * (fs / 2.0)
         Fix = (f >= fmin) & (f <= fmax)
         fdata = fdata[:, :, Fix]
+        freqs = f[Fix]
+    else:
+        if fmin is not None:
+            raise Warning('Parameter fmin not used because fs is None')
+        if fmax is not None:
+            raise Warning('Parameter fmax not used because fs is None')
+        freqs = None
 
-    # fdata = fdata.real
     Nf = fdata.shape[2]
     S = numpy.zeros((Ne, Ne, Nf), dtype=complex)
-    normval = numpy.linalg.norm(win)**2
     for i in range(Nf):
-        S[:, :, i] = numpy.dot(fdata[:, :, i].conj().T, fdata[:, :, i]) / (
-            number_windows * normval)
+        S[:, :, i] = numpy.dot(fdata[:, :, i].conj().T, fdata[:, :, i])
+    S /= number_windows * numpy.linalg.norm(win)**2
 
-    return numpy.abs(S)**2
+    return S, freqs
+
+
+def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
+    """Compute co-spectral matrices, the real part of cross-spectra."""
+    S, freqs = cross_spectrum(
+        X=X,
+        window=window,
+        overlap=overlap,
+        fmin=fmin,
+        fmax=fmax,
+        fs=fs)
+
+    return S.real, freqs
 
 
 def normalize(X, norm):

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -51,9 +51,9 @@ def test_covariances_cross_spectrum():
         cross_spectrum(x, fs=128, fmin=20, fmax=10)
     with pytest.raises(ValueError): # fmax > fs/2
         cross_spectrum(x, fs=128, fmin=20, fmax=65)
-    with pytest.raises(Warning): # fs is None
+    with pytest.warns(UserWarning): # fs is None
         cross_spectrum(x, fmin=12)
-    with pytest.raises(Warning): # fs is None
+    with pytest.warns(UserWarning): # fs is None
         cross_spectrum(x, fmax=12)
 
     c, _ = cross_spectrum(x, fs=128, window=256, fmin=3, fmax=51)


### PR DESCRIPTION
This PR solves #116:
- adding a function `cross_spectrum` in `utils.covariance` to compute cross-spectral matrices,
- adding tests for `cross_spectrum`,
- defining `cospectrum` (and `CospCovariances`) as the real part of cross-spectrum,
- adding frequencies in attributes of `CospCovariances`, and completing its documentation,
- modifying `coherence`, to return the same output as before.

Related to #90.