### PR TITLE
Add Riemannian Potato Field

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -58,6 +58,7 @@ Clustering
     Kmeans
     KmeansPerClassTransform
     Potato
+    PotatoField
 
 
 Tangent Space

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -24,6 +24,8 @@ v0.2.8.dev
 
 - Refactor tests + fix refit of :class:`pyriemann.tangentspace.TangentSpace`
 
+- Add :class:`pyriemann.clustering.PotatoField`, and an example on artifact detection
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -221,7 +221,6 @@ def online_update(self):
             rpotato.partial_fit(covs[np.newaxis, t], alpha=1 / t)
         if ep_label == 1:
             epotato.partial_fit(covs[np.newaxis, t], alpha=1 / t)
-            #TODO: update plot_potato_2D
 
     # Update data
     time_start = t * interval + test_time_end

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -254,8 +254,8 @@ def online_update(self):
 
 
 ###############################################################################
-
 # Plot online detection (a dynamic display is required)
+
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_update, frames=test_covs_max,

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-Artifact Detection with Riemannian Potato
+Online Artifact Detection with Riemannian Potato
 ===============================================================================
 
 Example of Riemannian Potato [1]_ applied on EEG time-series to detect
@@ -89,7 +89,7 @@ raw.pick_types(meg=False, eeg=True).apply_proj()
 # beginning, to have a reliable calibration
 ch_names = ['EEG 010', 'EEG 015']
 
-# Apply IIR band-pass filter, between 1 and 35 Hz, to mimic online filtering
+# Apply band-pass filter between 1 and 35 Hz
 raw.filter(1., 35., method='iir', picks=ch_names)
 
 # Epoch time-series with a sliding window
@@ -164,7 +164,7 @@ plt.show()
 # acquisition, processing and artifact detection of EEG time-series.
 # Initialized with an offline calibration, the online potato can be [2]_:
 #
-# * static: it is never updated, damaging its efficiency over time,
+# * static: it is never updated, damaging its efficiency over time;
 # * semi-dynamic: it is updated when EEG is not artifacted.
 
 is_static = False       # static or semi-dynamic mode
@@ -184,8 +184,7 @@ time = np.linspace(time_start, time_end, int((time_end - time_start) * sfreq),
                    endpoint=False)
 eeg_data = 3e5 * raw.get_data(picks=ch_names)
 sig = eeg_data[:, int(time_start * sfreq):int(time_end * sfreq)]
-covs_visu = np.empty([0, 2, 2])
-rp_colors, ep_colors = [], []
+covs_visu, rp_colors, ep_colors = np.empty([0, 2, 2]), [], []
 alphas = np.linspace(0, 1, test_covs_visu)
 
 fig = plt.figure(figsize=(12, 10), constrained_layout=False)
@@ -215,13 +214,14 @@ def online_update(self):
     global t, time, sig, covs_visu
 
     # Online artifact detection
-    rp_label = rpotato.predict(covs[t][np.newaxis, ...])
-    ep_label = epotato.predict(covs[t][np.newaxis, ...])
+    rp_label = rpotato.predict(covs[np.newaxis, t])[0]
+    ep_label = epotato.predict(covs[np.newaxis, t])[0]
     if not is_static:
-        if rp_label[0] == 1:
-            rpotato.partial_fit(covs[t][np.newaxis, ...], alpha=1 / t)
-        if ep_label[0] == 1:
-            epotato.partial_fit(covs[t][np.newaxis, ...], alpha=1 / t)
+        if rp_label == 1:
+            rpotato.partial_fit(covs[np.newaxis, t], alpha=1 / t)
+        if ep_label == 1:
+            epotato.partial_fit(covs[np.newaxis, t], alpha=1 / t)
+            #TODO: update plot_potato_2D
 
     # Update data
     time_start = t * interval + test_time_end
@@ -231,7 +231,7 @@ def online_update(self):
     time = np.r_[time[int(interval * sfreq):], time_]
     sig = np.hstack((sig[:, int(interval*sfreq):],
                      eeg_data[:, int(time_start*sfreq):int(time_end*sfreq)]))
-    covs_visu = np.vstack((covs_visu, covs[t][np.newaxis, ...]))
+    covs_visu = np.vstack((covs_visu, covs[np.newaxis, t]))
     rp_colors.append('b' if rp_label == 1 else 'r')
     ep_colors.append('b' if ep_label == 1 else 'r')
     if len(covs_visu) > test_covs_visu:
@@ -256,7 +256,7 @@ def online_update(self):
 
 ###############################################################################
 
-# Plot online detection (an interactive display is required).
+# Plot online detection (a dynamic display is required).
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_update, frames=test_covs_max,

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -75,7 +75,7 @@ def add_alpha(p_cols, alphas):
 raw_fname = os.path.join(sample.data_path(), 'MEG', 'sample',
                          'sample_audvis_filt-0-40_raw.fif')
 raw = read_raw_fif(raw_fname, preload=True, verbose=False)
-sfreq = int(raw.info['sfreq'])
+sfreq = int(raw.info['sfreq'])  # 150 Hz
 
 
 ###############################################################################
@@ -255,7 +255,7 @@ def online_update(self):
 
 ###############################################################################
 
-# Plot online detection (a dynamic display is required).
+# Plot online detection (a dynamic display is required)
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_update, frames=test_covs_max,

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -55,7 +55,7 @@ def plot_detection(ax, rp_label, rpf_label):
             xmin=-test_time_start / test_duration + 0.005,
             xmax=(duration - test_time_start) / test_duration + 0.005)
         labels.append(r2)
-        ax.text(0.65 , 0.95, 'RPF', color='m', size=16, transform=ax.transAxes)
+        ax.text(0.65, 0.95, 'RPF', color='m', size=16, transform=ax.transAxes)
     if rp_label and rpf_label:
         r3 = ax.axhspan(
             ylims[0] + 0.05 * height, ylims[1] - 0.05 * height,

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -118,9 +118,9 @@ rp.fit(rp_covs[train_set])
 # -----------------------
 #
 # Riemannian potato field (RPF) [1]_ combines several potatoes of low
-# dimension, each one being designed to capture specific artifact typically
-# affecting specific spatial areas (ie, subsets of channels) and/or specific
-# frequency bands.
+# dimensionality, each one designed to capture a different kind of artifact
+# typically affecting some specific spatial area (i.e. subsets of channels)
+# and/or specific frequency bands.
 #
 # BCI or NFB applications aim at the modulation specific brain oscillations, it
 # is thus advisable to exclude such frequencies from potatoes so as to prevent

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -97,7 +97,7 @@ interval = 0.2    # interval between epochs
 
 # RP definition
 z_th = 2.0           # z-score threshold
-low_freq, high_freq = 1, 35
+low_freq, high_freq = 1., 35.
 rp = Potato(metric='riemann', threshold=z_th)
 
 # EEG processing for RP
@@ -130,17 +130,17 @@ p_th = 0.01          # probability threshold
 rpf_config = {
     'RPF eye_blinks': {  # for eye-blinks
         'ch_names': ['Fp1', 'Fpz', 'Fp2'],
-        'low_freq': 1,
-        'high_freq': 20},
+        'low_freq': 1.,
+        'high_freq': 20.},
     'RPF occipital': {  # for high-frequency artifacts in occipital area
         'ch_names': ['O1', 'Oz', 'O2'],
-        'low_freq': 25,
-        'high_freq': 45,
+        'low_freq': 25.,
+        'high_freq': 45.,
         'cov_normalization': 'trace'},  # trace-norm to be insensitive to power
     'RPF global_lf': {  # for low-frequency artifacts in all channels
         'ch_names': None,
         'low_freq': 0.5,
-        'high_freq': 3}
+        'high_freq': 3.}
 }
 rpf = PotatoField(metric='riemann', z_threshold=z_th, p_threshold=p_th,
                   n_potatoes=len(rpf_config))
@@ -171,7 +171,8 @@ rpf.fit([c[train_set] for c in rpf_covs])
 # not artifacted [1]_.
 
 # Prepare data for online detection
-test_covs_max = 400     # nb of matrices to visualize in this example
+test_covs_max = 400     # nb of epochs to visualize in this example
+test_covs_visu = 100    # nb of z-scores/proba to display simultaneously
 test_time_start = -2    # start time to display signal
 test_time_end = 5       # end time to display signal
 
@@ -180,7 +181,7 @@ time_start = t * interval + test_time_start
 time_end = t * interval + test_time_end
 time = np.linspace(time_start, time_end, int((time_end - time_start) * sfreq),
                    endpoint=False)
-raw.filter(l_freq=0.5, h_freq=75, method='iir', verbose=False)
+raw.filter(l_freq=0.5, h_freq=75., method='iir', verbose=False)
 eeg_data = 1e5 * raw.get_data()
 sig = eeg_data[:, int(time_start * sfreq):int(time_end * sfreq)]
 eeg_offset = - 15 * np.linspace(1, ch_count, ch_count, endpoint=False)
@@ -238,7 +239,7 @@ def online_update(self):
     covs_z = np.hstack((covs_z,
                         np.vstack((rp_zscore[np.newaxis], rpf_zscores))))
     covs_p = np.r_[covs_p, rpf_proba]
-    if len(covs_p) > 100:
+    if len(covs_p) > test_covs_visu:
         covs_t, covs_z, covs_p = covs_t[1:], covs_z[:, 1:], covs_p[1:]
     t += 1
 
@@ -260,7 +261,7 @@ def online_update(self):
 
 ###############################################################################
 
-# Plot online detection (a dynamic display is required).
+# Plot online detection (a dynamic display is required)
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_update, frames=test_covs_max,

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -1,0 +1,279 @@
+"""
+===============================================================================
+Online Artifact Detection with Riemannian Potato Field
+===============================================================================
+
+Example of Riemannian Potato Field [1]_ applied on EEG time-series to detect
+artifacts in online processing, compared to the Riemannian Potato [2]_.
+"""
+# Authors: Quentin Barthélemy
+#
+# License: BSD (3-clause)
+
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+from mne.datasets import eegbci
+from mne.io import read_raw_edf
+from mne.channels import make_standard_montage
+from mne import make_fixed_length_epochs
+
+from pyriemann.estimation import Covariances
+from pyriemann.utils.covariance import normalize
+from pyriemann.clustering import Potato, PotatoField
+
+
+###############################################################################
+
+
+def filter_bandpass(signal, low_freq, high_freq, channels=None, method="iir"):
+    """Filter signal on specific channels and in a specific frequency band"""
+    sig = signal.copy()
+    if channels is not None:
+        sig.pick_channels(channels)
+    sig.filter(l_freq=low_freq, h_freq=high_freq, method=method, verbose=False)
+    return sig
+
+
+def plot_detection(ax, rp_label, rpf_label):
+    labels = []
+    ylims = ax.get_ylim()
+    height = ylims[1] - ylims[0]
+    if not rp_label:
+        r1 = ax.axhspan(
+            ylims[0] + 0.06 * height, ylims[1] - 0.05 * height,
+            edgecolor='r', facecolor='none',
+            xmin=-test_time_start / test_duration - 0.005,
+            xmax=(duration - test_time_start) / test_duration - 0.005)
+        labels.append(r1)
+        ax.text(0.25, 0.95, 'RP', color='r', size=16, transform=ax.transAxes)
+    if not rpf_label:
+        r2 = ax.axhspan(
+            ylims[0] + 0.05 * height, ylims[1] - 0.06 * height,
+            edgecolor='m', facecolor='none',
+            xmin=-test_time_start / test_duration + 0.005,
+            xmax=(duration - test_time_start) / test_duration + 0.005)
+        labels.append(r2)
+        ax.text(0.65 , 0.95, 'RPF', color='m', size=16, transform=ax.transAxes)
+    if rp_label and rpf_label:
+        r3 = ax.axhspan(
+            ylims[0] + 0.05 * height, ylims[1] - 0.05 * height,
+            edgecolor='k', facecolor='none',
+            xmin=-test_time_start / test_duration,
+            xmax=(duration - test_time_start) / test_duration)
+        labels.append(r3)
+    return labels
+
+
+###############################################################################
+# Load EEG data
+# -------------
+
+# Load motor imagery data
+raw = read_raw_edf(eegbci.load_data(2, [5])[0], preload=True, verbose=False)
+eegbci.standardize(raw)
+raw.set_montage(make_standard_montage('standard_1005'))
+sfreq = int(raw.info['sfreq'])  # 160 Hz
+
+# Select the 21 channels of the 10-20 montage
+raw.pick_channels(
+    ['Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8', 'T7', 'C3', 'Cz', 'C4',
+     'T8', 'P7', 'P3', 'Pz', 'P4', 'P8', 'O1', 'Oz', 'O2'], ordered=True)
+ch_names = raw.ch_names
+ch_count = len(ch_names)
+
+# Define time-series epoching with a sliding window
+duration = 2.5    # duration of epochs
+interval = 0.2    # interval between epochs
+
+
+###############################################################################
+# Riemannian potato
+# -----------------
+#
+# Riemannian potato (RP) [2]_ selects all channels and filter between 1 and
+# 35 Hz.
+
+# RP definition
+z_th = 2.0           # z-score threshold
+low_freq, high_freq = 1, 35
+rp = Potato(metric='riemann', threshold=z_th)
+
+# EEG processing for RP
+rp_sig = filter_bandpass(raw, low_freq, high_freq)  # band-pass filter
+rp_epochs = make_fixed_length_epochs(  # epoch time-series
+    rp_sig, duration=duration, overlap=duration - interval, verbose=False)
+rp_covs = Covariances(estimator='scm').transform(rp_epochs.get_data())
+
+# RP training
+t = 45               # nb of matrices for training
+train_set = range(t)
+rp.fit(rp_covs[train_set])
+
+
+###############################################################################
+# Riemannian potato field
+# -----------------------
+#
+# Riemannian potato field (RPF) [1]_ combines several potatoes of low dimension
+# , each one being designed to capture specific artifact typically affecting
+# specific spatial areas (ie, subsets of channels) and/or specific frequency
+# bands.
+#
+# BCI or NFB applications aim at the modulation specific brain oscillations, it
+# is thus advisable to exclude such frequencies from potatoes so as to prevent
+# desirable brain modulations to be detected as artifactual.
+
+# RPF definition
+p_th = 0.01          # probability threshold
+rpf_config = {
+    'RPF eye_blinks': {  # for eye-blinks
+        'ch_names': ['Fp1', 'Fpz', 'Fp2'],
+        'low_freq': 1,
+        'high_freq': 20},
+    'RPF occipital': {  # for high-frequency artifacts in occipital area
+        'ch_names': ['O1', 'Oz', 'O2'],
+        'low_freq': 25,
+        'high_freq': 45,
+        'cov_normalization': 'trace'},  # trace-norm to be insensitive to power
+    'RPF global_lf': {  # for low-frequency artifacts in all channels
+        'ch_names': None,
+        'low_freq': 0.5,
+        'high_freq': 3}
+}
+rpf = PotatoField(metric='riemann', z_threshold=z_th, p_threshold=p_th,
+                  n_potatoes=len(rpf_config))
+
+# EEG processing for RPF
+rpf_covs = []
+for p in rpf_config.values():  # loop on potatoes
+    rpf_sig = filter_bandpass(raw, p.get('low_freq'), p.get('high_freq'),
+                              channels=p.get('ch_names'))
+    rpf_epochs = make_fixed_length_epochs(
+        rpf_sig, duration=duration, overlap=duration - interval, verbose=False)
+    covs_ = Covariances(estimator='scm').transform(rpf_epochs.get_data())
+    if p.get('cov_normalization'):
+        covs_ = normalize(covs_, p.get('cov_normalization'))
+    rpf_covs.append(covs_)
+
+# RPF training
+rpf.fit([c[train_set] for c in rpf_covs])
+
+
+###############################################################################
+# Online Artifact Detection with Potatoes
+# ---------------------------------------
+#
+# Detect artifacts/outliers on test set, with an animation to imitate an online
+# acquisition, processing and artifact detection of EEG time-series.
+# Remak that all these potatoes are semi-dynamic: they are updated when EEG is
+# not artifacted [1]_.
+
+# Prepare data for online detection
+test_covs_max = 400     # nb of matrices to visualize in this example
+test_time_start = -2    # start time to display signal
+test_time_end = 5       # end time to display signal
+
+test_duration = test_time_end - test_time_start
+time_start = t * interval + test_time_start
+time_end = t * interval + test_time_end
+time = np.linspace(time_start, time_end, int((time_end - time_start) * sfreq),
+                   endpoint=False)
+raw.filter(l_freq=0.5, h_freq=75, method='iir', verbose=False)
+eeg_data = 1e5 * raw.get_data()
+sig = eeg_data[:, int(time_start * sfreq):int(time_end * sfreq)]
+eeg_offset = - 15 * np.linspace(1, ch_count, ch_count, endpoint=False)
+covs_t, covs_z = np.empty([0]), np.empty([len(rpf_config) + 1, 0])
+covs_p = np.empty([0])
+
+fig, ax = plt.subplots(figsize=(12, 10), nrows=2, ncols=1)
+fig.suptitle('Online artifact detection, RP vs RPF', fontsize=16)
+ax[0].set(xlabel='Time (s)', ylabel='EEG channels')
+ax[0].set_xlim([time[0], time[-1]])
+ax[0].set_yticks(eeg_offset)
+ax[0].set_yticklabels(ch_names)
+pl = ax[0].plot(time, sig.T + eeg_offset.T, lw=0.75)
+labels = []
+
+ax[1].set(ylabel='Z-scores of distances to references')
+pl2 = ax[1].plot(covs_t, covs_z.T, lw=0.75)
+for c, l in enumerate(['RP'] + [*rpf_config]):
+    pl2[c].set_label(l)
+ax[1].set_ylim([-1.5, 8.5])
+ax[1].legend(loc='upper left')
+axp = ax[1].twinx()
+axp.set(ylabel='RPF probability of being clean')
+pl3 = axp.plot(covs_t, covs_p, lw=0.75, c='k', label='RPF proba')
+axp.set_ylim([0, 1])
+axp.legend(loc='upper right')
+
+
+###############################################################################
+
+# Prepare animation for online detection
+def online_update(self):
+    global t, time, sig, labels, covs_t, covs_z, covs_p
+
+    # Online artifact detection
+    rp_label = rp.predict(rp_covs[np.newaxis, t])[0]
+    rp_zscore = rp.transform(rp_covs[np.newaxis, t])
+    rpf_label = rpf.predict([c[np.newaxis, t] for c in rpf_covs])[0]
+    rpf_zscores = rpf.transform([c[np.newaxis, t] for c in rpf_covs])
+    rpf_proba = rpf.predict_proba([c[np.newaxis, t] for c in rpf_covs])
+    if rp_label == 1:
+        rp.partial_fit(rp_covs[np.newaxis, t], alpha=1 / t)
+    if rpf_label == 1:
+        rpf.partial_fit([c[np.newaxis, t] for c in rpf_covs], alpha=1 / t)
+
+    # Update data
+    time_start = t * interval + test_time_end
+    time_end = (t + 1) * interval + test_time_end
+    time_ = np.linspace(time_start, time_end, int(interval * sfreq),
+                        endpoint=False)
+    time = np.r_[time[int(interval * sfreq):], time_]
+    sig = np.hstack((sig[:, int(interval * sfreq):],
+                     eeg_data[:, int(time_start*sfreq):int(time_end*sfreq)]))
+    covs_t = np.r_[covs_t, time_start]
+    covs_z = np.hstack((covs_z,
+                        np.vstack((rp_zscore[np.newaxis], rpf_zscores))))
+    covs_p = np.r_[covs_p, rpf_proba]
+    if len(covs_p) > 100:
+        covs_t, covs_z, covs_p = covs_t[1:], covs_z[:, 1:], covs_p[1:]
+    t += 1
+
+    # Update plot
+    for c in range(ch_count):
+        pl[c].set_data(time, sig[c] + eeg_offset[c])
+        pl[c].axes.set_xlim(time[0], time[-1])
+    for lbl in labels:
+        lbl.remove()
+    for txt in ax[0].texts:
+        txt.set_visible(False)
+    labels = plot_detection(ax[0], rp_label, rpf_label)
+    for c in range(len(pl2)):
+        pl2[c].set_data(covs_t, covs_z[c])
+        pl2[c].axes.set_xlim(covs_t[0] - 0.1, covs_t[-1])
+    pl3[0].set_data(covs_t, covs_p)
+    return pl, pl2, pl3
+
+
+###############################################################################
+
+# Plot online detection (a dynamic display is required).
+interval_display = 1.0  # can be changed for a slower display
+
+potato = FuncAnimation(fig, online_update, frames=test_covs_max,
+                       interval=interval_display, blit=False, repeat=False)
+plt.show()
+
+
+###############################################################################
+# References
+# ----------
+# .. [1] Q. Barthélemy, L. Mayaud, D. Ojeda, M. Congedo, "The Riemannian potato
+#    field: a tool for online signal quality index of EEG", IEEE TNSRE, 2019.
+#
+# .. [2] A. Barachant, A. Andreev, M. Congedo, "The Riemannian Potato: an
+#    automatic and adaptive artifact detection method for online experiments
+#    using Riemannian geometry", Proc. TOBI Workshop IV, 2013.

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -3,8 +3,9 @@
 Online Artifact Detection with Riemannian Potato Field
 ===============================================================================
 
-Example of Riemannian Potato Field [1]_ applied on EEG time-series to detect
-artifacts in online processing, compared to the Riemannian Potato [2]_.
+Example of Riemannian Potato Field (RPF) [1]_ applied on EEG time-series to
+detect artifacts in online processing. It is compared to the Riemannian Potato
+(RP) [2]_.
 """
 # Authors: Quentin Barthélemy
 #
@@ -116,10 +117,10 @@ rp.fit(rp_covs[train_set])
 # Riemannian potato field
 # -----------------------
 #
-# Riemannian potato field (RPF) [1]_ combines several potatoes of low dimension
-# , each one being designed to capture specific artifact typically affecting
-# specific spatial areas (ie, subsets of channels) and/or specific frequency
-# bands.
+# Riemannian potato field (RPF) [1]_ combines several potatoes of low
+# dimension, each one being designed to capture specific artifact typically
+# affecting specific spatial areas (ie, subsets of channels) and/or specific
+# frequency bands.
 #
 # BCI or NFB applications aim at the modulation specific brain oscillations, it
 # is thus advisable to exclude such frequencies from potatoes so as to prevent
@@ -167,7 +168,7 @@ rpf.fit([c[train_set] for c in rpf_covs])
 #
 # Detect artifacts/outliers on test set, with an animation to imitate an online
 # acquisition, processing and artifact detection of EEG time-series.
-# Remak that all these potatoes are semi-dynamic: they are updated when EEG is
+# Remark that all these potatoes are semi-dynamic: they are updated when EEG is
 # not artifacted [1]_.
 
 # Prepare data for online detection
@@ -204,7 +205,7 @@ for c, l in enumerate(['RP'] + [*rpf_config]):
 ax[1].set_ylim([-1.5, 8.5])
 ax[1].legend(loc='upper left')
 axp = ax[1].twinx()
-axp.set(ylabel='RPF probability of being clean')
+axp.set(ylabel='RPF probability of clean EEG')
 pl3 = axp.plot(covs_t, covs_p, lw=0.75, c='k', label='RPF proba')
 axp.set_ylim([0, 1])
 axp.legend(loc='upper right')
@@ -237,7 +238,7 @@ def online_update(self):
                      eeg_data[:, int(time_start*sfreq):int(time_end*sfreq)]))
     covs_t = np.r_[covs_t, time_start]
     covs_z = np.hstack((covs_z,
-                        np.vstack((rp_zscore[np.newaxis], rpf_zscores))))
+                        np.vstack((rp_zscore[np.newaxis], rpf_zscores.T))))
     covs_p = np.r_[covs_p, rpf_proba]
     if len(covs_p) > test_covs_visu:
         covs_t, covs_z, covs_p = covs_t[1:], covs_z[:, 1:], covs_p[1:]
@@ -260,8 +261,8 @@ def online_update(self):
 
 
 ###############################################################################
-
 # Plot online detection (a dynamic display is required)
+
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_update, frames=test_covs_max,

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -590,7 +590,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                     'got %d.' % (n_trials, X[i].shape[0]))
             self._potatoes.append(clone(pt))
             self._potatoes[i].fit(X[i], y)
-            
+
         return self
 
     def partial_fit(self, X, y=None, alpha=0.1):
@@ -711,7 +711,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         if len(X) != self.n_potatoes:
             raise ValueError(
                 'Length of X is not equal to n_potatoes. Should be %d but got '
-                '%d.' % (self.n_potatoes, len(X)))        
+                '%d.' % (self.n_potatoes, len(X)))
 
     def _get_proba(self, q):
         """Get proba from a chi-squared value q."""

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -326,8 +326,9 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         X : ndarray, shape (n_trials, n_channels, n_channels)
             ndarray of SPD matrices.
         y : ndarray, shape (n_trials,) | None (default None)
-            Labels corresponding to each trial. If None, all trials are
-            considered as clean.
+            Labels corresponding to each trial: positive (resp. negative) label
+            corresponds to a clean (resp. artifact) trial. If None, all trials
+            are considered as clean.
 
         Returns
         -------
@@ -607,8 +608,9 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels), with same n_trials but different n_channels
             list of ndarray of SPD matrices.
         y : ndarray, shape (n_trials,) | None (default None)
-            Labels corresponding to each trial. If None, all trials are
-            considered as clean.
+            Labels corresponding to each trial: positive (resp. negative) label
+            corresponds to a clean (resp. artifact) trial. If None, all trials
+            are considered as clean.
         alpha : float (default 0.1)
             Update rate in [0, 1] for the centroid, and mean and standard
             deviation of log-distances: 0 for no update, 1 for full update.

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -519,7 +519,8 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
     metric : string (default 'riemann')
         The type of metric used for centroid and distance estimation.
     z_threshold : float (default 3)
-        Threshold on z-score of distance to the centroid.
+        Threshold on z-score of distance to reject artifacts. It is the number
+        of standard deviations from the mean of distances to the centroid.    
     n_iter_max : int (default 10)
         The maximum number of iteration to reach convergence.
     pos_label: int (default 1)
@@ -542,8 +543,8 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         TNSRE, 2019.
     """
 
-    def __init__(self, n_potatoes=1, p_threshold=0.01, metric='riemann',
-                 z_threshold=3, n_iter_max=10, pos_label=1, neg_label=0):
+    def __init__(self, n_potatoes=1, p_threshold=0.01, z_threshold=3,
+                 metric='riemann', n_iter_max=10, pos_label=1, neg_label=0):
         """Init."""
         self.n_potatoes = int(n_potatoes)
         self.p_threshold = p_threshold
@@ -559,9 +560,10 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarray of shape (n_trials, n_channels,
-                n_channels), with same n_trials but different n_channels
-            list of ndarray of SPD matrices.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels,
+            n_channels) with same n_trials but potentially different n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different 
+            subset of EEG channels and/or filtering with a specific frequency band.
         y : ndarray, shape (n_trials,) | None (default None)
             Labels corresponding to each trial: positive (resp. negative) label
             corresponds to a clean (resp. artifact) trial. If None, all trials
@@ -617,8 +619,8 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Returns
         -------
-        self : Potato instance
-            The Potato instance.
+        self : PotatoField instance
+            The Potato Field instance.
         """
         self._check_length(X)
         n_trials = X[0].shape[0]
@@ -658,7 +660,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
             z[:, i] = self._potatoes[i].transform(X[i])
         return z
 
-    def predict(self, X, alpha=0):
+    def predict(self, X):
         """Predict artefact from data.
 
         Parameters

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -515,12 +515,13 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
     n_potatoes : int (default 1)
         Number of potatoes in the field.
     p_threshold : float (default 0.01)
-        Threshold on probability to being clean, in (0, 1).
-    metric : string (default 'riemann')
-        The type of metric used for centroid and distance estimation.
+        Threshold on probability to being clean, in (0, 1), combining
+        probabilities of potatoes using Fisher's method.
     z_threshold : float (default 3)
         Threshold on z-score of distance to reject artifacts. It is the number
-        of standard deviations from the mean of distances to the centroid.    
+        of standard deviations from the mean of distances to the centroid.
+    metric : string (default 'riemann')
+        The type of metric used for centroid and distance estimation.
     n_iter_max : int (default 10)
         The maximum number of iteration to reach convergence.
     pos_label: int (default 1)
@@ -560,10 +561,12 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarrays of shape (n_trials, n_channels,
-            n_channels) with same n_trials but potentially different n_channels
-            List of ndarrays of SPD matrices, each corresponding to a different 
-            subset of EEG channels and/or filtering with a specific frequency band.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels, \
+                n_channels) with same n_trials but potentially different \
+                n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different
+            subset of EEG channels and/or filtering with a specific frequency
+            band.
         y : ndarray, shape (n_trials,) | None (default None)
             Labels corresponding to each trial: positive (resp. negative) label
             corresponds to a clean (resp. artifact) trial. If None, all trials
@@ -606,9 +609,12 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarray of shape (n_trials, n_channels,
-                n_channels), with same n_trials but different n_channels
-            list of ndarray of SPD matrices.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels, \
+                n_channels) with same n_trials but potentially different \
+                n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different
+            subset of EEG channels and/or filtering with a specific frequency
+            band.
         y : ndarray, shape (n_trials,) | None (default None)
             Labels corresponding to each trial: positive (resp. negative) label
             corresponds to a clean (resp. artifact) trial. If None, all trials
@@ -639,9 +645,12 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarray of shape (n_trials, n_channels,
-                n_channels), with same n_trials but different n_channels
-            list of ndarray of SPD matrices.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels, \
+                n_channels) with same n_trials but potentially different \
+                n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different
+            subset of EEG channels and/or filtering with a specific frequency
+            band.
 
         Returns
         -------
@@ -665,9 +674,12 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarray of shape (n_trials, n_channels,
-                n_channels), with same n_trials but different n_channels
-            list of ndarray of SPD matrices.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels, \
+                n_channels) with same n_trials but potentially different \
+                n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different
+            subset of EEG channels and/or filtering with a specific frequency
+            band.
 
         Returns
         -------
@@ -687,9 +699,12 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Parameters
         ----------
-        X : list of n_potatoes ndarray of shape (n_trials, n_channels,
-                n_channels), with same n_trials but different n_channels
-            list of ndarray of SPD matrices.
+        X : list of n_potatoes ndarrays of shape (n_trials, n_channels, \
+                n_channels) with same n_trials but potentially different \
+                n_channels
+            List of ndarrays of SPD matrices, each corresponding to a different
+            subset of EEG channels and/or filtering with a specific frequency
+            band.
 
         Returns
         -------

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -639,19 +639,19 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Returns
         -------
-        z : ndarray, shape (n_potatoes, n_trials)
+        z : ndarray, shape (n_trials, n_potatoes)
             the normalized log-distances to the centroids.
         """
         self._check_length(X)
         n_trials = X[0].shape[0]
 
-        z = np.zeros((self.n_potatoes, n_trials))
+        z = np.zeros((n_trials, self.n_potatoes))
         for i in range(self.n_potatoes):
             if X[i].shape[0] != n_trials:
                 raise ValueError(
                     'Unequal n_trials between ndarray of X. Should be %d but '
                     'got %d.' % (n_trials, X[i].shape[0]))
-            z[i] = self._potatoes[i].transform(X[i])
+            z[:, i] = self._potatoes[i].transform(X[i])
         return z
 
     def predict(self, X, alpha=0):

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -367,8 +367,9 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         X : ndarray, shape (n_trials, n_channels, n_channels)
             ndarray of SPD matrices.
         y : ndarray, shape (n_trials,) | None (default None)
-            Labels corresponding to each trial. If None, all trials are
-            considered as clean.
+            Labels corresponding to each trial: positive (resp. negative) label
+            corresponds to a clean (resp. artifact) trial. If None, all trials
+            are considered as clean.
         alpha : float (default 0.1)
             Update rate in [0, 1] for the centroid, and mean and standard
             deviation of log-distances: 0 for no update, 1 for full update.
@@ -561,8 +562,9 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels), with same n_trials but different n_channels
             list of ndarray of SPD matrices.
         y : ndarray, shape (n_trials,) | None (default None)
-            Labels corresponding to each trial. If None, all trials are
-            considered as clean.
+            Labels corresponding to each trial: positive (resp. negative) label
+            corresponds to a clean (resp. artifact) trial. If None, all trials
+            are considered as clean.
 
         Returns
         -------

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -314,4 +314,3 @@ def test_PotatoField_predictproba(get_covmats):
         pf.predict_proba([covmats1, covmats1, covmats2])
     with pytest.raises(ValueError):  # n_trials not equal
         pf.predict_proba([covmats1, covmats2[:1]])
-

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -75,8 +75,6 @@ class TestRiemannianClustering(ClusteringTestCase):
         transformed = clf.transform(covmats)
         if n_clusters is None:
             assert transformed.shape == (n_trials,)
-        elif clust is PotatoField:
-            assert transformed.shape == (n_clusters, n_trials)
         else:
             assert transformed.shape == (n_trials, n_clusters)
 
@@ -262,7 +260,7 @@ def test_Potato_specific_labels(get_covmats):
     pt.fit(covmats, y=[2] * n_trials)
 
 
-def test_PotatoField_fit(get_covmats):
+def test_potato_field_fit(get_covmats):
     n_potatoes, n_trials, n_channels = 2, 6, 3
     covmats1 = get_covmats(n_trials, n_channels)
     covmats2 = get_covmats(n_trials, n_channels + 1)
@@ -280,7 +278,7 @@ def test_PotatoField_fit(get_covmats):
         pf.fit([covmats1, covmats2[:1]])
 
 
-def test_PotatoField_partialfit(get_covmats):
+def test_potato_field_partialfit(get_covmats):
     n_potatoes, n_trials, n_channels = 2, 6, 3
     covmats1 = get_covmats(n_trials, n_channels)
     covmats2 = get_covmats(n_trials, n_channels + 1)
@@ -292,7 +290,7 @@ def test_PotatoField_partialfit(get_covmats):
         pf.partial_fit([covmats1, covmats2[:1]])
 
 
-def test_PotatoField_transform(get_covmats):
+def test_potato_field_transform(get_covmats):
     n_potatoes, n_trials, n_channels = 2, 6, 3
     covmats1 = get_covmats(n_trials, n_channels)
     covmats2 = get_covmats(n_trials, n_channels + 1)
@@ -304,7 +302,7 @@ def test_PotatoField_transform(get_covmats):
         pf.transform([covmats1, covmats2[:1]])
 
 
-def test_PotatoField_predictproba(get_covmats):
+def test_potato_field_predictproba(get_covmats):
     n_potatoes, n_trials, n_channels = 2, 6, 3
     covmats1 = get_covmats(n_trials, n_channels)
     covmats2 = get_covmats(n_trials, n_channels + 1)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -184,7 +184,7 @@ def test_km_init_metric(clust, init, n_init, metric, get_covmats, get_labels):
     assert len(transformed) == n_trials
 
 
-def test_Potato_fit_equal_labels(get_covmats):
+def test_potato_fit_equal_labels(get_covmats):
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
     with pytest.raises(ValueError):
@@ -192,21 +192,21 @@ def test_Potato_fit_equal_labels(get_covmats):
 
 
 @pytest.mark.parametrize("y_fail", [[1], [0] * 6, [0] * 7, [0, 1, 2] * 2])
-def test_Potato_fit_error(y_fail, get_covmats):
+def test_potato_fit_error(y_fail, get_covmats):
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
     with pytest.raises(ValueError):
         Potato().fit(covmats, y=y_fail)
 
 
-def test_Potato_partial_fit_not_fitted(get_covmats):
+def test_potato_partial_fit_not_fitted(get_covmats):
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
     with pytest.raises(ValueError):  # potato not fitted
         Potato().partial_fit(covmats)
 
 
-def test_Potato_partial_fit_diff_channels(get_covmats, get_labels):
+def test_potato_partial_fit_diff_channels(get_covmats, get_labels):
     n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     labels = get_labels(n_trials, n_classes)
@@ -215,7 +215,7 @@ def test_Potato_partial_fit_diff_channels(get_covmats, get_labels):
         pt.partial_fit(get_covmats(2, n_channels + 1))
 
 
-def test_Potato_partial_fit_no_poslabel(get_covmats, get_labels):
+def test_potato_partial_fit_no_poslabel(get_covmats, get_labels):
     n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     labels = get_labels(n_trials, n_classes)
@@ -225,7 +225,7 @@ def test_Potato_partial_fit_no_poslabel(get_covmats, get_labels):
 
 
 @pytest.mark.parametrize("alpha", [-0.1, 1.1])
-def test_Potato_partial_fit_alpha(alpha, get_covmats, get_labels):
+def test_potato_partial_fit_alpha(alpha, get_covmats, get_labels):
     n_trials, n_channels, n_classes = 6, 3, 2
     covmats = get_covmats(n_trials, n_channels)
     labels = get_labels(n_trials, n_classes)
@@ -234,7 +234,7 @@ def test_Potato_partial_fit_alpha(alpha, get_covmats, get_labels):
         pt.partial_fit(covmats, labels, alpha=alpha)
 
 
-def test_Potato_1channel(get_covmats):
+def test_potato_1channel(get_covmats):
     n_trials, n_channels = 6, 1
     covmats_1chan = get_covmats(n_trials, n_channels)
     pt = Potato()
@@ -243,14 +243,14 @@ def test_Potato_1channel(get_covmats):
     pt.predict_proba(covmats_1chan)
 
 
-def test_Potato_threshold(get_covmats):
+def test_potato_threshold(get_covmats):
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
     pt = Potato(threshold=1)
     pt.fit(covmats)
 
 
-def test_Potato_specific_labels(get_covmats):
+def test_potato_specific_labels(get_covmats):
     n_trials, n_channels = 6, 3
     covmats = get_covmats(n_trials, n_channels)
     pt = Potato(threshold=1, pos_label=2, neg_label=7)


### PR DESCRIPTION
This PR:
- adds the class `PotatoField`,
- adds an animated example in the gallery, on artifact detection by  Riemannian Potato Field , compared with  Riemannian Potato.

Q. Barthélemy, L. Mayaud, D. Ojeda, M. Congedo, "The Riemannian potato field: a tool for online signal quality index of EEG", IEEE TNSRE, 2019, [link to pdf](https://hal.archives-ouvertes.fr/hal-02015909/document).