### PR TITLE
Correct spectral estimations

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,8 +7,13 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release.
 
-v0.2.7
-------
+v0.2.8.dev
+----------
+
+- Correct spectral estimation in :func:`pyriemann.utils.covariance.cross_spectrum` to obtain equivalence with SciPy
+
+v0.2.7 (June 2021)
+------------------
 
 - Add example on SSVEP classification
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -449,7 +449,7 @@ class Coherences(CospCovariances):
         out = []
 
         for i in range(Nt):
-            S = coherence(
+            S, _ = coherence(
                 X[i],
                 window=self.window,
                 overlap=self.overlap,

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -129,7 +129,7 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
 
     Parameters
     ----------
-    X : ndarray, shape (n_channels, n_samples)
+    X : ndarray, shape (n_channels, n_times)
         Multi-channel time-series.
     window : int (default 128)
         The length of the FFT window used for spectral estimation.
@@ -153,33 +153,26 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Cross-spectrum
     """
-    Ne, Ns = X.shape
-    number_freqs = int(window / 2)
+    window = int(window)
+    if window < 1:
+        raise ValueError('Value window must be a positive integer')
+    if not 0 < overlap < 1:
+        raise ValueError(
+            'Value overlap must be included in (0, 1) (Got %d)' % overlap)
 
+    n_channels, n_times = X.shape
+    n_freqs = int(window / 2) + 1 # X real signal => compute half-spectrum
     step = int((1.0 - overlap) * window)
-    step = max(1, step)
-
-    number_windows = int((Ns - window) / step + 1)
-    # pre-allocation of memory
-    fdata = np.zeros((number_windows, Ne, number_freqs), dtype=complex)
+    n_windows = int((n_times - window) / step + 1)
     win = np.hanning(window)
 
-    # Loop on all frequencies
-    for window_ix in range(int(number_windows)):
+    # FFT calculation on all windows
+    shape = (n_channels, n_windows, window)
+    strides = X.strides[:-1]+(step*X.strides[-1], X.strides[-1])
+    Xs = np.lib.stride_tricks.as_strided(X, shape=shape, strides=strides)
+    fdata = np.fft.rfft(Xs * win, n=window).transpose(1, 0, 2)
 
-        # time markers to select the data
-        # marker of the beginning of the time window
-        t1 = int(window_ix * step)
-        # marker of the end of the time window
-        t2 = int(t1 + window)
-        # select current window and apodize it
-        cdata = X[:, t1:t2] * win
-
-        # FFT calculation
-        fdata[window_ix, :, :] = np.fft.fft(
-            cdata, n=window, axis=1)[:, 0:number_freqs]
-
-    # adjust frequency range to specified range (in case it is a parameter)
+    # adjust frequency range to specified range
     if fs is not None:
         if fmin is None:
             fmin = 0
@@ -189,10 +182,10 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
             raise ValueError('Parameter fmax must be superior to fmin')
         if 2.0 * fmax > fs:  # check Nyquist-Shannon
             raise ValueError('Parameter fmax must be inferior to fs/2')
-        f = np.arange(0, 1, 1.0 / number_freqs) * (fs / 2.0)
-        Fix = (f >= fmin) & (f <= fmax)
-        fdata = fdata[:, :, Fix]
-        freqs = f[Fix]
+        f = np.arange(0, n_freqs, dtype=int) * float(fs / window)
+        fix = (f >= fmin) & (f <= fmax)
+        fdata = fdata[:, :, fix]
+        freqs = f[fix]
     else:
         if fmin is not None:
             warnings.warn('Parameter fmin not used because fs is None')
@@ -200,11 +193,18 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
             warnings.warn('Parameter fmax not used because fs is None')
         freqs = None
 
-    Nf = fdata.shape[2]
-    S = np.zeros((Ne, Ne, Nf), dtype=complex)
-    for i in range(Nf):
-        S[:, :, i] = np.dot(fdata[:, :, i].conj().T, fdata[:, :, i])
-    S /= number_windows * np.linalg.norm(win)**2
+    n_freqs = fdata.shape[2]
+    S = np.zeros((n_channels, n_channels, n_freqs), dtype=complex)
+    for i in range(n_freqs):
+        S[:, :, i] = fdata[:, :, i].conj().T @ fdata[:, :, i]
+    S /= n_windows * np.linalg.norm(win)**2
+
+    # normalization to respect Parseval's theorem with the half-spectrum
+    # excepted DC bin (always), and Nyquist bin (when window is even)
+    if window % 2:
+        S[..., 1:] *= 2
+    else:
+        S[..., 1:-1] *= 2
 
     return S, freqs
 
@@ -267,14 +267,16 @@ def coherence(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     -------
     C : ndarray, shape (n_channels, n_channels, n_freqs)
         Coherence matrices, for each frequency bin.
+    freqs : ndarray, shape (n_freqs,)
+        The frequencies associated to coherence.
     """
-    S, _ = cross_spectrum(X, window, overlap, fmin, fmax, fs)
+    S, freqs = cross_spectrum(X, window, overlap, fmin, fmax, fs)
     S2 = np.abs(S)**2  # squared cross-spectral modulus
     C = np.zeros_like(S2)
     for f in range(S2.shape[-1]):
         psd = np.sqrt(np.diag(S2[..., f]))
         C[..., f] = S2[..., f] / np.outer(psd, psd)
-    return C
+    return C, freqs
 
 
 ###############################################################################

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -161,7 +161,7 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
             'Value overlap must be included in (0, 1) (Got %d)' % overlap)
 
     n_channels, n_times = X.shape
-    n_freqs = int(window / 2) + 1 # X real signal => compute half-spectrum
+    n_freqs = int(window / 2) + 1  # X real signal => compute half-spectrum
     step = int((1.0 - overlap) * window)
     n_windows = int((n_times - window) / step + 1)
     win = np.hanning(window)

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -92,8 +92,8 @@ def test_covariances_cross_spectrum():
         fs=fs,
         window=window,
         overlap=overlap)
-    spect_pr = np.diagonal(spect_pr.real).T # auto-spectra on diagonal
-    spect_pr = spect_pr / np.linalg.norm(spect_pr) # unit norm
+    spect_pr = np.diagonal(spect_pr.real).T  # auto-spectra on diagonal
+    spect_pr = spect_pr / np.linalg.norm(spect_pr)  # unit norm
     freqs_sp, spect_sp = welch(
         x,
         fs=fs,
@@ -102,7 +102,7 @@ def test_covariances_cross_spectrum():
         window=np.hanning(window),
         detrend=False,
         scaling='spectrum')
-    spect_sp /= np.linalg.norm(spect_sp) # unit norm
+    spect_sp /= np.linalg.norm(spect_sp)  # unit norm
     # compare frequencies
     assert_array_almost_equal(freqs_pr, freqs_sp, 6)
     # compare auto-spectra
@@ -116,7 +116,7 @@ def test_covariances_cross_spectrum():
         fs=fs,
         window=window,
         overlap=overlap)
-    cross_pr = cross_pr[0, 1] / np.linalg.norm(cross_pr[0, 1]) # unit norm
+    cross_pr = cross_pr[0, 1] / np.linalg.norm(cross_pr[0, 1])  # unit norm
     freqs_sp, cross_sp = csd(
         x[0],
         x[1],
@@ -126,7 +126,7 @@ def test_covariances_cross_spectrum():
         window=np.hanning(window),
         detrend=False,
         scaling='spectrum')
-    cross_sp /= np.linalg.norm(cross_sp) # unit norm
+    cross_sp /= np.linalg.norm(cross_sp)  # unit norm
     # compare frequencies
     assert_array_almost_equal(freqs_pr, freqs_sp, 6)
     # compare cross-spectra
@@ -143,7 +143,7 @@ def test_covariances_cospectrum():
     # test equivalence between pyriemann and scipy for cospectra
     fs, window, overlap = 128, 256, 0.75
     cosp_pr, freqs_pr = cospectrum(x, fs=fs, window=window, overlap=overlap)
-    cosp_pr = cosp_pr[0, 1] / np.linalg.norm(cosp_pr[0, 1]) # unit norm
+    cosp_pr = cosp_pr[0, 1] / np.linalg.norm(cosp_pr[0, 1])  # unit norm
     freqs_sp, cross_sp = csd(
         x[0],
         x[1],
@@ -153,7 +153,7 @@ def test_covariances_cospectrum():
         window=np.hanning(window),
         detrend=False,
         scaling='spectrum')
-    cosp_sp = cross_sp.real / np.linalg.norm(cross_sp.real) # unit norm
+    cosp_sp = cross_sp.real / np.linalg.norm(cross_sp.real)  # unit norm
     # compare frequencies
     assert_array_almost_equal(freqs_pr, freqs_sp, 6)
     # compare co-spectra


### PR DESCRIPTION
This PR allows to obtain a 10e-6 equivalence with SciPy for spectral estimations (ie spectra, cross-spectra, co-spectra and coherence):
- adding the Nyquist bin (to obtain the same frequencies),
- adding the half-spectrum normalization, to respect the Parseval's theorem on the Fourier transform (to obtain the same spectral powers) .

Moreover, it provides a faster implementation, removing the for-loop on sliding windows (related to #80).