### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install .[tests]
     - name: Lint with flake8
       run: |
-        flake8 examples pyriemann
+        flake8 examples tests pyriemann
     - name: Test with pytest
       run: |
         pytest

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,8 @@ v0.2.8.dev
 
 - Add Ando-Li-Mathias mean estimation in :func:`pyriemann.utils.mean.mean_covariance`
 
+- Add Schaefer-Strimmer covariance estimator in :func:`pyriemann.utils.covariance.covariances`, and an example to compare estimators
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -22,6 +22,8 @@ v0.2.8.dev
 
 - Add Schaefer-Strimmer covariance estimator in :func:`pyriemann.utils.covariance.covariances`, and an example to compare estimators
 
+- Refactor tests + fix refit of :class:`pyriemann.tangentspace.TangentSpace`
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/examples/signal/README.txt
+++ b/examples/signal/README.txt
@@ -1,0 +1,4 @@
+Preprocessing
+-------------------
+
+Using pyRiemann for signal processing and covariance estimation

--- a/examples/signal/plot_covariance_estimation.py
+++ b/examples/signal/plot_covariance_estimation.py
@@ -1,0 +1,209 @@
+"""
+===============================================================================
+Estimate covariance with different time windows
+===============================================================================
+
+Covariance estimators comparison for different EEG signal lengths and their
+impact on classification [1]_.
+"""
+# Author: Sylvain Chevallier
+#
+# License: BSD (3-clause)
+
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+import seaborn as sns
+
+from mne import Epochs, pick_types, events_from_annotations
+from mne.io import concatenate_raws
+from mne.io.edf import read_raw_edf
+from mne.datasets import eegbci
+from sklearn.model_selection import cross_val_score, StratifiedKFold
+from sklearn.pipeline import make_pipeline
+
+from pyriemann.estimation import Covariances
+from pyriemann.utils.distance import distance
+from pyriemann.classification import MDM
+
+rs = np.random.RandomState(42)
+
+###############################################################################
+# Estimating covariance on synthetic data
+# ----------------------------------------
+#
+# Generate synthetic data, sampled from a distribution considered as the
+# groundtruth.
+
+n_trials, n_channels, n_times = 10, 5, 1000
+var = 2.0 + 0.1 * rs.randn(n_trials, n_channels)
+A = 2 * rs.rand(n_channels, n_channels) - 1
+A /= np.linalg.norm(A, axis=1)[:, np.newaxis]
+true_cov = np.empty(shape=(n_trials, n_channels, n_channels))
+X = np.empty(shape=(n_trials, n_channels, n_times))
+for i in range(n_trials):
+    true_cov[i] = A @ np.diag(var[i]) @ A.T
+    X[i] = rs.multivariate_normal(
+        np.array([0.0] * n_channels), true_cov[i], size=n_times
+    ).T
+
+###############################################################################
+# Covariances() object offers several estimators: SCM, Ledoit-Wolf (LWF),
+# Schaefer-Strimmer (SCH), oracle approximating shrunk covariance (OAS),
+# minimum covariance determinant (MCD) and others. We will compare the
+# distance of LWF, OAS and SCH estimators with the groundtruth, while
+# increasing epoch length.
+
+estimators = ["lwf", "oas", "sch"]
+w_len = np.linspace(10, n_times, 20, dtype=int)
+dfd = list()
+for est in estimators:
+    for wl in w_len:
+        cov_est = Covariances(estimator=est).transform(X[:, :, :wl])
+        for k in range(n_trials):
+            dist = distance(cov_est[k], true_cov[k], metric="riemann")
+            dfd.append(dict(estimator=est, wlen=wl, dist=dist))
+dfd = pd.DataFrame(dfd)
+
+###############################################################################
+
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.set(xscale="log")
+sns.lineplot(data=dfd, x="wlen", y="dist", hue="estimator", ax=ax)
+ax.set_title("Distance to groundtruth covariance matrix")
+ax.set_xlabel("Number of samples")
+ax.set_ylabel(r"$\delta(\Sigma, \hat{\Sigma})$")
+plt.tight_layout()
+
+###############################################################################
+# Choice of estimator for motor imagery data
+# -------------------------------------------
+# Loading data from PhysioNet MI dataset, for subject 1.
+
+event_id = dict(hands=2, feet=3)
+subject = 1
+runs = [6, 10, 14]  # motor imagery: hands vs feet
+raw_files = [
+    read_raw_edf(f, preload=True, stim_channel="auto")
+    for f in eegbci.load_data(subject, runs)
+]
+raw = concatenate_raws(raw_files)
+picks = pick_types(raw.info, eeg=True, exclude="bads")
+
+# subsample elecs
+picks = picks[::2]
+# Apply band-pass filter
+raw.filter(7.0, 35.0, method="iir", picks=picks, skip_by_annotation="edge")
+events, _ = events_from_annotations(raw, event_id=dict(T1=2, T2=3))
+event_ids = dict(hands=2, feet=3)
+
+###############################################################################
+# Influence of shrinkage to estimate covariance
+# -----------------------------------------------
+# Sample covariance matrix (SCM) estimation could lead to ill-conditionned
+# matrices depending on the quality and quantity of EEG data available.
+# Matrix condition number is the ratio between the highest and lowest
+# eigenvalues: high values indicates ill-conditionned matrices that are not
+# suitable for classification.
+# A common approach to mitigate this issue is to regularize covariance matrices
+# by shrinkage, like in Ledoit-Wolf, Schaefer-Strimmer or oracle estimators.
+
+estimators = ["lwf", "oas", "sch", "scm"]
+tmin = -0.2
+w_len = np.linspace(0.2, 2, 10)
+n_trials = 45
+dfc = list()
+
+for wl in w_len:
+    epochs = Epochs(
+        raw,
+        events,
+        event_ids,
+        tmin,
+        tmin + wl,
+        picks=picks,
+        preload=True,
+        verbose=False,
+    )
+    for est in estimators:
+        cov = Covariances(estimator=est).transform(epochs.get_data())
+        for k in range(len(cov)):
+            ev, _ = np.linalg.eigh(cov[k, :, :])
+            dfc.append(dict(estimator=est, wlen=wl, cond=ev[-1] / ev[0]))
+dfc = pd.DataFrame(dfc)
+
+###############################################################################
+
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.set(yscale="log")
+sns.lineplot(data=dfc, x="wlen", y="cond", hue="estimator", ax=ax)
+ax.set_title("Condition number of estimated covariance matrices")
+ax.set_xlabel("Epoch length (s)")
+ax.set_ylabel(r"$\lambda_{\max}$/$\lambda_{\min}$")
+plt.tight_layout()
+
+###############################################################################
+# Picking a good estimator for classification
+# -----------------------------------------------
+# The choice of covariance estimator have an impact on classification,
+# especially when the covariances are estimated on short time windows.
+
+estimators = ["lwf", "oas", "sch", "scm"]
+tmin = 0.0
+w_len = np.linspace(0.2, 2.0, 5)
+n_trials, n_splits = 45, 3
+dfa = list()
+sc = "balanced_accuracy"
+
+cv = StratifiedKFold(n_splits=n_splits, shuffle=True)
+for wl in w_len:
+    epochs = Epochs(
+        raw,
+        events,
+        event_ids,
+        tmin,
+        tmin + wl,
+        proj=True,
+        picks=picks,
+        preload=True,
+        baseline=None,
+        verbose=False,
+    )
+    X = epochs.get_data()
+    y = np.array([0 if ev == 2 else 1 for ev in epochs.events[:, -1]])
+    for est in estimators:
+        clf = make_pipeline(Covariances(estimator=est), MDM())
+        try:
+            score = cross_val_score(clf, X, y, cv=cv, scoring=sc)
+            dfa += [dict(estimator=est, wlen=wl, accuracy=sc) for sc in score]
+        except ValueError:
+            print(f"{est}: {wl} is not sufficent to estimate a SPD matrix")
+            dfa += [dict(estimator=est, wlen=wl, accuracy=np.nan)] * n_splits
+dfa = pd.DataFrame(dfa)
+
+###############################################################################
+
+fig, ax = plt.subplots(figsize=(6, 4))
+sns.lineplot(
+    data=dfa,
+    x="wlen",
+    y="accuracy",
+    hue="estimator",
+    style="estimator",
+    ax=ax,
+    ci=None,
+    markers=True,
+    dashes=False,
+)
+ax.set_title("Accuracy for different estimators and epoch lengths")
+ax.set_xlabel("Epoch length (s)")
+ax.set_ylabel("Classification accuracy")
+plt.tight_layout()
+
+###############################################################################
+# References
+# ----------
+# .. [1] S. Chevallier, E. Kalunga, Q. Barthélemy, F. Yger. "Riemannian
+#    classification for SSVEP based BCI: offline versus online implementations"
+#    Brain–Computer Interfaces Handbook: Technological and Theoretical Advances
+#    , 2018.

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -80,15 +80,12 @@ class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.
-    init : 'k-means++', 'random' or an ndarray (default 'random')
+    init : 'random' or an ndarray (default 'random')
         Method for initialization of centers.
-        'k-means++' : selects initial cluster centers for k-mean
-        clustering in a smart way to speed up convergence. See section
-        Notes in k_init for more details.
         'random': choose k observations (rows) at random from data for
         the initial centroids.
-        If an ndarray is passed, it should be of shape (n_clusters, n_features)
-        and gives the initial centers.
+        If an ndarray is passed, it should be of shape
+        (n_clusters, n_channels, n_channels) and gives the initial centers.
     n_init : int, (default: 10)
         Number of time the k-means algorithm will be run with different
         centroid seeds. The final results will be the best output of
@@ -151,7 +148,7 @@ class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
         self : Kmeans instance
             The Kmean instance.
         """
-        if (self.init != 'random') | (self.n_init == 1):
+        if (self.init != 'random'):
             # no need to iterate if init is not random
             labels, inertia, mdm = _fit_single(X, y,
                                                n_clusters=self.n_clusters,

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -185,7 +185,7 @@ class BilinearFilter(BaseEstimator, TransformerMixin):
         self.log = log
 
     def fit(self, X, y):
-        """Train CSP spatial filters.
+        """Train BilinearFilter spatial filters.
 
         Parameters
         ----------
@@ -196,8 +196,8 @@ class BilinearFilter(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        self : CSP instance
-            The CSP instance.
+        self : BilinearFilter instance
+            The BilinearFilter instance.
         """
         self.filters_ = self.filters
         return self

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -164,7 +164,6 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             the tangent space projection of the matrices.
         """
         # compute mean covariance
-        self._check_reference_points(X)
         self.reference_ = mean_covariance(X, metric=self.metric,
                                           sample_weight=sample_weight)
         return tangent_space(X, self.reference_)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
+[flake8]
+ignore = E226,E704,W503,W504,F401,F811
+
 [build_sphinx]
 source-dir = doc/
 build-dir  = doc/build

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
-[flake8]
-ignore = E226,E704,W503,W504,F401,F811
-
 [build_sphinx]
 source-dir = doc/
 build-dir  = doc/build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest import approx
 import numpy as np
 from functools import partial
 
@@ -65,6 +66,99 @@ def get_labels():
     return _get_labels
 
 
+def is_positive_semi_definite(mats):
+    """Check if all matrices are positive semi-definite
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of square matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    ret : boolean
+        True if all matrices are positive semi-definite
+    """
+    cs = mats.shape[-1]
+    return np.all(np.linalg.eigvals(mats.reshape((-1, cs, cs))) >= 0.0)
+
+
+def is_positive_definite(mats):
+    """Check if all matrices are positive definite
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of square matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    ret : boolean
+        True if all matrices are positive definite.
+    """
+    cs = mats.shape[-1]
+    return np.all(np.linalg.eigvals(mats.reshape((-1, cs, cs))) > 0.0)
+
+
+def is_symmetric(X):
+    """Check if all matrices are symmetric.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of square matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    ret : boolean
+        True if all matrices are symmetric.
+    """
+    # return assert_array_almost_equal(X, np.swapaxes(X, -2, -1), 6)
+    return X == approx(np.swapaxes(X, -2, -1))
+
+
+@pytest.fixture
+def is_spd():
+    """Check if all matrices are symmetric positive-definite.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of square matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    ret : boolean
+        True if all matrices are symmetric positive-definite.
+    """
+
+    def _is_spd(X):
+        return is_symmetric(X) and is_positive_definite(X)
+
+    return _is_spd
+
+
+@pytest.fixture
+def is_spsd():
+    """Check if all matrices are symmetric positive semi-definite.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        The set of square matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    ret : boolean
+        True if all matrices are symmetric positive semi-definite.
+    """
+
+    def _is_spsd(X):
+        return is_symmetric(X) and is_positive_semi_definite(X)
+
+    return _is_spsd
+
+
 def get_distances():
     distances = [
         "riemann",
@@ -105,11 +199,3 @@ def get_metrics():
     ]
     for met in metrics:
         yield met
-
-
-def is_semi_psd(mats):
-    return np.all(np.linalg.eigvals(mats) >= 0.0)
-
-
-def is_psd(mats):
-    return np.all(np.linalg.eigvals(mats) > 0.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,3 +105,7 @@ def get_metrics():
     ]
     for met in metrics:
         yield met
+
+
+def is_spsd(mats):
+    return np.all(np.linalg.eigvals(mats) >= 0.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,27 +22,78 @@ requires_matplotlib = partial(requires_module, name="matplotlib")
 requires_seaborn = partial(requires_module, name="seaborn")
 
 
-def generate_cov(n_trials, n_channels):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
+def generate_cov(n_trials, n_channels, rs, return_params=False):
+    """Generate a set of covariances matrices for test purpose"""
     diags = 2.0 + 0.1 * rs.randn(n_trials, n_channels)
     A = 2 * rs.rand(n_channels, n_channels) - 1
     A /= np.linalg.norm(A, axis=1)[:, np.newaxis]
     covmats = np.empty((n_trials, n_channels, n_channels))
     for i in range(n_trials):
         covmats[i] = A @ np.diag(diags[i]) @ A.T
-    return covmats, diags, A
+    if return_params:
+        return covmats, diags, A
+    else:
+        return covmats
 
 
 @pytest.fixture
-def covmats():
-    """Generate covariance matrices for test"""
-    covmats, _, _ = generate_cov(6, 3)
-    return covmats
+def rndstate():
+    return np.random.RandomState(1234)
 
 
 @pytest.fixture
-def many_covmats():
-    """Generate covariance matrices for test"""
-    covmats, _, _ = generate_cov(100, 3)
-    return covmats
+def get_covmats(rndstate):
+    def _gen_cov(n_trials, n_channels):
+        return generate_cov(n_trials, n_channels, rndstate, return_params=False)
+
+    return _gen_cov
+
+
+@pytest.fixture
+def get_covmats_params(rndstate):
+    def _gen_cov_params(n_trials, n_channels):
+        return generate_cov(n_trials, n_channels, rndstate, return_params=True)
+
+    return _gen_cov_params
+
+
+def get_distances():
+    distances = [
+        "riemann",
+        "logeuclid",
+        "euclid",
+        "logdet",
+        "kullback",
+        "kullback_right",
+        "kullback_sym",
+    ]
+    for dist in distances:
+        yield dist
+
+
+def get_means():
+    means = [
+        "riemann",
+        "logeuclid",
+        "euclid",
+        "logdet",
+        "identity",
+        "wasserstein",
+        "ale",
+        "harmonic",
+        "kullback_sym",
+    ]
+    for mean in means:
+        yield mean
+
+
+def get_metrics():
+    metrics = [
+        "riemann",
+        "logeuclid",
+        "euclid",
+        "logdet",
+        "kullback_sym",
+    ]
+    for met in metrics:
+        yield met

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,5 +107,9 @@ def get_metrics():
         yield met
 
 
-def is_spsd(mats):
+def is_semi_psd(mats):
     return np.all(np.linalg.eigvals(mats) >= 0.0)
+
+
+def is_psd(mats):
+    return np.all(np.linalg.eigvals(mats) > 0.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,14 @@ def get_covmats_params(rndstate):
     return _gen_cov_params
 
 
+@pytest.fixture
+def get_labels():
+    def _get_labels(n_trials, n_classes):
+        return np.arange(n_classes).repeat(n_trials // n_classes)
+
+    return _get_labels
+
+
 def get_distances():
     distances = [
         "riemann",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,16 +43,16 @@ def rndstate():
 
 @pytest.fixture
 def get_covmats(rndstate):
-    def _gen_cov(n_trials, n_channels):
-        return generate_cov(n_trials, n_channels, rndstate, return_params=False)
+    def _gen_cov(n_trials, n_chan):
+        return generate_cov(n_trials, n_chan, rndstate, return_params=False)
 
     return _gen_cov
 
 
 @pytest.fixture
 def get_covmats_params(rndstate):
-    def _gen_cov_params(n_trials, n_channels):
-        return generate_cov(n_trials, n_channels, rndstate, return_params=True)
+    def _gen_cov_params(n_trials, n_chan):
+        return generate_cov(n_trials, n_chan, rndstate, return_params=True)
 
     return _gen_cov_params
 

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -1,4 +1,3 @@
-from conftest import get_covmats, get_covmats_params
 from numpy.testing import assert_array_equal
 import numpy as np
 import pytest

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -42,11 +42,11 @@ def test_ajd_shape(ajd, get_covmats):
 
 def test_pham(get_covmats):
     """Test pham's ajd"""
-    n_trials, n_channels = 5, 3
+    n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     V, D = ajd_pham(covmats)
 
-    w = n_trials * np.ones(n_trials)
+    w = w_val * np.ones(n_trials)
     Vw, Dw = ajd_pham(covmats, sample_weight=w)
     assert_array_equal(V, Vw)  # same result as ajd_pham without weight
     assert_array_equal(D, Dw)
@@ -54,9 +54,9 @@ def test_pham(get_covmats):
 
 def test_pham_pos_weight(get_covmats):
     # Test that weight must be strictly positive
-    n_trials, n_channels = 5, 3
+    n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    w = n_trials * np.ones(n_trials)
+    w = w_val * np.ones(n_trials)
     with pytest.raises(ValueError):  # not strictly positive weight
         w[0] = 0
         ajd_pham(covmats, sample_weight=w)
@@ -65,9 +65,9 @@ def test_pham_pos_weight(get_covmats):
 def test_pham_zero_weight(get_covmats):
     # now test that setting one weight to almost zero it's almost
     # like not passing the matrix
-    n_trials, n_channels = 5, 3
+    n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    w = n_trials * np.ones(n_trials)
+    w = w_val * np.ones(n_trials)
     V, D = ajd_pham(covmats[1:])
     w[0] = 1e-12
 

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -1,73 +1,88 @@
+from conftest import get_covmats, get_covmats_params
 from numpy.testing import assert_array_equal
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from pytest import approx
 
 from pyriemann.utils.ajd import rjd, ajd_pham, uwedge, _get_normalized_weight
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats, diags, A
-
-
-def test_get_normalized_weight():
+def test_get_normalized_weight(get_covmats):
     """Test get_normalized_weight"""
-    Nt = 100
-    covmats, diags, A = generate_cov(Nt, 3)
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
     w = _get_normalized_weight(None, covmats)
-    assert np.isclose(np.sum(w), 1., atol=1e-10)
+    assert np.sum(w) == approx(1.0, abs=1e-10)
 
+
+def test_get_normalized_weight_length(get_covmats):
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
+    w = _get_normalized_weight(None, covmats)
     with pytest.raises(ValueError):  # not same length
-        _get_normalized_weight(w[:Nt//2], covmats)
+        _get_normalized_weight(w[: n_trials // 2], covmats)
+
+
+def test_get_normalized_weight_pos(get_covmats):
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
+    w = _get_normalized_weight(None, covmats)
     with pytest.raises(ValueError):  # not strictly positive weight
         w[0] = 0
         _get_normalized_weight(w, covmats)
 
 
-def test_rjd():
-    """Test rjd"""
-    covmats, _, _ = generate_cov(100, 3)
+@pytest.mark.parametrize("ajd", [rjd, ajd_pham])
+def test_ajd_shape(ajd, get_covmats):
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
     V, D = rjd(covmats)
-    assert V.shape == (3, 3)
-    assert D.shape == (100, 3, 3)
+    assert V.shape == (n_channels, n_channels)
+    assert D.shape == (n_trials, n_channels, n_channels)
 
 
-def test_pham():
+def test_pham(get_covmats):
     """Test pham's ajd"""
-    Nt = 100
-    covmats, diags, A = generate_cov(Nt, 3)
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
     V, D = ajd_pham(covmats)
 
-    w = 5 * np.ones(Nt)
+    w = n_trials * np.ones(n_trials)
     Vw, Dw = ajd_pham(covmats, sample_weight=w)
     assert_array_equal(V, Vw)  # same result as ajd_pham without weight
     assert_array_equal(D, Dw)
 
+
+def test_pham_pos_weight(get_covmats):
     # Test that weight must be strictly positive
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
+    w = n_trials * np.ones(n_trials)
     with pytest.raises(ValueError):  # not strictly positive weight
         w[0] = 0
         ajd_pham(covmats, sample_weight=w)
 
+
+def test_pham_zero_weight(get_covmats):
     # now test that setting one weight to almost zero it's almost
     # like not passing the matrix
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
+    w = n_trials * np.ones(n_trials)
     V, D = ajd_pham(covmats[1:])
     w[0] = 1e-12
 
     Vw, Dw = ajd_pham(covmats, sample_weight=w)
-    assert_allclose(V, Vw, rtol=1e-4, atol=1e-8)
-    assert_allclose(D, Dw[1:], rtol=1e-4, atol=1e-8)
+    assert V == approx(Vw, rel=1e-4, abs=1e-8)
+    assert D == approx(Dw[1:], rel=1e-4, abs=1e-8)
 
 
-def test_uwedge():
+@pytest.mark.parametrize("init", [True, False])
+def test_uwedge(init, get_covmats_params):
     """Test uwedge."""
-    covmats, diags, A = generate_cov(100, 3)
-    V, D = uwedge(covmats)
-    V, D = uwedge(covmats, init=A)
+    n_trials, n_channels = 5, 3
+    covmats, _, A = get_covmats_params(n_trials, n_channels)
+    if init:
+        V, D = uwedge(covmats)
+    else:
+        V, D = uwedge(covmats, init=A)

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -45,9 +45,10 @@ def test_pham(get_covmats):
     n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     V, D = ajd_pham(covmats)
+    assert V.shape == (n_channels, n_channels)
+    assert D.shape == (n_trials, n_channels, n_channels)
 
-    w = w_val * np.ones(n_trials)
-    Vw, Dw = ajd_pham(covmats, sample_weight=w)
+    Vw, Dw = ajd_pham(covmats, sample_weight=w_val * np.ones(n_trials))
     assert_array_equal(V, Vw)  # same result as ajd_pham without weight
     assert_array_equal(D, Dw)
 
@@ -68,7 +69,7 @@ def test_pham_zero_weight(get_covmats):
     n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     w = w_val * np.ones(n_trials)
-    V, D = ajd_pham(covmats[1:])
+    V, D = ajd_pham(covmats[1:], sample_weight=w)
     w[0] = 1e-12
 
     Vw, Dw = ajd_pham(covmats, sample_weight=w)
@@ -85,3 +86,5 @@ def test_uwedge(init, get_covmats_params):
         V, D = uwedge(covmats)
     else:
         V, D = uwedge(covmats, init=A)
+    assert V.shape == (n_channels, n_channels)
+    assert D.shape == (n_trials, n_channels, n_channels)

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -69,7 +69,7 @@ def test_pham_zero_weight(get_covmats):
     n_trials, n_channels, w_val = 5, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     w = w_val * np.ones(n_trials)
-    V, D = ajd_pham(covmats[1:], sample_weight=w)
+    V, D = ajd_pham(covmats[1:], sample_weight=w[1:])
     w[0] = 1e-12
 
     Vw, Dw = ajd_pham(covmats, sample_weight=w)

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -1,31 +1,26 @@
 """Test for channel selection."""
+from conftest import get_covmats, rndstate
 import numpy as np
+from numpy.testing import assert_array_equal
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose."""
-    diags = 1.0+0.1*np.random.randn(Nt, Ne)
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.diag(diags[i])
-    return covmats
-
-
-def test_ElectrodeSelection_transform():
+def test_ElectrodeSelection_transform(get_covmats):
     """Test transform of channelselection."""
-    covset = generate_cov(10, 30)
+    n_trials, n_channels = 10, 3
+    covset = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(5)
     se = ElectrodeSelection()
     se.fit(covset, labels)
     se.transform(covset)
 
 
-def test_FlatChannelRemover():
-    X = np.random.rand(100, 10, 3)
+def test_FlatChannelRemover(rndstate):
+    n_times, n_trials, n_channels = 100, 10, 3
+    X = rndstate.rand(n_times, n_trials, n_channels)
     X[:, 0, :] = 999
     fcr = FlatChannelRemover()
     fcr.fit(X)
-    np.testing.assert_array_equal(fcr.channels_, range(1, 10))
+    assert_array_equal(fcr.channels_, range(1, 10))
     Xt = fcr.fit_transform(X)
-    np.testing.assert_array_equal(Xt, X[:, 1:, :])
+    assert_array_equal(Xt, X[:, 1:, :])

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -8,7 +8,7 @@ def test_ElectrodeSelection_transform(get_covmats, get_labels):
     n_trials, n_channels, n_classes = 10, 30, 2
     # labels = get_labels(n_trials, n_classes)
     covset = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(5)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     se = ElectrodeSelection()
     se.fit(covset, labels)
     se.transform(covset)

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -6,9 +6,8 @@ from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 def test_ElectrodeSelection_transform(get_covmats, get_labels):
     """Test transform of channelselection."""
     n_trials, n_channels, n_classes = 10, 30, 2
-    # labels = get_labels(n_trials, n_classes)
     covset = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     se = ElectrodeSelection()
     se.fit(covset, labels)
     se.transform(covset)

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -1,5 +1,3 @@
-"""Test for channel selection."""
-from conftest import get_covmats, rndstate
 import numpy as np
 from numpy.testing import assert_array_equal
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -1,4 +1,3 @@
-import numpy as np
 from numpy.testing import assert_array_equal
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -3,9 +3,10 @@ from numpy.testing import assert_array_equal
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 
 
-def test_ElectrodeSelection_transform(get_covmats):
+def test_ElectrodeSelection_transform(get_covmats, get_labels):
     """Test transform of channelselection."""
-    n_trials, n_channels = 10, 30
+    n_trials, n_channels, n_classes = 10, 30, 2
+    # labels = get_labels(n_trials, n_classes)
     covset = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(5)
     se = ElectrodeSelection()

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -7,7 +7,7 @@ from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 
 def test_ElectrodeSelection_transform(get_covmats):
     """Test transform of channelselection."""
-    n_trials, n_channels = 10, 3
+    n_trials, n_channels = 10, 30
     covset = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(5)
     se = ElectrodeSelection()

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -25,6 +25,8 @@ class ClassifierTestCase:
             self.clf_populate_classes(classif, covmats, labels)
         if classif is KNearestNeighbor:
             self.clf_predict_proba_trials(classif, covmats, labels)
+        if classif is (FgMDM, TSclassifier):
+            self.clf_tsupdate(classif, covmats, labels)
 
     def test_multi_classes(self, classif, get_covmats):
         n_classes, n_trials, n_channels = 3, 9, 3
@@ -42,6 +44,8 @@ class ClassifierTestCase:
             self.clf_populate_classes(classif, covmats, labels)
         if classif is KNearestNeighbor:
             self.clf_predict_proba_trials(classif, covmats, labels)
+        if classif is (FgMDM, TSclassifier):
+            self.clf_tsupdate(classif, covmats, labels)
 
 
 class TestClassifier(ClassifierTestCase):
@@ -92,6 +96,10 @@ class TestClassifier(ClassifierTestCase):
         clf = classif()
         clf.fit(covmats, labels)
         assert_array_equal(clf.classes_, np.unique(labels))
+
+    def clf_classif_tsupdate(self, classif, covmats, labels):
+        clf = classif(tsupdate=True)
+        clf.fit(covmats, labels).predict(covmats)
 
 
 @pytest.mark.parametrize("classif", [MDM, FgMDM, TSclassifier])
@@ -169,4 +177,9 @@ def test_TSclassifier_classifier(get_covmats):
     clf.fit(covmats, labels).predict(covmats)
 
 
-# TODO: add tsupdate test
+@pytest.mark.parametrize("classif", [FgMDM, TSclassifier])
+def test_classif_tsupdate(classif, get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
+    clf = classif(tsupdate=True)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, get_distances, get_means, get_metrics
+from conftest import get_distances, get_means, get_metrics
 import numpy as np
 from numpy.testing import assert_array_equal
 from pyriemann.classification import MDM, FgMDM, KNearestNeighbor, TSclassifier

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -184,4 +184,4 @@ def test_TSclassifier_classifier(get_covmats):
 def test_TSclassifier_classifier_error():
     """Test TS if not Classifier"""
     with pytest.raises(TypeError):
-        clf = TSclassifier(clf=Covariances())
+        TSclassifier(clf=Covariances())

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -18,6 +18,7 @@ class ClassifierTestCase:
         covmats = get_covmats(n_trials, n_channels)
         labels = get_labels(n_trials, n_classes)
         self.clf_predict(classif, covmats, labels)
+        self.clf_fit_independence(classif, covmats, labels)
         if classif is MDM:
             self.clf_fitpredict(classif, covmats, labels)
         if classif in (MDM, FgMDM):
@@ -36,6 +37,7 @@ class ClassifierTestCase:
         n_classes, n_trials, n_channels = 3, 9, 3
         covmats = get_covmats(n_trials, n_channels)
         labels = get_labels(n_trials, n_classes)
+        self.clf_fit_independence(classif, covmats, labels)
         self.clf_predict(classif, covmats, labels)
         if classif is MDM:
             self.clf_fitpredict(classif, covmats, labels)
@@ -90,6 +92,13 @@ class TestClassifier(ClassifierTestCase):
         clf.fit(covmats, labels)
         transformed = clf.transform(covmats)
         assert transformed.shape == (n_trials, n_classes)
+
+    def clf_fit_independence(self, classif, covmats, labels):
+        clf = classif()
+        clf.fit(covmats, labels).predict(covmats)
+        # retraining with different size should erase previous fit
+        new_covmats = covmats[:, :-1, :-1]
+        clf.fit(new_covmats, labels).predict(new_covmats)
 
     def clf_jobs(self, classif, covmats, labels):
         clf = classif(n_jobs=2)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -2,6 +2,7 @@ from conftest import get_covmats, get_distances, get_means, get_metrics
 import numpy as np
 from numpy.testing import assert_array_equal
 from pyriemann.classification import MDM, FgMDM, KNearestNeighbor, TSclassifier
+from pyriemann.estimation import Covariances
 import pytest
 from pytest import approx
 from sklearn.dummy import DummyClassifier
@@ -129,7 +130,7 @@ def test_metric_dist(classif, mean, dist, get_covmats):
 
 
 @pytest.mark.parametrize("classif", rclf)
-@pytest.mark.parametrize("metric", [42, "faulty"])
+@pytest.mark.parametrize("metric", [42, "faulty", {"foo": "bar"}])
 def test_metric_wrong_keys(classif, metric, get_covmats):
     with pytest.raises((TypeError, KeyError)):
         n_trials, n_channels = 6, 3
@@ -178,3 +179,9 @@ def test_TSclassifier_classifier(get_covmats):
     labels = np.array([0, 1]).repeat(n_trials // 2)
     clf = TSclassifier(clf=DummyClassifier())
     clf.fit(covmats, labels).predict(covmats)
+
+
+def test_TSclassifier_classifier_error():
+    """Test TS if not Classifier"""
+    with pytest.raises(TypeError):
+        clf = TSclassifier(clf=Covariances())

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -7,7 +7,10 @@ from pytest import approx
 from sklearn.dummy import DummyClassifier
 
 
-@pytest.mark.parametrize("classif", [MDM, FgMDM, KNearestNeighbor, TSclassifier])
+rclf = [MDM, FgMDM, KNearestNeighbor, TSclassifier]
+
+
+@pytest.mark.parametrize("classif", rclf)
 class ClassifierTestCase:
     def test_two_classes(self, classif, get_covmats):
         n_classes, n_trials, n_channels = 2, 6, 3
@@ -125,7 +128,7 @@ def test_metric_dist(classif, mean, dist, get_covmats):
     clf.fit(covmats, labels).predict(covmats)
 
 
-@pytest.mark.parametrize("classif", [MDM, FgMDM, KNearestNeighbor, TSclassifier])
+@pytest.mark.parametrize("classif", rclf)
 @pytest.mark.parametrize("metric", [42, "faulty"])
 def test_metric_wrong_keys(classif, metric, get_covmats):
     with pytest.raises((TypeError, KeyError)):
@@ -136,7 +139,7 @@ def test_metric_wrong_keys(classif, metric, get_covmats):
         clf.fit(covmats, labels).predict(covmats)
 
 
-@pytest.mark.parametrize("classif", [MDM, FgMDM, KNearestNeighbor, TSclassifier])
+@pytest.mark.parametrize("classif", rclf)
 @pytest.mark.parametrize("metric", get_metrics())
 def test_metric_str(classif, metric, get_covmats):
     n_trials, n_channels = 6, 3
@@ -175,11 +178,3 @@ def test_TSclassifier_classifier(get_covmats):
     labels = np.array([0, 1]).repeat(n_trials // 2)
     clf = TSclassifier(clf=DummyClassifier())
     clf.fit(covmats, labels).predict(covmats)
-
-
-@pytest.mark.parametrize("classif", [FgMDM, TSclassifier])
-def test_classif_tsupdate(classif, get_covmats):
-    n_trials, n_channels = 6, 3
-    covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
-    clf = classif(tsupdate=True)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,8 +1,7 @@
-from conftest import get_covmats, get_metrics
+from conftest import get_metrics
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
-from pytest import approx
 from pyriemann.clustering import Kmeans, KmeansPerClassTransform, Potato
 
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -121,7 +121,12 @@ def test_km_init_metric(clust, init, n_init, metric, get_covmats):
             n_init=n_init,
         )
     else:
-        clf = clust(n_clusters=n_clusters, metric=metric, init=init, n_init=n_init)
+        clf = clust(
+            n_clusters=n_clusters,
+            metric=metric,
+            init=init,
+            n_init=n_init
+        )
     clf.fit(covmats, labels)
     transformed = clf.transform(covmats)
     assert len(transformed) == n_trials

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -75,7 +75,8 @@ class TestRiemannianClustering(ClusteringTestCase):
         _, n_channels, n_channels = covmats.shape
         clf = clust(n_clusters=n_clusters).fit(covmats)
         centroids = clf.centroids()
-        assert np.array(centroids).shape == (n_clusters, n_channels, n_channels)
+        shape = (n_clusters, n_channels, n_channels)
+        assert np.array(centroids).shape == shape
 
     def clf_transform_per_class(self, clust, covmats, n_clusters, labels):
         n_classes = len(np.unique(labels))
@@ -131,7 +132,10 @@ def test_km_init_metric(clust, init, n_init, metric, get_covmats):
             n_init=n_init,
         )
     else:
-        clf = clust(n_clusters=n_clusters, metric=metric, init=init, n_init=n_init)
+        clf = clust(n_clusters=n_clusters,
+                    metric=metric,
+                    init=init,
+                    n_init=n_init)
     clf.fit(covmats, labels)
     transformed = clf.transform(covmats)
     assert len(transformed) == n_trials

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,128 +1,211 @@
+from conftest import get_covmats, get_metrics
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
+from pytest import approx
 from pyriemann.clustering import Kmeans, KmeansPerClassTransform, Potato
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose."""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats
+@pytest.mark.parametrize("clust", [Kmeans, KmeansPerClassTransform, Potato])
+class ClusteringTestCase:
+    def test_two_clusters(self, clust, get_covmats):
+        n_clusters = 2
+        n_trials, n_channels = 6, 3
+        covmats = get_covmats(n_trials, n_channels)
+        if clust is Kmeans:
+            self.clf_predict(clust, covmats, n_clusters)
+            self.clf_transform(clust, covmats, n_clusters)
+            self.clf_jobs(clust, covmats, n_clusters)
+            self.clf_centroids(clust, covmats, n_clusters)
+        if clust is KmeansPerClassTransform:
+            labels = np.array([0, 1]).repeat(n_trials // 2)
+            self.clf_transform_per_class(clust, covmats, n_clusters, labels)
+            self.clf_jobs(clust, covmats, n_clusters, labels)
+        if clust is Potato:
+            self.clf_transform(clust, covmats)
+            self.clf_predict(clust, covmats)
+            self.clf_predict_proba(clust, covmats)
+            self.clf_partial_fit(clust, covmats)
+
+    def test_three_clusters(self, clust, get_covmats):
+        n_clusters = 3
+        n_trials, n_channels = 6, 3
+        covmats = get_covmats(n_trials, n_channels)
+        if clust is Kmeans:
+            self.clf_predict(clust, covmats, n_clusters)
+            self.clf_transform(clust, covmats, n_clusters)
+            self.clf_jobs(clust, covmats, n_clusters)
+            self.clf_centroids(clust, covmats, n_clusters)
+        if clust is KmeansPerClassTransform:
+            labels = np.array([0, 1]).repeat(n_trials // 2)
+            self.clf_transform_per_class(clust, covmats, n_clusters, labels)
+            self.clf_jobs(clust, covmats, n_clusters, labels)
+        if clust is Potato:
+            self.clf_transform(clust, covmats)
+            self.clf_predict(clust, covmats)
+            self.clf_predict_proba(clust, covmats)
+            self.clf_partial_fit(clust, covmats)
 
 
-def test_Kmeans_init():
-    """Test Kmeans"""
-    covset = generate_cov(20, 3)
-    labels = np.array([0, 1]).repeat(10)
+class TestRiemannianClustering(ClusteringTestCase):
+    def clf_transform(self, clust, covmats, n_clusters=None):
+        n_trials = covmats.shape[0]
+        if n_clusters is None:
+            clf = clust()
+        else:
+            clf = clust(n_clusters=n_clusters)
+        clf.fit(covmats)
+        transformed = clf.transform(covmats)
+        if n_clusters is None:
+            assert transformed.shape == (n_trials,)
+        else:
+            assert transformed.shape == (n_trials, n_clusters)
 
-    # init
-    km = Kmeans(2)
+    def clf_jobs(self, clust, covmats, n_clusters, labels=None):
+        n_trials = covmats.shape[0]
+        clf = clust(n_clusters=n_clusters, n_jobs=2)
+        if labels is None:
+            clf.fit(covmats)
+        else:
+            clf.fit(covmats, labels)
+        transformed = clf.transform(covmats)
+        assert len(transformed) == (n_trials)
 
-    # fit
-    km.fit(covset)
+    def clf_centroids(self, clust, covmats, n_clusters):
+        _, n_channels, n_channels = covmats.shape
+        clf = clust(n_clusters=n_clusters).fit(covmats)
+        centroids = clf.centroids()
+        assert np.array(centroids).shape == (n_clusters, n_channels, n_channels)
 
-    # fit with init
-    km = Kmeans(2, init=covset[0:2])
-    km.fit(covset)
+    def clf_transform_per_class(self, clust, covmats, n_clusters, labels):
+        n_classes = len(np.unique(labels))
+        n_trials = covmats.shape[0]
+        clf = clust(n_clusters=n_clusters)
+        clf.fit(covmats, labels)
+        transformed = clf.transform(covmats)
+        assert transformed.shape == (n_trials, n_classes * n_clusters)
 
-    # fit with labels
-    km.fit(covset, y=labels)
+    def clf_predict(self, clust, covmats, n_clusters=None):
+        n_trials = covmats.shape[0]
+        if n_clusters is None:
+            clf = clust()
+        else:
+            clf = clust(n_clusters=n_clusters)
+        clf.fit(covmats)
+        predicted = clf.predict(covmats)
+        assert predicted.shape == (n_trials,)
 
-    # predict
-    km.predict(covset)
+    def clf_predict_proba(self, clust, covmats, n_clusters=None):
+        n_trials = covmats.shape[0]
+        if n_clusters is None:
+            clf = clust()
+        else:
+            clf = clust(n_clusters=n_clusters)
+        clf.fit(covmats)
+        probabilities = clf.predict(covmats)
+        if n_clusters is None:
+            assert probabilities.shape == (n_trials,)
+        else:
+            assert probabilities.shape == (n_trials, n_clusters)
+            assert probabilities.sum(axis=1) == approx(np.ones(n_trials))
 
-    # transform
-    km.transform(covset)
-
-    # n_jobs
-    km = Kmeans(2, n_jobs=2)
-    km.fit(covset)
-
-
-def test_KmeansPCT_init():
-    """Test Kmeans PCT"""
-    covset = generate_cov(20, 3)
-    labels = np.array([0, 1]).repeat(10)
-
-    # init
-    km = KmeansPerClassTransform(2)
-
-    # fit
-    km.fit(covset, labels)
-
-    # transform
-    km.transform(covset)
+    def clf_partial_fit(self, clust, covmats):
+        clf = clust()
+        clf.fit(covmats)
+        clf.partial_fit(covmats)
 
 
-def test_Potato_init():
-    """Test Potato"""
-    n_trials, n_channels = 20, 3
-    covset = generate_cov(n_trials, n_channels)
-    cov = covset[0][np.newaxis, ...]  # to test potato with a single trial
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+@pytest.mark.parametrize("clust", [Kmeans, KmeansPerClassTransform])
+@pytest.mark.parametrize("init", ["random", "ndarray"])
+@pytest.mark.parametrize("n_init", [1, 5])
+@pytest.mark.parametrize("metric", get_metrics())
+def test_km_init_metric(clust, init, n_init, metric, get_covmats):
+    n_clusters, n_trials, n_channels = 2, 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // n_clusters)
+    if init == "ndarray":
+        clf = clust(
+            n_clusters=n_clusters,
+            metric=metric,
+            init=covmats[:n_clusters],
+            n_init=n_init,
+        )
+    else:
+        clf = clust(n_clusters=n_clusters, metric=metric, init=init, n_init=n_init)
+    clf.fit(covmats, labels)
+    transformed = clf.transform(covmats)
+    assert len(transformed) == n_trials
 
-    # init
-    with pytest.raises(ValueError):  # positive and neg labels equal
+
+def test_Potato_equal_labels():
+    with pytest.raises(ValueError):
         Potato(pos_label=0)
-    pt = Potato()
 
-    # fit no labels
-    pt.fit(covset)
 
-    # fit with labels
+@pytest.mark.parametrize("y_fail", [[1], [0] * 6, [0, 2, 3] + [1] * 17])
+def test_Potato_fit_error(y_fail, get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     with pytest.raises(ValueError):
-        pt.fit(covset, y=[1])
-    with pytest.raises(ValueError):
-        pt.fit(covset, y=[0] * 20)
-    with pytest.raises(ValueError):
-        pt.fit(covset, y=[0, 2, 3] + [1] * 17)
-    pt.fit(covset, labels)
+        Potato().fit(covmats, y=y_fail)
 
-    # partial_fit
+
+def test_Potato_partial_fit_not_fitted(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     with pytest.raises(ValueError):  # potato not fitted
-        Potato().partial_fit(covset)
+        Potato().partial_fit(covmats)
+
+
+def test_Potato_partial_fit_diff_channels(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
+    pt = Potato().fit(covmats, labels)
     with pytest.raises(ValueError):  # unequal # of chans
-        pt.partial_fit(generate_cov(2, n_channels + 1))
-    with pytest.raises(ValueError):  # alpha < 0
-        pt.partial_fit(covset, labels, alpha=-0.1)
-    with pytest.raises(ValueError):  # alpha > 1
-        pt.partial_fit(covset, labels, alpha=1.1)
+        pt.partial_fit(get_covmats(2, n_channels + 1))
+
+
+def test_Potato_partial_fit_no_poslabel(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
+    pt = Potato().fit(covmats, labels)
     with pytest.raises(ValueError):  # no positive labels
-        pt.partial_fit(covset, [0] * n_trials)
-    pt.partial_fit(covset, labels, alpha=0.6)
-    pt.partial_fit(cov, alpha=0.1)
+        pt.partial_fit(covmats, [0] * n_trials)
 
-    # transform
-    pt.transform(covset)
-    pt.transform(cov)
 
-    # predict
-    pt.predict(covset)
-    pt.predict(cov)
+@pytest.mark.parametrize("alpha", [-0.1, 1.1])
+def test_Potato_partial_fit_alpha(alpha, get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
+    pt = Potato().fit(covmats, labels)
+    with pytest.raises(ValueError):
+        pt.partial_fit(covmats, labels, alpha=alpha)
 
-    # predict_proba
-    pt.predict_proba(covset)
-    pt.predict_proba(cov)
 
-    # potato with a single channel
-    covset_1chan = generate_cov(n_trials, 1)
-    pt.fit_transform(covset_1chan)
-    pt.predict(covset_1chan)
-    pt.predict_proba(covset_1chan)
+def test_Potato_1channel(get_covmats):
+    n_trials, n_channels = 6, 1
+    covmats_1chan = get_covmats(n_trials, n_channels)
+    pt = Potato()
+    pt.fit_transform(covmats_1chan)
+    pt.predict(covmats_1chan)
+    pt.predict_proba(covmats_1chan)
 
-    # lower threshold
+
+def test_Potato_threshold(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     pt = Potato(threshold=1)
-    pt.fit(covset)
+    pt.fit(covmats)
 
-    # test positive labels
+
+def test_Potato_specific_labels(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     pt = Potato(threshold=1, pos_label=2, neg_label=7)
-    pt.fit(covset)
-    assert_array_equal(np.unique(pt.predict(covset)), [2, 7])
+    pt.fit(covmats)
+    assert_array_equal(np.unique(pt.predict(covmats)), [2, 7])
     # fit with custom positive label
-    pt.fit(covset, y=[2]*n_trials)
+    pt.fit(covmats, y=[2] * n_trials)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,6 +1,4 @@
-from conftest import get_covmats, get_metrics
-import numpy as np
-from numpy.testing import assert_array_equal
+from conftest import get_metrics
 from pyriemann.embedding import Embedding
 import pytest
 
@@ -14,4 +12,3 @@ def test_embedding(metric, eps, get_covmats):
     embd = Embedding(metric=metric, n_components=n_comp, eps=eps)
     covembd = embd.fit_transform(covmats)
     assert covembd.shape == (n_trials, n_comp)
-    # assert_array_equal(embd.shape[1, n_components)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,23 +1,17 @@
+from conftest import get_covmats, get_metrics
 import numpy as np
-
-from pyriemann.embedding import Embedding
 from numpy.testing import assert_array_equal
+from pyriemann.embedding import Embedding
+import pytest
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose."""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats, diags, A
-
-
-def test_embedding():
+@pytest.mark.parametrize("metric", get_metrics())
+@pytest.mark.parametrize("eps", [None, 0.1])
+def test_embedding(metric, eps, get_covmats):
     """Test Embedding."""
-    covmats, diags, A = generate_cov(100, 3)
-    embd = Embedding(metric='riemann', n_components=2).fit_transform(covmats)
-    assert_array_equal(embd.shape[1], 2)
+    n_trials, n_channels, n_comp = 6, 3, 2
+    covmats = get_covmats(n_trials, n_channels)
+    embd = Embedding(metric=metric, n_components=n_comp, eps=eps)
+    covembd = embd.fit_transform(covmats)
+    assert covembd.shape == (n_trials, n_comp)
+    # assert_array_equal(embd.shape[1, n_components)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -12,3 +12,13 @@ def test_embedding(metric, eps, get_covmats):
     embd = Embedding(metric=metric, n_components=n_comp, eps=eps)
     covembd = embd.fit_transform(covmats)
     assert covembd.shape == (n_trials, n_comp)
+
+
+def test_fit_independence(get_covmats):
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    embd = Embedding()
+    embd.fit_transform(covmats)
+    # retraining with different size should erase previous fit
+    new_covmats = covmats[:, :-1, :-1]
+    embd.fit_transform(new_covmats)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,4 +1,3 @@
-from conftest import rndstate
 import numpy as np
 from pyriemann.estimation import (
     Covariances,
@@ -86,7 +85,7 @@ def test_erp_covariances_svd_error(rndstate):
 
 
 @pytest.mark.parametrize("est", estim)
-def test_xdawn_covariances(est, rndstate):
+def test_xdawn_est(est, rndstate):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
     n_trials, n_channels, n_times = 4, 6, 100
@@ -108,7 +107,7 @@ def test_xdawn_covariances(est, rndstate):
 
 
 @pytest.mark.parametrize("xdawn_est", estim)
-def test_xdawn_covariances(xdawn_est, rndstate):
+def test_xdawn_covariances_est(xdawn_est, rndstate):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
     n_trials, n_channels, n_times = 4, 6, 100

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -11,7 +11,7 @@ from pyriemann.estimation import (
 import pytest
 
 
-estim = ["cov", "scm", "lwf", "oas", "mcd", "corr"]
+estim = ["cov", "scm", "lwf", "oas", "mcd", "corr", "sch"]
 coh = ["ordinary", "instantaneous", "lagged", "imaginary"]
 
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -10,8 +10,8 @@ from pyriemann.estimation import (
 )
 import pytest
 
-
-estim = ["cov", "scm", "lwf", "oas", "mcd", "corr", "sch"]
+# TODO = add "sch" when PR merged
+estim = ["cov", "scm", "lwf", "oas", "mcd", "corr"]
 coh = ["ordinary", "instantaneous", "lagged", "imaginary"]
 
 
@@ -52,11 +52,11 @@ def test_hankel_covariances_delays(rndstate):
 
 @pytest.mark.parametrize("estimator", estim)
 @pytest.mark.parametrize("svd", [None, 2])
-def test_erp_covariances(estimator, svd, rndstate):
+def test_erp_covariances(estimator, svd, rndstate, get_labels):
     """Test fit ERPCovariances"""
     n_classes, n_trials, n_channels, n_times = 2, 4, 3, 100
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     cov = ERPCovariances(estimator=estimator, svd=svd)
     covmats = cov.fit_transform(x, labels)
     if svd is None:
@@ -68,10 +68,10 @@ def test_erp_covariances(estimator, svd, rndstate):
     assert np.any(np.linalg.eigvals(covmats) > 0.0)
 
 
-def test_erp_covariances_classes(rndstate):
-    n_trials, n_channels, n_times = 4, 3, 100
+def test_erp_covariances_classes(rndstate, get_labels):
+    n_trials, n_channels, n_times, n_classes = 4, 3, 100, 2
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     cov = ERPCovariances(classes=[0])
     covmats = cov.fit_transform(x, labels)
     assert covmats.shape == (n_trials, 2 * n_channels, 2 * n_channels)
@@ -85,12 +85,12 @@ def test_erp_covariances_svd_error(rndstate):
 
 
 @pytest.mark.parametrize("est", estim)
-def test_xdawn_est(est, rndstate):
+def test_xdawn_est(est, rndstate, get_labels):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
     n_trials, n_channels, n_times = 4, 6, 100
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     cov = XdawnCovariances(nfilter, estimator=est)
     covmats = cov.fit_transform(x, labels)
     assert cov.get_params() == dict(
@@ -107,12 +107,12 @@ def test_xdawn_est(est, rndstate):
 
 
 @pytest.mark.parametrize("xdawn_est", estim)
-def test_xdawn_covariances_est(xdawn_est, rndstate):
+def test_xdawn_covariances_est(xdawn_est, rndstate, get_labels):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
     n_trials, n_channels, n_times = 4, 6, 100
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     cov = XdawnCovariances(nfilter, xdawn_estimator=xdawn_est)
     covmats = cov.fit_transform(x, labels)
     assert cov.get_params() == dict(
@@ -129,11 +129,11 @@ def test_xdawn_covariances_est(xdawn_est, rndstate):
 
 
 @pytest.mark.parametrize("nfilter", [2, 4])
-def test_xdawn_covariances_nfilter(nfilter, rndstate):
+def test_xdawn_covariances_nfilter(nfilter, rndstate, get_labels):
     """Test fit XdawnCovariances"""
     n_classes, n_trials, n_channels, n_times = 2, 4, 6, 100
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     cov = XdawnCovariances(nfilter=nfilter)
     covmats = cov.fit_transform(x, labels)
     assert cov.get_params() == dict(
@@ -149,11 +149,11 @@ def test_xdawn_covariances_nfilter(nfilter, rndstate):
     assert np.any(np.linalg.eigvals(covmats) > 0.0)
 
 
-def test_xdawn_covariances_applyfilters(rndstate):
+def test_xdawn_covariances_applyfilters(rndstate, get_labels):
     n_classes, nfilter = 2, 2
     n_trials, n_channels, n_times = 4, 6, 100
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     cov = XdawnCovariances(nfilter=nfilter, applyfilters=False)
     covmats = cov.fit_transform(x, labels)
     covsize = n_classes * nfilter + n_channels

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -12,7 +12,11 @@ from pyriemann.estimation import (
 import pytest
 
 
-@pytest.mark.parametrize("estimator", ["cov", "scm", "lwf", "oas", "mcd", "corr"])
+estim = ["cov", "scm", "lwf", "oas", "mcd", "corr"]
+coh = ["ordinary", "instantaneous", "lagged", "imaginary"]
+
+
+@pytest.mark.parametrize("estimator", estim)
 def test_covariances(estimator, rndstate):
     """Test Covariances"""
     n_trials, n_channels, n_times = 2, 3, 100
@@ -47,7 +51,7 @@ def test_hankel_covariances_delays(rndstate):
     assert np.any(np.linalg.eigvals(covmats) > 0.0)
 
 
-@pytest.mark.parametrize("estimator", ["cov", "scm", "lwf", "oas", "mcd", "corr"])
+@pytest.mark.parametrize("estimator", estim)
 @pytest.mark.parametrize("svd", [None, 2])
 def test_erp_covariances(estimator, svd, rndstate):
     """Test fit ERPCovariances"""
@@ -81,7 +85,7 @@ def test_erp_covariances_svd_error(rndstate):
         ERPCovariances(svd="42")
 
 
-@pytest.mark.parametrize("est", ["cov", "scm", "lwf", "oas", "mcd", "corr"])
+@pytest.mark.parametrize("est", estim)
 def test_xdawn_covariances(est, rndstate):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
@@ -103,7 +107,7 @@ def test_xdawn_covariances(est, rndstate):
     assert np.any(np.linalg.eigvals(covmats) > 0.0)
 
 
-@pytest.mark.parametrize("xdawn_est", ["cov", "scm", "lwf", "oas", "mcd", "corr"])
+@pytest.mark.parametrize("xdawn_est", estim)
 def test_xdawn_covariances(xdawn_est, rndstate):
     """Test fit XdawnCovariances"""
     n_classes, nfilter = 2, 2
@@ -173,7 +177,7 @@ def test_cosp_covariances(rndstate):
     assert np.any(np.linalg.eigvals(covmats.mean(axis=-1)) > 0.0)
 
 
-@pytest.mark.parametrize("coh", ["ordinary", "instantaneous", "lagged", "imaginary"])
+@pytest.mark.parametrize("coh", coh)
 def test_coherences(coh, rndstate):
     """Test fit Coherences"""
     n_trials, n_channels, n_times = 2, 3, 1000

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -64,8 +64,8 @@ def test_whitening_dimred(dim_red, rndstate, get_covmats):
         assert whit.n_components_ <= n_channels
     else:
         assert whit.n_components_ == n_comp
-    assert_array_equal(whit.filters_.shape, [n_channels, n_comp])
-    assert_array_equal(whit.inv_filters_.shape, [n_comp, n_channels])
+    assert whit.filters_.shape == (n_channels, n_comp)
+    assert whit.inv_filters_.shape == (n_comp, n_channels)
 
 
 @pytest.mark.parametrize("dim_red", dim_red)
@@ -80,7 +80,7 @@ def test_whitening_transform(dim_red, rndstate, get_covmats):
         n_comp = n_channels
     else:
         n_comp = whit.n_components_
-    assert_array_equal(cov_w.shape, [n_trials, n_comp, n_comp])
+    assert cov_w.shape == (n_trials, n_comp, n_comp)
     # after whitening, mean = identity
     assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_comp))
     if dim_red is not None and "max_cond" in dim_red.keys():
@@ -94,6 +94,6 @@ def test_whitening_inverse_transform(dim_red, rndstate, get_covmats):
     cov = get_covmats(n_trials, n_channels)
     whit = Whitening(dim_red=dim_red).fit(cov)
     cov_iw = whit.inverse_transform(whit.transform(cov))
-    assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])
+    assert cov_iw.shape == (n_trials, n_channels, n_channels)
     if dim_red is None:
         assert_array_almost_equal(cov, cov_iw)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 from pyriemann.spatialfilters import Whitening
 import pytest
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,125 +1,104 @@
-import pytest
-
+from conftest import get_covmats, rndstate
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-
 from pyriemann.spatialfilters import Whitening
+import pytest
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats
+n_components = 3
+expl_var = 0.9
+max_cond = 10
+dim_red = [
+    None,
+    {"n_components": n_components},
+    {"expl_var": expl_var},
+    {"max_cond": max_cond},
+]
 
 
-def test_whitening():
-    """Test Whitening"""
-    n_trials, n_channels, n_components = 20, 6, 3
-    cov = generate_cov(n_trials, n_channels)
-    rs = np.random.RandomState(1234)
-    w = rs.rand(n_trials)
-    max_cond = 10
-
-    # Test Init
+def test_whitening_init():
     whit = Whitening()
-    assert whit.metric == 'euclid'
+    assert whit.metric == "euclid"
     assert whit.dim_red is None
     assert not whit.verbose
 
+
+def test_whitening_error(rndstate, get_covmats):
+    """Test Whitening"""
+    n_trials, n_channels, n_components = 20, 6, 3
+    cov = get_covmats(n_trials, n_channels)
+    w = rndstate.rand(n_trials)
+    whit = Whitening()
     # Test Fit
     with pytest.raises(ValueError):  # len dim_red not equal to 1
-        Whitening(dim_red={'n_components': 2, 'expl_var': 0.5}).fit(cov)
+        Whitening(dim_red={"n_components": 2, "expl_var": 0.5}).fit(cov)
     with pytest.raises(ValueError):  # n_components not superior to 1
-        Whitening(dim_red={'n_components': 0}).fit(cov)
+        Whitening(dim_red={"n_components": 0}).fit(cov)
     with pytest.raises(ValueError):  # n_components not a int
-        Whitening(dim_red={'n_components': 2.5}).fit(cov)
+        Whitening(dim_red={"n_components": 2.5}).fit(cov)
     with pytest.raises(ValueError):  # expl_var out of bound
-        Whitening(dim_red={'expl_var': 0}).fit(cov)
+        Whitening(dim_red={"expl_var": 0}).fit(cov)
     with pytest.raises(ValueError):  # expl_var out of bound
-        Whitening(dim_red={'expl_var': 1.1}).fit(cov)
+        Whitening(dim_red={"expl_var": 1.1}).fit(cov)
     with pytest.raises(ValueError):  # max_cond not strictly superior to 1
-        Whitening(dim_red={'max_cond': 1}).fit(cov)
+        Whitening(dim_red={"max_cond": 1}).fit(cov)
     with pytest.raises(ValueError):  # unknown key
-        Whitening(dim_red={'abc': 42}).fit(cov)
+        Whitening(dim_red={"abc": 42}).fit(cov)
     with pytest.raises(ValueError):  # unknown type
-        Whitening(dim_red='max_cond').fit(cov)
+        Whitening(dim_red="max_cond").fit(cov)
     with pytest.raises(ValueError):  # unknown type
         Whitening(dim_red=20).fit(cov)
 
-    whit = Whitening().fit(cov, sample_weight=w)
-    assert whit.n_components_ == n_channels
-    assert_array_equal(whit.filters_.shape, [n_channels, n_channels])
-    assert_array_equal(whit.inv_filters_.shape, [n_channels, n_channels])
 
-    whit = Whitening(
-        dim_red={'n_components': n_components}
-    ).fit(cov, sample_weight=w)
-    assert whit.n_components_ == n_components
-    assert_array_equal(whit.filters_.shape, [n_channels, n_components])
-    assert_array_equal(whit.inv_filters_.shape, [n_components, n_channels])
+@pytest.mark.parametrize("dim_red", dim_red)
+def test_whitening_dimred(dim_red, rndstate, get_covmats):
+    """Test Whitening"""
+    n_trials, n_channels, n_components = 20, 6, 3
+    cov = get_covmats(n_trials, n_channels)
+    w = rndstate.rand(n_trials)
 
-    whit = Whitening(dim_red={'expl_var': 0.9}).fit(cov, sample_weight=w)
-    assert whit.n_components_ <= n_channels
-    assert_array_equal(whit.filters_.shape, [n_channels, whit.n_components_])
-    assert_array_equal(whit.inv_filters_.shape,
-                       [whit.n_components_, n_channels])
+    whit = Whitening(dim_red=dim_red).fit(cov, sample_weight=w)
+    if dim_red is None:
+        n_comp = n_channels
+    else:
+        n_comp = whit.n_components_
 
-    whit = Whitening(dim_red={'max_cond': max_cond}).fit(cov, sample_weight=w)
-    assert whit.n_components_ <= n_channels
-    assert_array_equal(whit.filters_.shape, [n_channels, whit.n_components_])
-    assert_array_equal(whit.inv_filters_.shape,
-                       [whit.n_components_, n_channels])
+    if dim_red and list(dim_red.keys())[0] in ["expl_var", "max_cond"]:
+        assert whit.n_components_ <= n_channels
+    else:
+        assert whit.n_components_ == n_comp
+    assert_array_equal(whit.filters_.shape, [n_channels, n_comp])
+    assert_array_equal(whit.inv_filters_.shape, [n_comp, n_channels])
 
+
+@pytest.mark.parametrize("dim_red", dim_red)
+def test_whitening_transform(dim_red, rndstate, get_covmats):
+    """Test Whitening"""
+    n_trials, n_channels = 20, 6
+    cov = get_covmats(n_trials, n_channels)
+    w = rndstate.rand(n_trials)
     # Test transform
     whit = Whitening().fit(cov)
     cov_w = whit.transform(cov)
-    assert_array_equal(cov_w.shape, [n_trials, n_channels, n_channels])
+    if dim_red is None:
+        n_comp = n_channels
+    else:
+        n_comp = whit.n_components_
+    assert_array_equal(cov_w.shape, [n_trials, n_comp, n_comp])
     # after whitening, mean = identity
-    assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_channels))
+    assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_comp))
+    if not dim_red is None and "max_cond" in dim_red.keys():
+        assert np.linalg.cond(cov_w.mean(axis=0)) <= max_cond
 
-    whit = Whitening(dim_red={'n_components': n_components}).fit(cov)
-    cov_w = whit.transform(cov)
-    n_components_ = whit.n_components_
-    assert_array_equal(cov_w.shape, [n_trials, n_components_, n_components_])
-    # after whitening, mean = identity
-    assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_components_))
 
-    whit = Whitening(dim_red={'expl_var': 0.9}).fit(cov)
-    cov_w = whit.transform(cov)
-    n_components_ = whit.n_components_
-    assert_array_equal(cov_w.shape, [n_trials, n_components_, n_components_])
-    # after whitening, mean = identity
-    assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_components_))
-
-    whit = Whitening(dim_red={'max_cond': max_cond}).fit(cov)
-    cov_w = whit.transform(cov)
-    n_components_ = whit.n_components_
-    assert_array_equal(cov_w.shape, [n_trials, n_components_, n_components_])
-    # after whitening, mean = identity
-    mean = cov_w.mean(axis=0)
-    assert_array_almost_equal(mean, np.eye(n_components_))
-    assert np.linalg.cond(mean) <= max_cond
-
-    # Test inverse_transform
-    whit = Whitening().fit(cov)
+@pytest.mark.parametrize("dim_red", dim_red)
+def test_whitening_inverse_transform(dim_red, rndstate, get_covmats):
+    """Test Whitening inverse transform"""
+    n_trials, n_channels = 20, 6
+    cov = get_covmats(n_trials, n_channels)
+    w = rndstate.rand(n_trials)
+    whit = Whitening(dim_red=dim_red).fit(cov)
     cov_iw = whit.inverse_transform(whit.transform(cov))
     assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])
-    assert_array_almost_equal(cov, cov_iw)
-
-    whit = Whitening(dim_red={'n_components': n_components}).fit(cov)
-    cov_iw = whit.inverse_transform(whit.transform(cov))
-    assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])
-
-    whit = Whitening(dim_red={'expl_var': 0.9}).fit(cov)
-    cov_iw = whit.inverse_transform(whit.transform(cov))
-    assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])
-
-    whit = Whitening(dim_red={'max_cond': max_cond}).fit(cov)
-    cov_iw = whit.inverse_transform(whit.transform(cov))
-    assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])
+    if dim_red is None:
+        assert_array_almost_equal(cov, cov_iw)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -25,10 +25,8 @@ def test_whitening_init():
 
 def test_whitening_error(rndstate, get_covmats):
     """Test Whitening"""
-    n_trials, n_channels, n_components = 20, 6, 3
+    n_trials, n_channels = 20, 6
     cov = get_covmats(n_trials, n_channels)
-    w = rndstate.rand(n_trials)
-    whit = Whitening()
     # Test Fit
     with pytest.raises(ValueError):  # len dim_red not equal to 1
         Whitening(dim_red={"n_components": 2, "expl_var": 0.5}).fit(cov)
@@ -53,10 +51,10 @@ def test_whitening_error(rndstate, get_covmats):
 @pytest.mark.parametrize("dim_red", dim_red)
 def test_whitening_dimred(dim_red, rndstate, get_covmats):
     """Test Whitening"""
-    n_trials, n_channels, n_components = 20, 6, 3
+    n_trials, n_channels = 20, 6
     cov = get_covmats(n_trials, n_channels)
-    w = rndstate.rand(n_trials)
 
+    w = rndstate.rand(n_trials)
     whit = Whitening(dim_red=dim_red).fit(cov, sample_weight=w)
     if dim_red is None:
         n_comp = n_channels
@@ -76,7 +74,6 @@ def test_whitening_transform(dim_red, rndstate, get_covmats):
     """Test Whitening"""
     n_trials, n_channels = 20, 6
     cov = get_covmats(n_trials, n_channels)
-    w = rndstate.rand(n_trials)
     # Test transform
     whit = Whitening().fit(cov)
     cov_w = whit.transform(cov)
@@ -87,7 +84,7 @@ def test_whitening_transform(dim_red, rndstate, get_covmats):
     assert_array_equal(cov_w.shape, [n_trials, n_comp, n_comp])
     # after whitening, mean = identity
     assert_array_almost_equal(cov_w.mean(axis=0), np.eye(n_comp))
-    if not dim_red is None and "max_cond" in dim_red.keys():
+    if dim_red is not None and "max_cond" in dim_red.keys():
         assert np.linalg.cond(cov_w.mean(axis=0)) <= max_cond
 
 
@@ -96,7 +93,6 @@ def test_whitening_inverse_transform(dim_red, rndstate, get_covmats):
     """Test Whitening inverse transform"""
     n_trials, n_channels = 20, 6
     cov = get_covmats(n_trials, n_channels)
-    w = rndstate.rand(n_trials)
     whit = Whitening(dim_red=dim_red).fit(cov)
     cov_iw = whit.inverse_transform(whit.transform(cov))
     assert_array_equal(cov_iw.shape, [n_trials, n_channels, n_channels])

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,4 +1,3 @@
-from conftest import get_covmats, rndstate
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from pyriemann.spatialfilters import Whitening

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -184,10 +184,8 @@ def test_AJDC_fit(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
-    shape_ffilt = (ajdc.n_sources_, n_channels)
-    shape_bfilt = (n_channels, ajdc.n_sources_)
-    assert_array_equal(ajdc.forward_filters_.shape, shape_ffilt)
-    assert_array_equal(ajdc.backward_filters_.shape, shape_bfilt)
+    assert ajdc.forward_filters_.shape == (ajdc.n_sources_, n_channels)
+    assert ajdc.backward_filters_.shape == (n_channels, ajdc.n_sources_)
 
 
 def test_AJDC_fit_error(rndstate):
@@ -258,7 +256,7 @@ def test_AJDC_inverse_transform(rndstate):
         ajdc.inverse_transform(rndstate.randn(*shape))
 
     Xit = ajdc.inverse_transform(Xt, supp=[ajdc.n_sources_ - 1])
-    assert_array_equal(Xit.shape, [n_trials, n_channels, n_times])
+    assert Xit.shape == (n_trials, n_channels, n_times)
     with pytest.raises(ValueError):  # not a list
         ajdc.inverse_transform(Xt, supp=1)
 
@@ -271,7 +269,7 @@ def test_AJDC_expl_var(rndstate):
     n_trials = 4
     X_new = rndstate.randn(n_trials, n_channels, n_times)
     v = ajdc.get_src_expl_var(X_new)
-    assert_array_equal(v.shape, [n_trials, ajdc.n_sources_])
+    assert v.shape == (n_trials, ajdc.n_sources_)
     with pytest.raises(ValueError):  # not 3 dims
         ajdc.get_src_expl_var(X_new[0])
     with pytest.raises(ValueError):  # unequal # of chans

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -1,231 +1,263 @@
+from conftest import get_covmats, get_metrics, rndstate
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from pyriemann.spatialfilters import (Xdawn, CSP, SPoC,
-                                      BilinearFilter, AJDC)
+from pyriemann.spatialfilters import Xdawn, CSP, SPoC, BilinearFilter, AJDC
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats
+@pytest.mark.parametrize("spfilt", [Xdawn, CSP, SPoC, BilinearFilter, AJDC])
+class SpatialFiltersTestCase:
+    def test_two_classes(self, spfilt, get_covmats, rndstate):
+        n_classes = 2
+        n_trials, n_channels, n_times = 8, 3, 512
+        labels = np.array([0, 1]).repeat(n_trials // n_classes)
+        if spfilt is Xdawn:
+            X = rndstate.randn(n_trials, n_channels, n_times)
+        elif spfilt in (CSP, SPoC, BilinearFilter):
+            X = get_covmats(n_trials, n_channels)
+        elif spfilt is AJDC:
+            n_subjects, n_conditions = 2, 2
+            X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+
+        if spfilt in (Xdawn, CSP, SPoC, AJDC):
+            self.clf_fit(spfilt, X, labels, n_channels, n_times)
+        if spfilt is CSP:
+            self.clf_fit_error(spfilt, X, labels)
+        self.clf_transform(spfilt, X, labels, n_trials, n_channels, n_times)
+        if spfilt in (CSP, SPoC, BilinearFilter):
+            self.clf_transform_error(spfilt, X, labels, n_channels)
+
+    def test_three_classes(self, spfilt, get_covmats, rndstate):
+        n_classes = 3
+        n_trials, n_channels, n_times = 6, 3, 512
+        labels = np.array([0, 1, 2]).repeat(n_trials // n_classes)
 
 
-def test_Xdawn_init():
-    """Test init of Xdawn"""
-    _ = Xdawn()
+class TestSpatialFilters(SpatialFiltersTestCase):
+    def clf_fit(self, spfilt, X, labels, n_channels, n_times):
+        n_classes = len(np.unique(labels))
+        default_nfilter = 4
+        if spfilt is BilinearFilter:
+            filters = np.eye(n_channels)
+            sf = spfilt(filters)
+        else:
+            sf = spfilt()
+        sf.fit(X, labels)
+        if sf is Xdawn:
+            assert len(xd.classes_) == n_classes
+            assert len(sf.filters_) == n_classes * default_nfilter
+            for sfilt in sf.filters_:
+                assert sfilt.shape == (n_channels,)
+        elif sf in [CSP, SPoC]:
+            assert sf.filters_.shape == (default_nfilter, n_times)
+        elif sf is AJDC:
+            n_sources = sf.n_sources_
+            assert sf.forward_filters_.shape == (n_sources_, n_channels)
+
+    def clf_fit_error(self, spfilt, X, labels):
+        sf = spfilt()
+        with pytest.raises(ValueError):
+            sf.fit(X, labels * 0.0)  # 1 class
+        with pytest.raises(ValueError):
+            sf.fit(X, labels[:1])  # unequal # of samples
+        with pytest.raises(TypeError):
+            sf.fit(X, "foo")  # y must be an array
+        with pytest.raises(TypeError):
+            sf.fit("foo", labels)  # X must be an array
+        with pytest.raises(ValueError):
+            sf.fit(X[:, 0], labels)
+        with pytest.raises(ValueError):
+            sf.fit(X, X)
+
+    def clf_transform(self, spfilt, X, labels, n_trials, n_channels, n_times):
+        default_nfilter = 4
+        n_classes = len(np.unique(labels))
+        if spfilt is BilinearFilter:
+            filters = np.eye(n_channels)
+            sf = spfilt(filters)
+        else:
+            sf = spfilt()
+        if spfilt is AJDC:
+            sf.fit(X, labels)
+            X_new = np.squeeze(X[0])
+            n_trials = X_new.shape[0]
+            Xtr = sf.transform(X_new)
+        else:
+            Xtr = sf.fit(X, labels).transform(X)
+        if spfilt is Xdawn:
+            n_comp = n_classes * n_channels
+            assert Xtr.shape == (n_trials, n_comp, n_times)
+        elif spfilt is BilinearFilter:
+            assert Xtr.shape == (n_trials, n_channels, n_channels)
+        elif spfilt is AJDC:
+            assert Xtr.shape == (n_trials, n_channels, n_times)
+        else:
+            assert Xtr.shape == (n_trials, n_channels)
+
+    def clf_transform_error(self, spfilt, X, labels, n_channels):
+        if spfilt is BilinearFilter:
+            filters = np.eye(n_channels)
+            sf = spfilt(filters)
+        else:
+            sf = spfilt()
+        with pytest.raises(ValueError):
+            sf.fit(X, labels).transform(X[:, :-1, :-1])
 
 
-def test_Xdawn_fit():
-    """Test Fit of Xdawn"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    xd = Xdawn()
-    xd.fit(x, labels)
-
-
-def test_Xdawn_transform():
-    """Test transform of Xdawn"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    xd = Xdawn()
-    xd.fit(x, labels)
-    xd.transform(x)
-
-
-def test_Xdawn_baselinecov():
+def test_Xdawn_baselinecov(rndstate):
     """Test cov precomputation"""
-    x = np.random.randn(100, 3, 10)
-    labels = np.array([0, 1]).repeat(50)
-    baseline_cov = np.identity(3)
+    n_trials, n_channels, n_times = 6, 5, 100
+    n_classes, default_nfilter = 2, 4
+    x = rndstate.randn(n_trials, n_channels, n_times)
+    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    baseline_cov = np.identity(n_channels)
     xd = Xdawn(baseline_cov=baseline_cov)
     xd.fit(x, labels)
-    xd.transform(x)
+    transformed = xd.transform(x)
+    assert len(xd.filters_) == n_classes * default_nfilter
+    for sfilt in xd.filters_:
+        assert sfilt.shape == (n_channels,)
 
 
-def test_CSP():
-    """Test CSP"""
-    n_trials = 90
-    X = generate_cov(n_trials, 3)
-    labels = np.array([0, 1, 2]).repeat(n_trials // 3)
+@pytest.mark.parametrize("nfilter", [3, 4])
+@pytest.mark.parametrize("metric", get_metrics())
+@pytest.mark.parametrize("log", [True, False])
+def test_CSP_init(nfilter, metric, log, get_covmats):
+    n_classes, n_trials, n_channels = 2, 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    csp = CSP(nfilter=nfilter, metric=metric, log=log)
+    csp.fit(covmats, labels)
+    Xtr = csp.transform(covmats)
+    if log:
+        assert Xtr.shape == (n_trials, n_channels)
+    else:
+        assert Xtr.shape == (n_trials, n_channels, n_channels)
+    assert csp.filters_.shape == (n_channels, n_channels)
+    assert csp.patterns_.shape == (n_channels, n_channels)
 
-    # Test Init
-    csp = CSP()
-    assert csp.nfilter == 4
-    assert csp.metric == 'euclid'
-    assert csp.log
-    csp = CSP(3, 'riemann', False)
-    assert csp.nfilter == 3
-    assert csp.metric == 'riemann'
-    assert not csp.log
 
+def test_BilinearFilter_filter_error():
     with pytest.raises(TypeError):
-        CSP('foo')
+        BilinearFilter("foo")
 
-    with pytest.raises(ValueError):
-        CSP(metric='foo')
 
+def test_BilinearFilter_log_error():
     with pytest.raises(TypeError):
-        CSP(log='foo')
-
-    # Test fit
-    csp = CSP()
-    csp.fit(X, labels % 2)  # two classes
-    csp.fit(X, labels)  # 3 classes
-
-    with pytest.raises(ValueError):
-        csp.fit(X, labels * 0.)  # 1 class
-    with pytest.raises(ValueError):
-        csp.fit(X, labels[:1])  # unequal # of samples
-    with pytest.raises(TypeError):
-        csp.fit(X, 'foo')  # y must be an array
-    with pytest.raises(TypeError):
-        csp.fit('foo', labels)  # X must be an array
-    with pytest.raises(ValueError):
-        csp.fit(X[:, 0], labels)
-    with pytest.raises(ValueError):
-        csp.fit(X, X)
-
-    assert_array_equal(csp.filters_.shape, [X.shape[1], X.shape[1]])
-    assert_array_equal(csp.patterns_.shape, [X.shape[1], X.shape[1]])
-
-    # Test transform
-    Xt = csp.transform(X)
-    assert_array_equal(Xt.shape, [len(X), X.shape[1]])
-
-    with pytest.raises(TypeError):
-        csp.transform('foo')
-    with pytest.raises(ValueError):
-        csp.transform(X[:, 1:, :])  # unequal # of chans
-
-    csp.log = False
-    Xt = csp.transform(X)
+        BilinearFilter(np.eye(3), log="foo")
 
 
-def test_Spoc():
-    """Test Spoc"""
-    n_trials = 90
-    X = generate_cov(n_trials, 3)
-    labels = np.random.randn(n_trials)
-
-    # Test Init
-    spoc = SPoC()
-
-    # Test fit
-    spoc.fit(X, labels)
-
-
-def test_BilinearFilter():
-    """Test Bilinear filter"""
-    n_trials = 90
-    X = generate_cov(n_trials, 3)
-    labels = np.array([0, 1, 2]).repeat(n_trials // 3)
-    filters = np.eye(3)
-    # Test Init
-    bf = BilinearFilter(filters)
-    assert not bf.log
-    with pytest.raises(TypeError):
-        BilinearFilter('foo')
-
-    with pytest.raises(TypeError):
-        BilinearFilter(np.eye(3), log='foo')
-
-    # test fit
-    bf = BilinearFilter(filters)
-    bf.fit(X, labels % 2)
-
-    # Test transform
-    Xt = bf.transform(X)
-    assert_array_equal(Xt.shape, [len(X), filters.shape[0], filters.shape[0]])
-
-    with pytest.raises(TypeError):
-        bf.transform('foo')
-    with pytest.raises(ValueError):
-        bf.transform(X[:, 1:, :])  # unequal # of chans
-
-    bf.log = True
-    Xt = bf.transform(X)
-    assert_array_equal(Xt.shape, [len(X), filters.shape[0]])
-
-    filters = filters[0:2, :]
-    bf = BilinearFilter(filters)
-    Xt = bf.transform(X)
-    assert_array_equal(Xt.shape, [len(X), filters.shape[0], filters.shape[0]])
+@pytest.mark.parametrize("log", [True, False])
+def test_BilinearFilter_log(log, get_covmats):
+    n_classes, n_trials, n_channels = 2, 6, 3
+    covmats = get_covmats(n_trials, n_channels)
+    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    bf = BilinearFilter(np.eye(n_channels), log=log)
+    Xtr = bf.fit(covmats, labels).transform(covmats)
+    if log:
+        assert Xtr.shape == (n_trials, n_channels)
+    else:
+        assert Xtr.shape == (n_trials, n_channels, n_channels)
 
 
-def test_AJDC():
-    """Test AJDC"""
-    rs = np.random.RandomState(33)
-    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
-    X = rs.randn(n_subjects, n_conditions, n_channels, n_times)
-
-    # Test Init
+def test_AJDC_init():
     ajdc = AJDC(fmin=1, fmax=32, fs=64)
     assert ajdc.window == 128
     assert ajdc.overlap == 0.5
     assert ajdc.dim_red is None
     assert ajdc.verbose
 
-    # Test fit
-    ajdc.fit(X)
-    assert ajdc.n_channels_ == n_channels
-    assert ajdc.n_sources_ <= n_channels
-    assert_array_equal(ajdc.forward_filters_.shape,
-                       [ajdc.n_sources_, n_channels])
-    assert_array_equal(ajdc.backward_filters_.shape,
-                       [n_channels, ajdc.n_sources_])
+
+def test_AJDC_fit(rndstate):
+    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    ajdc = AJDC().fit(X)
+    assert_array_equal(ajdc.forward_filters_.shape, [ajdc.n_sources_, n_channels])
+    assert_array_equal(ajdc.backward_filters_.shape, [n_channels, ajdc.n_sources_])
+
+
+def test_AJDC_fit_error(rndstate):
+    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    ajdc = AJDC()
     with pytest.raises(ValueError):  # unequal # of conditions
-        ajdc.fit([rs.randn(n_conditions, n_channels, n_times),
-                  rs.randn(n_conditions + 1, n_channels, n_times)])
+        ajdc.fit(
+            [
+                rndstate.randn(n_conditions, n_channels, n_times),
+                rndstate.randn(n_conditions + 1, n_channels, n_times),
+            ]
+        )
     with pytest.raises(ValueError):  # unequal # of channels
-        ajdc.fit([rs.randn(n_conditions, n_channels, n_times),
-                  rs.randn(n_conditions, n_channels + 1, n_times)])
-    # 3 subjects, same # conditions and channels, different # of times
-    X = [rs.randn(n_conditions, n_channels, n_times),
-         rs.randn(n_conditions, n_channels, n_times + 200),
-         rs.randn(n_conditions, n_channels, n_times + 500)]
-    ajdc.fit(X)
-    # 2 subjects, 2 conditions, same # channels, different # of times
-    X = [[rs.randn(n_channels, n_times),
-          rs.randn(n_channels, n_times + 200)],
-         [rs.randn(n_channels, n_times + 500),
-          rs.randn(n_channels, n_times + 100)]]
-    ajdc.fit(X)
+        ajdc.fit(
+            [
+                rndstate.randn(n_conditions, n_channels, n_times),
+                rndstate.randn(n_conditions, n_channels + 1, n_times),
+            ]
+        )
 
-    # Test transform
+
+def test_AJDC_transform_error(rndstate):
+    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    ajdc = AJDC().fit(X)
     n_trials = 4
-    X = rs.randn(n_trials, n_channels, n_times)
-    Xt = ajdc.transform(X)
-    assert_array_equal(Xt.shape, [n_trials, ajdc.n_sources_, n_times])
+    X_new = rndstate.randn(n_trials, n_channels, n_times)
     with pytest.raises(ValueError):  # not 3 dims
-        ajdc.transform(X[0])
+        ajdc.transform(X_new[0])
     with pytest.raises(ValueError):  # unequal # of chans
-        ajdc.transform(rs.randn(n_trials, n_channels + 1, 1))
+        ajdc.transform(rndstate.randn(n_trials, n_channels + 1, 1))
 
-    # Test inverse_transform
+
+def test_AJDC_fit_variable_input(rndstate):
+    n_subjects, n_cond, n_chan, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_cond, n_chan, n_times)
+    ajdc = AJDC()
+    # 3 subjects, same # conditions and channels, different # of times
+    X = [
+        rndstate.randn(n_cond, n_chan, n_times + rndstate.randint(500))
+        for _ in range(3)
+    ]
+    ajdc.fit(X)
+
+    # 2 subjects, 2 conditions, same # channels, different # of times
+    X = [
+        [rndstate.randn(n_chan, n_times + rndstate.randint(500)) for _ in range(2)],
+        [rndstate.randn(n_chan, n_times + rndstate.randint(500)) for _ in range(2)],
+    ]
+    ajdc.fit(X)
+
+
+def test_AJDC_inverse_transform(rndstate):
+    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    ajdc = AJDC().fit(X)
+    n_trials = 4
+    X_new = rndstate.randn(n_trials, n_channels, n_times)
+    Xt = ajdc.transform(X_new)
     Xtb = ajdc.inverse_transform(Xt)
     assert_array_equal(Xtb.shape, [n_trials, n_channels, n_times])
     with pytest.raises(ValueError):  # not 3 dims
         ajdc.inverse_transform(Xt[0])
     with pytest.raises(ValueError):  # unequal # of sources
-        ajdc.inverse_transform(rs.randn(n_trials, ajdc.n_sources_ + 1, 1))
+        ajdc.inverse_transform(rndstate.randn(n_trials, ajdc.n_sources_ + 1, 1))
 
     Xtb = ajdc.inverse_transform(Xt, supp=[ajdc.n_sources_ - 1])
     assert_array_equal(Xtb.shape, [n_trials, n_channels, n_times])
     with pytest.raises(ValueError):  # not a list
         ajdc.inverse_transform(Xt, supp=1)
 
+
+def test_AJDC_expl_var(rndstate):
     # Test get_src_expl_var
-    v = ajdc.get_src_expl_var(X)
+    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    ajdc = AJDC().fit(X)
+    n_trials = 4
+    X_new = rndstate.randn(n_trials, n_channels, n_times)
+    v = ajdc.get_src_expl_var(X_new)
     assert_array_equal(v.shape, [n_trials, ajdc.n_sources_])
     with pytest.raises(ValueError):  # not 3 dims
-        ajdc.get_src_expl_var(X[0])
+        ajdc.get_src_expl_var(X_new[0])
     with pytest.raises(ValueError):  # unequal # of chans
-        ajdc.get_src_expl_var(rs.randn(n_trials, n_channels + 1, 1))
+        ajdc.get_src_expl_var(rndstate.randn(n_trials, n_channels + 1, 1))

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -20,8 +20,8 @@ class SpatialFiltersTestCase:
             n_subjects, n_conditions = 2, 2
             X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
 
-        if spfilt in (Xdawn, CSP, SPoC, AJDC):
-            self.clf_fit(spfilt, X, labels, n_channels, n_times)
+        self.clf_fit(spfilt, X, labels, n_channels, n_times)
+        self.clf_fit_independence(spfilt, X, labels, n_channels, n_times)
         if spfilt is CSP:
             self.clf_fit_error(spfilt, X, labels)
         self.clf_transform(spfilt, X, labels, n_trials, n_channels, n_times)
@@ -40,8 +40,8 @@ class SpatialFiltersTestCase:
             n_subjects, n_conditions = 2, 2
             X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
 
-        if spfilt in (Xdawn, CSP, SPoC, AJDC):
-            self.clf_fit(spfilt, X, labels, n_channels, n_times)
+        self.clf_fit(spfilt, X, labels, n_channels, n_times)
+        self.clf_fit_independence(spfilt, X, labels, n_channels, n_times)
         if spfilt is CSP:
             self.clf_fit_error(spfilt, X, labels)
         self.clf_transform(spfilt, X, labels, n_trials, n_channels, n_times)
@@ -115,6 +115,22 @@ class TestSpatialFilters(SpatialFiltersTestCase):
             sf = spfilt()
         with pytest.raises(ValueError):
             sf.fit(X, labels).transform(X[:, :-1, :-1])
+
+    def clf_fit_independence(self, spfilt, X, labels, n_channels, n_times):
+        if spfilt is BilinearFilter:
+            filters = np.eye(n_channels)
+            sf = spfilt(filters)
+        else:
+            sf = spfilt()
+        sf.fit(X, labels)
+        if spfilt is Xdawn:
+            X_new = X[:, :-1, :]
+        elif spfilt in (CSP, SPoC, BilinearFilter):
+            X_new = X[:, :-1, :-1]
+        elif spfilt is AJDC:
+            X_new = X[:, :, :-1, :]
+        # retraining with different size should erase previous fit
+        sf.fit(X_new, labels)
 
 
 def test_Xdawn_baselinecov(rndstate, get_labels):

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, get_metrics, rndstate
+from conftest import get_metrics
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -249,16 +249,16 @@ def test_AJDC_inverse_transform(rndstate):
     n_trials = 4
     X_new = rndstate.randn(n_trials, n_channels, n_times)
     Xt = ajdc.transform(X_new)
-    Xtb = ajdc.inverse_transform(Xt)
-    assert_array_equal(Xtb.shape, [n_trials, n_channels, n_times])
+    Xit = ajdc.inverse_transform(Xt)
+    assert_array_equal(Xit.shape, [n_trials, n_channels, n_times])
     with pytest.raises(ValueError):  # not 3 dims
         ajdc.inverse_transform(Xt[0])
     with pytest.raises(ValueError):  # unequal # of sources
         shape = (n_trials, ajdc.n_sources_ + 1, 1)
         ajdc.inverse_transform(rndstate.randn(*shape))
 
-    Xtb = ajdc.inverse_transform(Xt, supp=[ajdc.n_sources_ - 1])
-    assert_array_equal(Xtb.shape, [n_trials, n_channels, n_times])
+    Xit = ajdc.inverse_transform(Xt, supp=[ajdc.n_sources_ - 1])
+    assert_array_equal(Xit.shape, [n_trials, n_channels, n_times])
     with pytest.raises(ValueError):  # not a list
         ajdc.inverse_transform(Xt, supp=1)
 

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -198,7 +198,7 @@ def test_AJDC_fit_error(rndstate):
 
 
 def test_AJDC_transform_error(rndstate):
-    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
     n_trials = 4
@@ -210,7 +210,7 @@ def test_AJDC_transform_error(rndstate):
 
 
 def test_AJDC_fit_variable_input(rndstate):
-    n_subjects, n_cond, n_chan, n_times = 5, 3, 8, 512
+    n_subjects, n_cond, n_chan, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_cond, n_chan, n_times)
     ajdc = AJDC()
     # 3 subjects, same # conditions and channels, different # of times
@@ -229,7 +229,7 @@ def test_AJDC_fit_variable_input(rndstate):
 
 
 def test_AJDC_inverse_transform(rndstate):
-    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
     n_trials = 4
@@ -250,7 +250,7 @@ def test_AJDC_inverse_transform(rndstate):
 
 def test_AJDC_expl_var(rndstate):
     # Test get_src_expl_var
-    n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
+    n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
     n_trials = 4

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -8,10 +8,10 @@ from pyriemann.spatialfilters import Xdawn, CSP, SPoC, BilinearFilter, AJDC
 
 @pytest.mark.parametrize("spfilt", [Xdawn, CSP, SPoC, BilinearFilter, AJDC])
 class SpatialFiltersTestCase:
-    def test_two_classes(self, spfilt, get_covmats, rndstate):
+    def test_two_classes(self, spfilt, get_covmats, rndstate, get_labels):
         n_classes = 2
         n_trials, n_channels, n_times = 8, 3, 512
-        labels = np.array([0, 1]).repeat(n_trials // n_classes)
+        labels = get_labels(n_trials, n_classes)
         if spfilt is Xdawn:
             X = rndstate.randn(n_trials, n_channels, n_times)
         elif spfilt in (CSP, SPoC, BilinearFilter):
@@ -28,10 +28,10 @@ class SpatialFiltersTestCase:
         if spfilt in (CSP, SPoC, BilinearFilter):
             self.clf_transform_error(spfilt, X, labels, n_channels)
 
-    def test_three_classes(self, spfilt, get_covmats, rndstate):
+    def test_three_classes(self, spfilt, get_covmats, rndstate, get_labels):
         n_classes = 3
         n_trials, n_channels, n_times = 6, 3, 512
-        labels = np.array([0, 1, 2]).repeat(n_trials // n_classes)
+        labels = get_labels(n_trials, n_classes)
         if spfilt is Xdawn:
             X = rndstate.randn(n_trials, n_channels, n_times)
         elif spfilt in (CSP, SPoC, BilinearFilter):
@@ -117,12 +117,12 @@ class TestSpatialFilters(SpatialFiltersTestCase):
             sf.fit(X, labels).transform(X[:, :-1, :-1])
 
 
-def test_Xdawn_baselinecov(rndstate):
+def test_Xdawn_baselinecov(rndstate, get_labels):
     """Test cov precomputation"""
     n_trials, n_channels, n_times = 6, 5, 100
     n_classes, default_nfilter = 2, 4
     x = rndstate.randn(n_trials, n_channels, n_times)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     baseline_cov = np.identity(n_channels)
     xd = Xdawn(baseline_cov=baseline_cov)
     xd.fit(x, labels).transform(x)
@@ -134,10 +134,10 @@ def test_Xdawn_baselinecov(rndstate):
 @pytest.mark.parametrize("nfilter", [3, 4])
 @pytest.mark.parametrize("metric", get_metrics())
 @pytest.mark.parametrize("log", [True, False])
-def test_CSP_init(nfilter, metric, log, get_covmats):
+def test_CSP_init(nfilter, metric, log, get_covmats, get_labels):
     n_classes, n_trials, n_channels = 2, 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     csp = CSP(nfilter=nfilter, metric=metric, log=log)
     csp.fit(covmats, labels)
     Xtr = csp.transform(covmats)
@@ -160,10 +160,10 @@ def test_BilinearFilter_log_error():
 
 
 @pytest.mark.parametrize("log", [True, False])
-def test_BilinearFilter_log(log, get_covmats):
+def test_BilinearFilter_log(log, get_covmats, get_labels):
     n_classes, n_trials, n_channels = 2, 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     bf = BilinearFilter(np.eye(n_channels), log=log)
     Xtr = bf.fit(covmats, labels).transform(covmats)
     if log:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -16,7 +16,7 @@ def test_permutation_mode(mode, get_covmats):
     """Test one way permutation test"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     p = PermutationDistance(100, mode=mode)
     p.test(covmats, labels)
 
@@ -25,7 +25,7 @@ def test_permutation_pairwise(get_covmats):
     """Test one way permutation pairwise test"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     groups = np.array([0] * 3 + [1] * 3)
     # pairwise
     p = PermutationDistance(100, mode="pairwise")
@@ -38,7 +38,7 @@ def test_permutation_pairwise_estimator(get_covmats):
     """Test one way permutation with estimator"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     # with custom estimator
     p = PermutationDistance(10, mode="pairwise", estimator=CSP(2, log=False))
     p.test(covmats, labels)
@@ -48,7 +48,7 @@ def test_permutation_pairwise_unique(get_covmats):
     """Test one way permutation with estimator"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     # unique perms
     p = PermutationDistance(1000)
     p.test(covmats, labels)
@@ -59,7 +59,7 @@ def test_permutation_pairwise_plot(get_covmats):
     """Test one way permutation with estimator"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     p = PermutationDistance(100, mode="pairwise")
     p.test(covmats, labels)
     p.plot(nbins=2)
@@ -69,7 +69,7 @@ def test_permutation_model(get_covmats):
     """Test one way permutation test"""
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(3)
+    labels = np.array([0, 1]).repeat(n_trials // 2)
     # pairwise
     p = PermutationModel(10)
     p.test(covmats, labels)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, requires_matplotlib
+from conftest import requires_matplotlib
 import numpy as np
 from pyriemann.stats import PermutationDistance, PermutationModel
 from pyriemann.spatialfilters import CSP

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,26 +1,30 @@
-from conftest import covmats, requires_matplotlib  # noqa: F401
+from conftest import get_covmats, requires_matplotlib
 import numpy as np
 from pyriemann.stats import PermutationDistance, PermutationModel
 from pyriemann.spatialfilters import CSP
 import pytest
 
 
-def test_permutation_badmode(covmats):  # noqa: F811
+def test_permutation_badmode():
     """Test one way permutation test"""
     with pytest.raises(ValueError):
         PermutationDistance(mode="badmode")
 
 
 @pytest.mark.parametrize("mode", ["ttest", "ftest"])
-def test_permutation_mode(mode, covmats):  # noqa: F811
+def test_permutation_mode(mode, get_covmats):
     """Test one way permutation test"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     p = PermutationDistance(100, mode=mode)
     p.test(covmats, labels)
 
 
-def test_permutation_pairwise(covmats):  # noqa: F811
+def test_permutation_pairwise(get_covmats):
     """Test one way permutation pairwise test"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     groups = np.array([0] * 3 + [1] * 3)
     # pairwise
@@ -30,16 +34,20 @@ def test_permutation_pairwise(covmats):  # noqa: F811
     p.test(covmats, labels, groups=groups)
 
 
-def test_permutation_pairwise_estimator(covmats):  # noqa: F811
+def test_permutation_pairwise_estimator(get_covmats):
     """Test one way permutation with estimator"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     # with custom estimator
     p = PermutationDistance(10, mode="pairwise", estimator=CSP(2, log=False))
     p.test(covmats, labels)
 
 
-def test_permutation_pairwise_unique(covmats):  # noqa: F811
+def test_permutation_pairwise_unique(get_covmats):
     """Test one way permutation with estimator"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     # unique perms
     p = PermutationDistance(1000)
@@ -47,16 +55,20 @@ def test_permutation_pairwise_unique(covmats):  # noqa: F811
 
 
 @requires_matplotlib
-def test_permutation_pairwise_plot(covmats):  # noqa: F811
+def test_permutation_pairwise_plot(get_covmats):
     """Test one way permutation with estimator"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     p = PermutationDistance(100, mode="pairwise")
     p.test(covmats, labels)
     p.plot(nbins=2)
 
 
-def test_permutation_model(covmats):  # noqa: F811
+def test_permutation_model(get_covmats):
     """Test one way permutation test"""
+    n_trials, n_channels = 6, 3
+    covmats = get_covmats(n_trials, n_channels)
     labels = np.array([0, 1]).repeat(3)
     # pairwise
     p = PermutationModel(10)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,20 +12,20 @@ def test_permutation_badmode():
 
 
 @pytest.mark.parametrize("mode", ["ttest", "ftest"])
-def test_permutation_mode(mode, get_covmats):
+def test_permutation_mode(mode, get_covmats, get_labels):
     """Test one way permutation test"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     p = PermutationDistance(100, mode=mode)
     p.test(covmats, labels)
 
 
-def test_permutation_pairwise(get_covmats):
+def test_permutation_pairwise(get_covmats, get_labels):
     """Test one way permutation pairwise test"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     groups = np.array([0] * 3 + [1] * 3)
     # pairwise
     p = PermutationDistance(100, mode="pairwise")
@@ -34,42 +34,42 @@ def test_permutation_pairwise(get_covmats):
     p.test(covmats, labels, groups=groups)
 
 
-def test_permutation_pairwise_estimator(get_covmats):
+def test_permutation_pairwise_estimator(get_covmats, get_labels):
     """Test one way permutation with estimator"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     # with custom estimator
     p = PermutationDistance(10, mode="pairwise", estimator=CSP(2, log=False))
     p.test(covmats, labels)
 
 
-def test_permutation_pairwise_unique(get_covmats):
+def test_permutation_pairwise_unique(get_covmats, get_labels):
     """Test one way permutation with estimator"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     # unique perms
     p = PermutationDistance(1000)
     p.test(covmats, labels)
 
 
 @requires_matplotlib
-def test_permutation_pairwise_plot(get_covmats):
+def test_permutation_pairwise_plot(get_covmats, get_labels):
     """Test one way permutation with estimator"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     p = PermutationDistance(100, mode="pairwise")
     p.test(covmats, labels)
     p.plot(nbins=2)
 
 
-def test_permutation_model(get_covmats):
+def test_permutation_model(get_covmats, get_labels):
     """Test one way permutation test"""
-    n_trials, n_channels = 6, 3
+    n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
-    labels = np.array([0, 1]).repeat(n_trials // 2)
+    labels = get_labels(n_trials, n_classes)
     # pairwise
     p = PermutationModel(10)
     p.test(covmats, labels)

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -1,6 +1,5 @@
-from conftest import get_covmats, get_metrics, rndstate
+from conftest import get_metrics
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 from pyriemann.tangentspace import TangentSpace, FGDA
 import pytest
 from pytest import approx

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -95,16 +95,14 @@ def test_FGDA_init(tsupdate, metric, get_covmats):
 def test_TS_vecdim_error(get_covmats, rndstate):
     n_trials, n_ts = 4, 6
     ts = TangentSpace()
-    # ts.fit(covmats, labels)
     with pytest.raises(ValueError):
         tsvectors_wrong = np.empty((n_trials, n_ts + 1))
         ts.transform(tsvectors_wrong)
 
 
 def test_TS_matdim_error(get_covmats):
-    n_trials, n_channels, n_ts = 4, 3, 6
+    n_trials, n_channels = 4, 3
     ts = TangentSpace()
-    # ts.fit(covmats, labels)
     with pytest.raises(ValueError):
         not_square_mat = np.empty((n_trials, n_channels, n_channels + 1))
         ts.transform(not_square_mat)

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -1,108 +1,81 @@
-"""Test tangent space functions."""
+from conftest import get_covmats, get_metrics
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-import pytest
-
 from pyriemann.tangentspace import TangentSpace, FGDA
+import pytest
+from pytest import approx
 
 
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose."""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats
+@pytest.mark.parametrize("tspace", [TangentSpace, FGDA])
+class TangentSpaceTestCase:
+    def test_tangentspace(self, tspace, get_covmats):
+        n_classes, n_trials, n_channels = 2, 6, 3
+        covmats = get_covmats(n_trials, n_channels)
+        labels = np.array([0, 1]).repeat(n_trials // n_classes)
+        self.clf_transform(tspace, covmats, labels)
+        self.clf_fit_transform(tspace, covmats, labels)
+        if tspace is TangentSpace:
+            self.clf_transform_wo_fit(tspace, covmats)
+            self.clf_inversetransform(tspace, covmats)
 
 
-def test_TangentSpace_init():
-    """Test init of Tangent."""
-    TangentSpace(metric='riemann')
+class TestTangentSpace(TangentSpaceTestCase):
+    def clf_transform(self, tspace, covmats, labels):
+        n_trials, n_channels, n_channels = covmats.shape
+        ts = tspace().fit(covmats, labels)
+        Xtr = ts.transform(covmats)
+        if tspace is TangentSpace:
+            n_ts = (n_channels * (n_channels + 1)) // 2
+            assert Xtr.shape == (n_trials, n_ts)
+        else:
+            assert Xtr.shape == (n_trials, n_channels, n_channels)
+
+    def clf_fit_transform(self, tspace, covmats, labels):
+        n_trials, n_channels, n_channels = covmats.shape
+        ts = tspace()
+        Xtr = ts.fit_transform(covmats, labels)
+        if tspace is TangentSpace:
+            n_ts = (n_channels * (n_channels + 1)) // 2
+            assert Xtr.shape == (n_trials, n_ts)
+        else:
+            assert Xtr.shape == (n_trials, n_channels, n_channels)
+
+    def clf_transform_wo_fit(self, tspace, covmats):
+        n_trials, n_channels, n_channels = covmats.shape
+        n_ts = (n_channels * (n_channels + 1)) // 2
+        ts = tspace()
+        Xtr = ts.transform(covmats)
+        assert Xtr.shape == (n_trials, n_ts)
+
+    def clf_inversetransform(self, tspace, covmats):
+        n_trials, n_channels, n_channels = covmats.shape
+        ts = tspace().fit(covmats)
+        Xtr = ts.transform(covmats)
+        covinv = ts.inverse_transform(Xtr)
+        assert covinv == approx(covmats)
 
 
-def test_TangentSpace_fit():
-    """Test Fit of Tangent Space."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='riemann')
-    ts.fit(covset)
+@pytest.mark.parametrize("fit", [True, False])
+@pytest.mark.parametrize("tsupdate", [True, False])
+@pytest.mark.parametrize("metric", get_metrics())
+def test_TangentSpace_init(fit, tsupdate, metric, get_covmats):
+    n_trials, n_channels = 4, 3
+    n_ts = (n_channels * (n_channels + 1)) // 2
+    covmats = get_covmats(n_trials, n_channels)
+    ts = TangentSpace(metric=metric, tsupdate=tsupdate)
+    if fit:
+        ts.fit(covmats)
+    Xtr = ts.transform(covmats)
+    assert Xtr.shape == (n_trials, n_ts)
 
 
-def test_TangentSpace_transform():
-    """Test transform of Tangent Space."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='riemann')
-    ts.fit(covset)
-    ts.transform(covset)
-
-
-@pytest.mark.parametrize('shape', [(10, 9), (10, 9, 8), (10), (12, 8, 8)])
-def test_TangentSpace_transform_dim(shape):
-    """Test transform input shape, could be TS vector or covmat"""
-    n_trials, n_channels = 10, 3
-    covset = generate_cov(n_trials, n_channels)
-    ts = TangentSpace(metric='riemann')
-    ts.fit(covset)
-
-    X = np.zeros(shape=shape)
-    with pytest.raises(ValueError):
-        ts.transform(X)
-
-
-def test_TangentSpace_transform_without_fit():
-    """Test transform of Tangent Space without fit."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='riemann')
-    ts.transform(covset)
-
-
-def test_TangentSpace_transform_with_ts_update():
-    """Test transform of Tangent Space with TSupdate."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='riemann', tsupdate=True)
-    ts.fit(covset)
-    ts.transform(covset)
-
-
-def test_TangentSpace_inversetransform():
-    """Test inverse transform of Tangent Space."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='riemann')
-    ts.fit(covset)
-    t = ts.transform(covset)
-    cov = ts.inverse_transform(t)
-    assert_array_almost_equal(covset, cov)
-
-
-def test_TangentSpace_inversetransform_without_fit():
-    """Test inverse transform of Tangent Space without fit."""
-    covset = generate_cov(10, 3)
-    ts = TangentSpace(metric='identity')
-    tsv = ts.fit_transform(covset)
-    ts = TangentSpace(metric='riemann')
-    cov = ts.inverse_transform(tsv)
-    assert_array_almost_equal(covset, cov)
-
-
-def test_FGDA_init():
-    """Test init of FGDA."""
-    FGDA(metric='riemann')
-
-
-def test_FGDA_fit():
-    """Test Fit of FGDA."""
-    covset = generate_cov(10, 3)
-    labels = np.array([0, 1]).repeat(5)
-    ts = FGDA(metric='riemann')
-    ts.fit(covset, labels)
-
-
-def test_FGDA_transform():
-    """Test transform of FGDA."""
-    covset = generate_cov(10, 3)
-    labels = np.array([0, 1]).repeat(5)
-    ts = FGDA(metric='riemann')
-    ts.fit(covset, labels)
-    ts.transform(covset)
+@pytest.mark.parametrize("tsupdate", [True, False])
+@pytest.mark.parametrize("metric", get_metrics())
+def test_FGDA_init(tsupdate, metric, get_covmats):
+    n_classes, n_trials, n_channels = 2, 6, 3
+    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    covmats = get_covmats(n_trials, n_channels)
+    ts = FGDA(metric=metric, tsupdate=tsupdate)
+    ts.fit(covmats, labels)
+    Xtr = ts.transform(covmats)
+    assert Xtr.shape == (n_trials, n_channels, n_channels)

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -1,6 +1,7 @@
 """Test tangent space functions."""
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import pytest
 
 from pyriemann.tangentspace import TangentSpace, FGDA
 
@@ -35,6 +36,19 @@ def test_TangentSpace_transform():
     ts = TangentSpace(metric='riemann')
     ts.fit(covset)
     ts.transform(covset)
+
+
+@pytest.mark.parametrize('shape', [(10, 9), (10, 9, 8), (10), (12, 8, 8)])
+def test_TangentSpace_transform_dim(shape):
+    """Test transform input shape, could be TS vector or covmat"""
+    n_trials, n_channels = 10, 3
+    covset = generate_cov(n_trials, n_channels)
+    ts = TangentSpace(metric='riemann')
+    ts.fit(covset)
+
+    X = np.zeros(shape=shape)
+    with pytest.raises(ValueError):
+        ts.transform(X)
 
 
 def test_TangentSpace_transform_without_fit():

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -7,10 +7,10 @@ from pytest import approx
 
 @pytest.mark.parametrize("tspace", [TangentSpace, FGDA])
 class TangentSpaceTestCase:
-    def test_tangentspace(self, tspace, get_covmats):
+    def test_tangentspace(self, tspace, get_covmats, get_labels):
         n_classes, n_trials, n_channels = 2, 6, 3
         covmats = get_covmats(n_trials, n_channels)
-        labels = np.array([0, 1]).repeat(n_trials // n_classes)
+        labels = get_labels(n_trials, n_classes)
         self.clf_transform(tspace, covmats, labels)
         self.clf_fit_transform(tspace, covmats, labels)
         self.clf_fit_transform_independence(tspace, covmats, labels)
@@ -81,9 +81,9 @@ def test_TangentSpace_init(fit, tsupdate, metric, get_covmats):
 
 @pytest.mark.parametrize("tsupdate", [True, False])
 @pytest.mark.parametrize("metric", get_metrics())
-def test_FGDA_init(tsupdate, metric, get_covmats):
+def test_FGDA_init(tsupdate, metric, get_covmats, get_labels):
     n_classes, n_trials, n_channels = 2, 6, 3
-    labels = np.array([0, 1]).repeat(n_trials // n_classes)
+    labels = get_labels(n_trials, n_classes)
     covmats = get_covmats(n_trials, n_channels)
     ts = FGDA(metric=metric, tsupdate=tsupdate)
     ts.fit(covmats, labels)

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -14,6 +14,7 @@ class TangentSpaceTestCase:
         labels = np.array([0, 1]).repeat(n_trials // n_classes)
         self.clf_transform(tspace, covmats, labels)
         self.clf_fit_transform(tspace, covmats, labels)
+        self.clf_fit_transform_independence(tspace, covmats, labels)
         if tspace is TangentSpace:
             self.clf_transform_wo_fit(tspace, covmats)
             self.clf_inversetransform(tspace, covmats)
@@ -39,6 +40,25 @@ class TestTangentSpace(TangentSpaceTestCase):
             assert Xtr.shape == (n_trials, n_ts)
         else:
             assert Xtr.shape == (n_trials, n_channels, n_channels)
+
+    def clf_fit_independence(self, tspace, covmats, labels):
+        n_trials, n_channels, n_channels = covmats.shape
+        ts = tspace()
+        Xtr = ts.fit(covmats, labels)
+        # retraining with different size should erase previous fit
+        new_covmats = covmats[:, :-1, :-1]
+        Xtr = ts.fit(new_covmats, labels)
+
+    def clf_fit_transform_independence(self, tspace, covmats, labels):
+        n_trials, n_channels, n_channels = covmats.shape
+        ts = tspace()
+        ts.fit(covmats, labels)
+        # retraining with different size should erase previous fit
+        new_covmats = covmats[:, :-1, :-1]
+        ts.fit(new_covmats, labels)
+        # fit_transform should work as well
+        ts.fit_transform(covmats, labels)
+
 
     def clf_transform_wo_fit(self, tspace, covmats):
         n_trials, n_channels, n_channels = covmats.shape

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -41,14 +41,6 @@ class TestTangentSpace(TangentSpaceTestCase):
         else:
             assert Xtr.shape == (n_trials, n_channels, n_channels)
 
-    def clf_fit_independence(self, tspace, covmats, labels):
-        n_trials, n_channels, n_channels = covmats.shape
-        ts = tspace()
-        Xtr = ts.fit(covmats, labels)
-        # retraining with different size should erase previous fit
-        new_covmats = covmats[:, :-1, :-1]
-        Xtr = ts.fit(new_covmats, labels)
-
     def clf_fit_transform_independence(self, tspace, covmats, labels):
         n_trials, n_channels, n_channels = covmats.shape
         ts = tspace()
@@ -58,7 +50,6 @@ class TestTangentSpace(TangentSpaceTestCase):
         ts.fit(new_covmats, labels)
         # fit_transform should work as well
         ts.fit_transform(covmats, labels)
-
 
     def clf_transform_wo_fit(self, tspace, covmats):
         n_trials, n_channels, n_channels = covmats.shape

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, get_metrics
+from conftest import get_covmats, get_metrics, rndstate
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from pyriemann.tangentspace import TangentSpace, FGDA
@@ -90,3 +90,24 @@ def test_FGDA_init(tsupdate, metric, get_covmats):
     ts.fit(covmats, labels)
     Xtr = ts.transform(covmats)
     assert Xtr.shape == (n_trials, n_channels, n_channels)
+
+
+def test_TS_vecdim_error(get_covmats, rndstate):
+    n_trials, n_ts = 4, 6
+    ts = TangentSpace()
+    # ts.fit(covmats, labels)
+    with pytest.raises(ValueError):
+        tsvectors_wrong = np.empty((n_trials, n_ts + 1))
+        ts.transform(tsvectors_wrong)
+
+
+def test_TS_matdim_error(get_covmats):
+    n_trials, n_channels, n_ts = 4, 3, 6
+    ts = TangentSpace()
+    # ts.fit(covmats, labels)
+    with pytest.raises(ValueError):
+        not_square_mat = np.empty((n_trials, n_channels, n_channels + 1))
+        ts.transform(not_square_mat)
+    with pytest.raises(ValueError):
+        too_many_dim = np.empty((1, 2, 3, 4))
+        ts.transform(too_many_dim)

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -225,7 +225,8 @@ def test_covariances_coherence(coh, rndstate):
         x[2] = np.sin(2 * np.pi * ft * t + np.pi / 2) \
             + noise * rndstate.randn((n_times))
         # pi shifted channel = opposite phase
-        x[3] = np.sin(2 * np.pi * ft * t + np.pi) + noise * rndstate.randn((n_times))
+        noise_term = noise * rndstate.randn((n_times))
+        x[3] = np.sin(2 * np.pi * ft * t + np.pi) + noise_term
 
         c, freqs = coherence(x, fs=fs, window=fs, overlap=0.5, coh=coh)
         foi = (freqs == ft)
@@ -287,7 +288,8 @@ def test_normalize(rndstate):
     with pytest.raises(ValueError):  # not at least 2d
         normalize(rndstate.randn(n_channels), "trace")
     with pytest.raises(ValueError):  # not square
-        normalize(rndstate.randn(n_trials, n_channels, n_channels + 2), "trace")
+        shape = (n_trials, n_channels, n_channels + 2)
+        normalize(rndstate.randn(*shape), "trace")
     with pytest.raises(ValueError):  # invalid normalization type
         normalize(rndstate.randn(n_trials, n_channels, n_channels), "abc")
 
@@ -303,7 +305,8 @@ def test_get_nondiag_weight(rndstate):
     w = get_nondiag_weight(rndstate.randn(n_trials, n_channels, n_channels))
     assert_array_equal(w.shape, [n_trials])
     # test a 4d array, ie a group of groups of square matrices
-    w = get_nondiag_weight(rndstate.randn(n_conds, n_trials, n_channels, n_channels))
+    shape = (n_conds, n_trials, n_channels, n_channels)
+    w = get_nondiag_weight(rndstate.randn(*shape))
     assert_array_equal(w.shape, [n_conds, n_trials])
 
     # 2x2 constant matrices => non-diag weights equal to 1
@@ -318,4 +321,5 @@ def test_get_nondiag_weight(rndstate):
     with pytest.raises(ValueError):  # not at least 2d
         get_nondiag_weight(rndstate.randn(n_channels))
     with pytest.raises(ValueError):  # not square
-        get_nondiag_weight(rndstate.randn(n_trials, n_channels, n_channels + 2))
+        shape = (n_trials, n_channels, n_channels + 2)
+        get_nondiag_weight(rndstate.randn(*shape))

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -264,15 +264,15 @@ def test_normalize(rndstate):
     # test a 2d array, ie a single square matrix
     mat = rndstate.randn(n_channels, n_channels)
     mat_n = normalize(mat, "trace")
-    assert_array_equal(mat.shape, mat_n.shape)
+    assert mat.shape == mat_n.shape
     # test a 3d array, ie a group of square matrices
     mat = rndstate.randn(n_trials, n_channels, n_channels)
     mat_n = normalize(mat, "determinant")
-    assert_array_equal(mat.shape, mat_n.shape)
+    assert mat.shape == mat_n.shape
     # test a 4d array, ie a group of groups of square matrices
     mat = rndstate.randn(n_conds, n_trials, n_channels, n_channels)
     mat_n = normalize(mat, "trace")
-    assert_array_equal(mat.shape, mat_n.shape)
+    assert mat.shape == mat_n.shape
 
     # after trace-normalization => trace equal to 1
     mat = rndstate.randn(n_trials, n_channels, n_channels)
@@ -302,11 +302,11 @@ def test_get_nondiag_weight(rndstate):
     assert np.isscalar(w)
     # test a 3d array, ie a group of square matrices
     w = get_nondiag_weight(rndstate.randn(n_trials, n_channels, n_channels))
-    assert_array_equal(w.shape, [n_trials])
+    assert w.shape == (n_trials,)
     # test a 4d array, ie a group of groups of square matrices
     shape = (n_conds, n_trials, n_channels, n_channels)
     w = get_nondiag_weight(rndstate.randn(*shape))
-    assert_array_equal(w.shape, [n_conds, n_trials])
+    assert w.shape == (n_conds, n_trials)
 
     # 2x2 constant matrices => non-diag weights equal to 1
     mats = rndstate.randn(n_trials, 1, 1) * np.ones((n_trials, 2, 2))

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal
 import numpy as np
 from scipy.signal import welch, csd, coherence as coherence_sp
 import pytest

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -9,42 +9,59 @@ from pyriemann.utils.covariance import (covariances, covariances_EP, eegtocov,
 
 
 @pytest.mark.parametrize(
-    'estimator', ['oas', 'lwf', 'scm', 'corr', 'mcd', np.cov, 'truc', None]
+    'estimator', ['oas', 'lwf', 'scm', 'corr', 'mcd',
+                  'sch', np.cov, 'truc', None]
 )
 def test_covariances(estimator):
     """Test covariance for multiple estimator"""
-    x = np.random.randn(2, 3, 100)
+    rs = np.random.RandomState(42)
+    n_trials, n_channels, n_times = 2, 3, 100
+    x = rs.randn(n_trials, n_channels, n_times)
     if estimator is None:
         cov = covariances(x)
-        assert cov.shape == (2, 3, 3)
+        assert cov.shape == (n_trials, n_channels, n_channels)
     elif estimator == 'truc':
         with pytest.raises(ValueError):
             covariances(x, estimator=estimator)
     else:
         cov = covariances(x, estimator=estimator)
-        assert cov.shape == (2, 3, 3)
+        assert cov.shape == (n_trials, n_channels, n_channels)
 
 
 @pytest.mark.parametrize(
-    'estimator', ['oas', 'lwf', 'scm', 'corr', 'mcd', None]
+    'estimator', ['oas', 'lwf', 'scm', 'corr', 'mcd', 'sch', None]
 )
 def test_covariances_EP(estimator):
     """Test covariance_EP for multiple estimator"""
-    x = np.random.randn(2, 3, 100)
-    p = np.random.randn(3, 100)
+    rs = np.random.RandomState(42)
+    n_trials, n_channels, n_times = 2, 3, 100
+    x = rs.randn(n_trials, n_channels, n_times)
+    p = rs.randn(n_channels, n_times)
 
     if estimator is None:
         cov = covariances_EP(x, p)
     else:
         cov = covariances_EP(x, p, estimator=estimator)
-    assert cov.shape == (2, 6, 6)
+    assert cov.shape == (n_trials, 2 * n_channels, 2 * n_channels)
+
+
+def test_covariances_EP_ntimes():
+    """Test that prototype and signal have same time dimension"""
+    rs = np.random.RandomState(42)
+    n_trials, n_channels, n_times, n_times_P = 2, 3, 100, 101
+    x = rs.randn(n_trials, n_channels, n_times)
+    p = rs.randn(n_channels, n_times_P)
+    with pytest.raises(ValueError):
+        covariances_EP(x, p)
 
 
 def test_covariances_eegtocov():
     """Test eegtocov"""
-    x = np.random.randn(1000, 3)
+    rs = np.random.RandomState(42)
+    n_times, n_channels = 1000, 3
+    x = rs.randn(n_times, n_channels)
     cov = eegtocov(x)
-    assert cov.shape[1] == 3
+    assert cov.shape[1] == n_channels
 
 
 def test_covariances_cross_spectrum():

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -1,4 +1,3 @@
-from conftest import rndstate
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 import numpy as np
 from scipy.signal import welch, csd, coherence as coherence_sp

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -213,7 +213,7 @@ def test_covariances_coherence(coh, rndstate):
         t = np.arange(0, n_periods, 1 / fs)
         n_times = t.shape[0]
 
-        x = np.zeros((4, len(t)))
+        x = np.empty((4, len(t)))
         noise = 1e-9
         # reference channel: a pure sine + small noise (to avoid nan or inf)
         x[0] = np.sin(2 * np.pi * ft * t) + noise * rndstate.randn((n_times))

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -61,11 +61,11 @@ def test_distance_func_eye(dist):
 
 @pytest.mark.parametrize("dist", get_dist_func())
 def test_distance_func_rand(dist, get_covmats):
-    n_trials, n_channels = 2, 5
+    n_trials, n_channels = 2, 6
     covmats = get_covmats(n_trials, n_channels)
     A, C = covmats[0], covmats[1]
-    B = geodesic(A, C, alpha=1e-8)
-    assert dist(A, B) == approx(0, abs=1e-4, rel=1e-6)
+    B = geodesic(A, C, alpha=0.5)
+    assert dist(A, B) < dist(A, C)
 
 
 @pytest.mark.parametrize("dist, dfunc", zip(get_distances(), get_dist_func()))

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -68,12 +68,12 @@ def test_distance_func_rand(dist, get_covmats):
     assert dist(A, B) == approx(0, abs=1e-4, rel=1e-6)
 
 
-@pytest.mark.parametrize("dist, dist_func", zip(get_distances(), get_dist_func()))
-def test_distance_wrapper(dist, dist_func, get_covmats):
+@pytest.mark.parametrize("dist, dfunc", zip(get_distances(), get_dist_func()))
+def test_distance_wrapper(dist, dfunc, get_covmats):
     n_trials, n_channels = 2, 5
     covmats = get_covmats(n_trials, n_channels)
     A, B = covmats[0], covmats[1]
-    assert distance(A, B, metric=dist) == dist_func(A, B)
+    assert distance(A, B, metric=dist) == dfunc(A, B)
 
 
 def test_pairwise_distance_matrix(get_covmats):

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -1,122 +1,84 @@
-from numpy.testing import assert_array_almost_equal
-import pytest
+from conftest import get_covmats, get_distances
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+from pyriemann.utils.distance import (
+    distance_riemann,
+    distance_euclid,
+    distance_logeuclid,
+    distance_logdet,
+    distance_kullback,
+    distance_kullback_right,
+    distance_kullback_sym,
+    distance_wasserstein,
+    distance,
+    pairwise_distance,
+    _check_distance_method,
+)
+from pyriemann.utils.geodesic import geodesic
+import pytest
+from pytest import approx
 
-from pyriemann.utils.distance import (distance_riemann,
-                                      distance_euclid,
-                                      distance_logeuclid,
-                                      distance_logdet,
-                                      distance_kullback,
-                                      distance_kullback_right,
-                                      distance_kullback_sym,
-                                      distance_wasserstein,
-                                      distance, pairwise_distance,
-                                      _check_distance_method)
+
+def get_dist_func():
+    dist_func = [
+        distance_riemann,
+        distance_logeuclid,
+        distance_euclid,
+        distance_logdet,
+        distance_kullback,
+        distance_kullback_right,
+        distance_kullback_sym,
+        distance_wasserstein,
+    ]
+    for df in dist_func:
+        yield df
 
 
-def test_check_distance_methd():
-    """Test _check_distance_method"""
-    _check_distance_method('riemann')
-    _check_distance_method(distance_riemann)
+@pytest.mark.parametrize("dist", get_distances())
+def test_check_distance_str(dist):
+    _check_distance_method(dist)
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_check_distance_func(dist):
+    _check_distance_method(dist)
+
+
+def test_check_distance_error():
     with pytest.raises(ValueError):
-        _check_distance_method('666')
+        _check_distance_method("universe")
     with pytest.raises(ValueError):
         _check_distance_method(42)
 
 
-def test_distance_riemann():
-    """Test riemannian distance"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(distance_riemann(A, B), 0)
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_func_eye(dist):
+    n_channels = 3
+    A = 2 * np.eye(n_channels)
+    B = 2 * np.eye(n_channels)
+    assert dist(A, B) == approx(0)
 
 
-def test_distance_kullback():
-    """Test kullback divergence"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(distance_kullback(A, B), 0)
-    assert_array_almost_equal(distance_kullback_right(A, B), 0)
-    assert_array_almost_equal(distance_kullback_sym(A, B), 0)
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_func_rand(dist, get_covmats):
+    n_trials, n_channels = 2, 5
+    covmats = get_covmats(n_trials, n_channels)
+    A, C = covmats[0], covmats[1]
+    B = geodesic(A, C, alpha=1e-8)
+    assert dist(A, B) == approx(0, abs=1e-4, rel=1e-6)
 
 
-def test_distance_euclid():
-    """Test euclidean distance"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance_euclid(A, B) == 0
+@pytest.mark.parametrize("dist, dist_func", zip(get_distances(), get_dist_func()))
+def test_distance_wrapper(dist, dist_func, get_covmats):
+    n_trials, n_channels = 2, 5
+    covmats = get_covmats(n_trials, n_channels)
+    A, B = covmats[0], covmats[1]
+    assert distance(A, B, metric=dist) == dist_func(A, B)
 
 
-def test_distance_logeuclid():
-    """Test logeuclid distance"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance_logeuclid(A, B) == 0
-
-
-def test_distance_wasserstein():
-    """Test wasserstein distance"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance_wasserstein(A, B) == 0
-
-
-def test_distance_logdet():
-    """Test logdet distance"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance_logdet(A, B) == 0
-
-
-def test_distance_generic_riemann():
-    """Test riemannian distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(A, B, metric='riemann') == distance_riemann(A, B)
-
-
-def test_distance_generic_euclid():
-    """Test euclidean distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(A, B, metric='euclid') == distance_euclid(A, B)
-
-
-def test_distance_generic_logdet():
-    """Test logdet distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(A, B, metric='logdet') == distance_logdet(A, B)
-
-
-def test_distance_generic_logeuclid():
-    """Test logeuclid distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(A, B, metric='logeuclid') == distance_logeuclid(A, B)
-
-
-def test_distance_generic_kullback():
-    """Test logeuclid distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(A, B, metric='kullback') == distance_kullback(A, B)
-    assert distance(A, B, metric='kullback_right') == \
-        distance_kullback_right(A, B)
-    assert distance(A, B, metric='kullback_sym') == \
-        distance_kullback_sym(A, B)
-
-
-def test_distance_generic_custom():
-    """Test custom distance for generic function"""
-    A = 2*np.eye(3)
-    B = 2*np.eye(3)
-    assert distance(
-        A, B, metric=distance_logeuclid) == distance_logeuclid(A, B)
-
-
-def test_pairwise_distance_matrix():
-    """Test pairwise distance"""
-    A = np.array([2*np.eye(3), 3*np.eye(3)])
-    B = np.array([2*np.eye(3), 3*np.eye(3)])
-    pairwise_distance(A, B)
+def test_pairwise_distance_matrix(get_covmats):
+    n_trials, n_channels = 6, 5
+    covmats = get_covmats(n_trials, n_channels)
+    A, B = covmats[:4], covmats[4:]
+    pdist = pairwise_distance(A, B)
+    assert pdist.shape == (4, 2)

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -1,6 +1,5 @@
-from conftest import get_covmats, get_distances
+from conftest import get_distances
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 from pyriemann.utils.distance import (
     distance_riemann,
     distance_euclid,

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -78,6 +78,7 @@ def test_distance_wrapper(dist, dfunc, get_covmats):
 def test_pairwise_distance_matrix(get_covmats):
     n_trials, n_channels = 6, 5
     covmats = get_covmats(n_trials, n_channels)
-    A, B = covmats[:4], covmats[4:]
+    n_subset = 4
+    A, B = covmats[:n_subset], covmats[n_subset:]
     pdist = pairwise_distance(A, B)
-    assert pdist.shape == (4, 2)
+    assert pdist.shape == (n_subset, 2)

--- a/tests/test_utils_geodesic.py
+++ b/tests/test_utils_geodesic.py
@@ -82,15 +82,15 @@ def test_distance_wrapper_simple(metric):
     assert geodesic(A, B, 0.5, metric=metric) == approx(Ctrue)
 
 
-@pytest.mark.parametrize("metric, geod_func", zip(get_geod_name(), get_geod_func()))
-def test_distance_wrapper_random(metric, geod_func, get_covmats):
+@pytest.mark.parametrize("met, gfunc", zip(get_geod_name(), get_geod_func()))
+def test_distance_wrapper_random(met, gfunc, get_covmats):
     n_trials, n_channels = 2, 5
     covmats = get_covmats(n_trials, n_channels)
     A, B = covmats[0], covmats[1]
-    if geod_func is geodesic_euclid:
+    if gfunc is geodesic_euclid:
         Ctrue = mean_euclid(covmats)
-    elif geod_func is geodesic_logeuclid:
+    elif gfunc is geodesic_logeuclid:
         Ctrue = mean_logeuclid(covmats)
-    elif geod_func is geodesic_riemann:
+    elif gfunc is geodesic_riemann:
         Ctrue = mean_riemann(covmats)
-    assert geodesic(A, B, 0.5, metric=metric) == approx(Ctrue)
+    assert geodesic(A, B, 0.5, metric=met) == approx(Ctrue)

--- a/tests/test_utils_geodesic.py
+++ b/tests/test_utils_geodesic.py
@@ -1,104 +1,96 @@
 from numpy.testing import assert_array_almost_equal
+from conftest import get_covmats
 import numpy as np
-
 from pyriemann.utils.geodesic import (
-    geodesic_riemann, geodesic_euclid, geodesic_logeuclid, geodesic)
-
-# Riemannian metric
-
-
-def test_geodesic_riemann_0():
-    """Test riemannian geodesic when alpha = 0"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_riemann(A, B, 0), A)
+    geodesic_riemann,
+    geodesic_euclid,
+    geodesic_logeuclid,
+    geodesic,
+)
+from pyriemann.utils.mean import mean_riemann, mean_logeuclid, mean_euclid
+import pytest
+from pytest import approx
 
 
-def test_geodesic_riemann_1():
-    """TTest riemannian geodesic when alpha = 1"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_riemann(A, B, 1), B)
+def get_geod_func():
+    geod_func = [geodesic_riemann, geodesic_euclid, geodesic_logeuclid]
+    for gf in geod_func:
+        yield gf
 
 
-def test_geodesic_riemann_middle():
-    """Test riemannian geodesic when alpha = 0.5"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = np.eye(3)
-    assert_array_almost_equal(geodesic_riemann(A, B, 0.5), Ctrue)
-
-# euclidean metric
+def get_geod_name():
+    geod_name = ["riemann", "euclid", "logeuclid"]
+    for gn in geod_name:
+        yield gn
 
 
-def test_geodesic_euclid_0():
-    """Test euclidean geodesic when alpha = 0"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_euclid(A, B, 0), A)
+@pytest.mark.parametrize(
+    "geodesic_func", [geodesic_riemann, geodesic_euclid, geodesic_logeuclid]
+)
+class GeodesicFuncTestCase:
+    def test_simple_mat(self, geodesic_func, get_covmats):
+        n_channels = 3
+        if geodesic_func is geodesic_euclid:
+            A = 1.0 * np.eye(n_channels)
+            B = 2.0 * np.eye(n_channels)
+            Ctrue = 1.5 * np.eye(n_channels)
+        else:
+            A = 0.5 * np.eye(n_channels)
+            B = 2 * np.eye(n_channels)
+            Ctrue = np.eye(n_channels)
+        self.geodesic_0(geodesic_func, A, B)
+        self.geodesic_1(geodesic_func, A, B)
+        self.geodesic_middle(geodesic_func, A, B, Ctrue)
+
+    def test_random_mat(self, geodesic_func, get_covmats):
+        n_trials, n_channels = 2, 5
+        covmats = get_covmats(n_trials, n_channels)
+        A, B = covmats[0], covmats[1]
+        if geodesic_func is geodesic_euclid:
+            Ctrue = mean_euclid(covmats)
+        elif geodesic_func is geodesic_logeuclid:
+            Ctrue = mean_logeuclid(covmats)
+        elif geodesic_func is geodesic_riemann:
+            Ctrue = mean_riemann(covmats)
+        self.geodesic_0(geodesic_func, A, B)
+        self.geodesic_1(geodesic_func, A, B)
+        self.geodesic_middle(geodesic_func, A, B, Ctrue)
 
 
-def test_geodesic_euclid_1():
-    """TTest euclidean geodesic when alpha = 1"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_euclid(A, B, 1), B)
+class TestGeodesicFunc(GeodesicFuncTestCase):
+    def geodesic_0(self, geodesic_func, A, B):
+        assert geodesic_func(A, B, 0) == approx(A)
+
+    def geodesic_1(self, geodesic_func, A, B):
+        assert geodesic_func(A, B, 1) == approx(B)
+
+    def geodesic_middle(self, geodesic_func, A, B, Ctrue):
+        assert geodesic_func(A, B, 0.5) == approx(Ctrue)
 
 
-def test_geodesic_euclid_middle():
-    """Test euclidean geodesic when alpha = 0.5"""
-    A = 1*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = 1.5*np.eye(3)
-    assert_array_almost_equal(geodesic_euclid(A, B, 0.5), Ctrue)
-
-# log-euclidean metric
-
-
-def test_geodesic_logeuclid_0():
-    """Test log euclidean geodesic when alpha = 0"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_logeuclid(A, B, 0), A)
+@pytest.mark.parametrize("metric", get_geod_name())
+def test_distance_wrapper_simple(metric):
+    n_channels = 3
+    if metric == "euclid":
+        A = 1.0 * np.eye(n_channels)
+        B = 2.0 * np.eye(n_channels)
+        Ctrue = 1.5 * np.eye(n_channels)
+    else:
+        A = 0.5 * np.eye(n_channels)
+        B = 2 * np.eye(n_channels)
+        Ctrue = np.eye(n_channels)
+    assert geodesic(A, B, 0.5, metric=metric) == approx(Ctrue)
 
 
-def test_geodesic_logeuclid_1():
-    """TTest log euclidean geodesic when alpha = 1"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    assert_array_almost_equal(geodesic_logeuclid(A, B, 1), B)
-
-
-def test_geodesic_logeuclid_middle():
-    """Test log euclidean geodesic when alpha = 0.5"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = 1*np.eye(3)
-    assert_array_almost_equal(geodesic_logeuclid(A, B, 0.5), Ctrue)
-
-########################
-# global geodesic
-
-
-def test_geodesic_riemann():
-    """Test riemannian geodesic when alpha = 0.5 for global function"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = 1*np.eye(3)
-    assert_array_almost_equal(geodesic(A, B, 0.5, metric='riemann'), Ctrue)
-
-
-def test_geodesic_euclid():
-    """Test euclidean geodesic when alpha = 0.5 for global function"""
-    A = 1*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = 1.5*np.eye(3)
-    assert_array_almost_equal(geodesic(A, B, 0.5, metric='euclid'), Ctrue)
-
-
-def test_geodesic_logeuclid():
-    """Test riemannian geodesic when alpha = 0.5 for global function"""
-    A = 0.5*np.eye(3)
-    B = 2*np.eye(3)
-    Ctrue = 1*np.eye(3)
-    assert_array_almost_equal(geodesic(A, B, 0.5, metric='logeuclid'), Ctrue)
+@pytest.mark.parametrize("metric, geod_func", zip(get_geod_name(), get_geod_func()))
+def test_distance_wrapper_random(metric, geod_func, get_covmats):
+    n_trials, n_channels = 2, 5
+    covmats = get_covmats(n_trials, n_channels)
+    A, B = covmats[0], covmats[1]
+    if geod_func is geodesic_euclid:
+        Ctrue = mean_euclid(covmats)
+    elif geod_func is geodesic_logeuclid:
+        Ctrue = mean_logeuclid(covmats)
+    elif geod_func is geodesic_riemann:
+        Ctrue = mean_riemann(covmats)
+    assert geodesic(A, B, 0.5, metric=metric) == approx(Ctrue)

--- a/tests/test_utils_geodesic.py
+++ b/tests/test_utils_geodesic.py
@@ -1,5 +1,3 @@
-from numpy.testing import assert_array_almost_equal
-from conftest import get_covmats
 import numpy as np
 from pyriemann.utils.geodesic import (
     geodesic_riemann,

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -1,3 +1,4 @@
+from conftest import get_covmats, get_covmats_params
 import numpy as np
 import pytest
 from pytest import approx
@@ -17,18 +18,6 @@ from pyriemann.utils.mean import (
 from pyriemann.utils.geodesic import geodesic_riemann
 
 
-def generate_cov(n_trials, n_channels):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(n_trials, n_channels)
-    A = 2 * rs.rand(n_channels, n_channels) - 1
-    A /= np.linalg.norm(A, axis=1)[:, np.newaxis]
-    covmats = np.empty((n_trials, n_channels, n_channels))
-    for i in range(n_trials):
-        covmats[i] = A @ np.diag(diags[i]) @ A.T
-    return covmats, diags, A
-
-
 @pytest.mark.parametrize(
     "mean",
     [
@@ -43,28 +32,28 @@ def generate_cov(n_trials, n_channels):
         mean_wasserstein,
     ],
 )
-def test_mean_shape(mean):
+def test_mean_shape(mean, get_covmats):
     """Test the shape of mean"""
     n_trials, n_channels = 5, 3
-    covmats, _, A = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C = mean(covmats)
     assert C.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("mean", [mean_riemann, mean_logdet])
-def test_mean_shape_with_init(mean):
+def test_mean_shape_with_init(mean, get_covmats):
     """Test the shape of mean with init"""
     n_trials, n_channels = 5, 3
-    covmats, _, A = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C = mean(covmats, init=covmats[0])
     assert C.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("init", [True, False])
-def test_riemann_mean(init):
+def test_riemann_mean(init, get_covmats_params):
     """Test the riemannian mean"""
     n_trials, n_channels = 100, 3
-    covmats, diags, A = generate_cov(n_trials, n_channels)
+    covmats, diags, A = get_covmats_params(n_trials, n_channels)
     if init:
         C = mean_riemann(covmats, init=covmats[0])
     else:
@@ -74,44 +63,44 @@ def test_riemann_mean(init):
     assert C == approx(Ctrue)
 
 
-def test_euclid_mean():
+def test_euclid_mean(get_covmats):
     """Test the euclidean mean"""
     n_trials, n_channels = 100, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C = mean_euclid(covmats)
     assert C == approx(covmats.mean(axis=0))
 
 
-def test_identity_mean():
+def test_identity_mean(get_covmats):
     """Test the identity mean"""
     n_trials, n_channels = 100, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C = mean_identity(covmats)
     assert np.all(C == np.eye(n_channels))
 
 
-def test_alm_mean():
+def test_alm_mean(get_covmats):
     """Test the ALM mean"""
     n_trials, n_channels = 3, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C_alm = mean_alm(covmats)
     C_riem = mean_riemann(covmats)
     assert C_alm == approx(C_riem)
 
 
-def test_alm_mean_maxiter():
+def test_alm_mean_maxiter(get_covmats):
     """Test the ALM mean with max iteration"""
     n_trials, n_channels = 3, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
-    C = mean_alm(covmats, maxiter=1, verbose=True)  # maxiter reached
+    covmats = get_covmats(n_trials, n_channels)
+    C = mean_alm(covmats, maxiter=1)
     assert C.shape == (n_channels, n_channels)
 
 
-def test_alm_mean_2trials():
+def test_alm_mean_2trials(get_covmats):
     """Test the ALM mean with 2 trials"""
     n_trials, n_channels = 2, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
-    C = mean_alm(covmats)  # n_trials=2
+    covmats = get_covmats(n_trials, n_channels)
+    C = mean_alm(covmats)
     assert np.all(C == geodesic_riemann(covmats[0], covmats[1], alpha=0.5))
 
 
@@ -130,10 +119,10 @@ def test_alm_mean_2trials():
         ("kullback_sym", mean_kullback_sym),
     ],
 )
-def test_mean_covariance_metric(metric, mean):
+def test_mean_covariance_metric(metric, mean, get_covmats):
     """Test mean_covariance for metric"""
     n_trials, n_channels = 3, 3
-    covmats, _, _ = generate_cov(n_trials, n_channels)
+    covmats = get_covmats(n_trials, n_channels)
     C = mean_covariance(covmats, metric=metric)
     Ctrue = mean(covmats)
     assert np.all(C == Ctrue)

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -1,4 +1,3 @@
-from conftest import get_covmats, get_covmats_params
 import numpy as np
 import pytest
 from pytest import approx

--- a/tests/test_utils_tangent_space.py
+++ b/tests/test_utils_tangent_space.py
@@ -1,6 +1,8 @@
 from conftest import get_covmats, rndstate, get_metrics
 import numpy as np
-from pyriemann.utils.tangentspace import tangent_space, untangent_space, transport
+from pyriemann.utils.tangentspace import (
+    tangent_space, untangent_space, transport
+)
 import pytest
 from pytest import approx
 
@@ -26,7 +28,6 @@ def test_untangent_space(rndstate):
 def test_tangent_and_untangent_space(get_covmats):
     """Test tangent space projection and retro-projection should be the same"""
     n_trials, n_channels = 10, 3
-    n_ts = (n_channels * (n_channels + 1)) // 2
     covmats = get_covmats(n_trials, n_channels)
     Xts = tangent_space(covmats, np.eye(n_channels))
     covmats_ut = untangent_space(Xts, np.eye(n_channels))
@@ -36,7 +37,6 @@ def test_tangent_and_untangent_space(get_covmats):
 @pytest.mark.parametrize("metric", get_metrics())
 def test_transport(metric, get_covmats):
     n_trials, n_channels = 10, 3
-    n_ts = (n_channels * (n_channels + 1)) // 2
     covmats = get_covmats(n_trials, n_channels)
     ref = np.eye(n_channels)
     covtr = transport(covmats, ref, metric=metric)

--- a/tests/test_utils_tangent_space.py
+++ b/tests/test_utils_tangent_space.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, rndstate, get_metrics
+from conftest import get_metrics
 import numpy as np
 from pyriemann.utils.tangentspace import (
     tangent_space, untangent_space, transport

--- a/tests/test_utils_tangent_space.py
+++ b/tests/test_utils_tangent_space.py
@@ -1,36 +1,43 @@
+from conftest import get_covmats, rndstate, get_metrics
 import numpy as np
-from numpy.testing import assert_array_almost_equal
-
-from pyriemann.utils.tangentspace import tangent_space, untangent_space
-
-
-def generate_cov(Nt, Ne):
-    """Generate a set of cavariances matrices for test purpose"""
-    rs = np.random.RandomState(1234)
-    diags = 2.0 + 0.1 * rs.randn(Nt, Ne)
-    A = 2*rs.rand(Ne, Ne) - 1
-    A /= np.atleast_2d(np.sqrt(np.sum(A**2, 1))).T
-    covmats = np.empty((Nt, Ne, Ne))
-    for i in range(Nt):
-        covmats[i] = np.dot(np.dot(A, np.diag(diags[i])), A.T)
-    return covmats
+from pyriemann.utils.tangentspace import tangent_space, untangent_space, transport
+import pytest
+from pytest import approx
 
 
-def test_tangent_space():
+def test_tangent_space(get_covmats):
     """Test tangent space projection"""
-    C = generate_cov(10, 3)
-    tangent_space(C, np.eye(3))
+    n_trials, n_channels = 6, 3
+    n_ts = (n_channels * (n_channels + 1)) // 2
+    covmats = get_covmats(n_trials, n_channels)
+    Xts = tangent_space(covmats, np.eye(n_channels))
+    assert Xts.shape == (n_trials, n_ts)
 
 
-def test_untangent_space():
+def test_untangent_space(rndstate):
     """Test untangent space projection"""
-    T = np.random.randn(10, 6)
-    untangent_space(T, np.eye(3))
+    n_trials, n_channels = 10, 3
+    n_ts = (n_channels * (n_channels + 1)) // 2
+    T = rndstate.randn(n_trials, n_ts)
+    covmats = untangent_space(T, np.eye(n_channels))
+    assert covmats.shape == (n_trials, n_channels, n_channels)
 
 
-def test_tangent_and_untangent_space():
+def test_tangent_and_untangent_space(get_covmats):
     """Test tangent space projection and retro-projection should be the same"""
-    C = generate_cov(10, 3)
-    T = tangent_space(C, np.eye(3))
-    covmats = untangent_space(T, np.eye(3))
-    assert_array_almost_equal(C, covmats)
+    n_trials, n_channels = 10, 3
+    n_ts = (n_channels * (n_channels + 1)) // 2
+    covmats = get_covmats(n_trials, n_channels)
+    Xts = tangent_space(covmats, np.eye(n_channels))
+    covmats_ut = untangent_space(Xts, np.eye(n_channels))
+    assert covmats_ut == approx(covmats)
+
+
+@pytest.mark.parametrize("metric", get_metrics())
+def test_transport(metric, get_covmats):
+    n_trials, n_channels = 10, 3
+    n_ts = (n_channels * (n_channels + 1)) // 2
+    covmats = get_covmats(n_trials, n_channels)
+    ref = np.eye(n_channels)
+    covtr = transport(covmats, ref, metric=metric)
+    assert covtr.shape == (n_trials, n_channels, n_channels)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,4 @@
-from conftest import get_covmats, requires_matplotlib
+from conftest import requires_matplotlib
 import numpy as np
 import pytest
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,4 @@
-from conftest import covmats, requires_matplotlib  # noqa: F401
+from conftest import get_covmats, requires_matplotlib
 import numpy as np
 import pytest
 
@@ -10,8 +10,10 @@ from pyriemann.utils.viz import (
 
 
 @requires_matplotlib
-def test_embedding(covmats):  # noqa: F811
+def test_embedding(get_covmats):
     """Test Embedding."""
+    n_trials, n_channels = 5, 3
+    covmats = get_covmats(n_trials, n_channels)
     plot_embedding(covmats, y=None, metric="euclid")
     y = np.ones(covmats.shape[0])
     plot_embedding(covmats, y=y, metric="euclid")
@@ -22,8 +24,7 @@ def test_confusion_matrix():
     """Test confusion_matrix"""
     target = np.array([0, 1] * 10)
     preds = np.array([0, 1] * 10)
-    with pytest.warns(DeprecationWarning,
-                      match="plot_confusion_matrix is deprecated"):
+    with pytest.warns(DeprecationWarning, match="plot_confusion_matrix is deprecated"):
         plot_confusion_matrix(target, preds, ["a", "b"])
 
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -24,7 +24,8 @@ def test_confusion_matrix():
     """Test confusion_matrix"""
     target = np.array([0, 1] * 10)
     preds = np.array([0, 1] * 10)
-    with pytest.warns(DeprecationWarning, match="plot_confusion_matrix is deprecated"):
+    with pytest.warns(DeprecationWarning,
+                      match="plot_confusion_matrix is deprecated"):
         plot_confusion_matrix(target, preds, ["a", "b"])
 
 


### PR DESCRIPTION
As started in #135, I rewrote the test using pytest fixture and parametrize. The goal is to have a unique definition of functions (creating covariance matrices, ...), lists (distance, metric, mean) and RandomState shared across tests. 
All numeric variables follows the defined naming scheme (n_trials, n_channels, n_times, ...)

@kjersbry As proposed, I integrated your PR code #115 and added a test for it in this PR.

Closes #114 