### PR TITLE
Add example on ERP

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -108,7 +108,7 @@ Channel selection
     :template: class.rst
 
     ElectrodeSelection
-    FlatChannelRemover         
+    FlatChannelRemover
 
 Stats
 ------------------
@@ -156,7 +156,6 @@ Covariance preprocessing
     normalize
     get_nondiag_weight
 
-
 Distances
 ~~~~~~~~~~~~~~~~~~~~~~
 .. _distance_api:
@@ -173,7 +172,6 @@ Distances
     distance_kullback
     distance_kullback_sym
     distance_wasserstein
-
 
 Mean
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -194,7 +192,6 @@ Mean
     mean_harmonic
     mean_kullback_sym
 
-
 Geodesic
 ~~~~~~~~~~~~~~~~~~~~~~
 .. _geodesic_api:
@@ -207,7 +204,6 @@ Geodesic
     geodesic_riemann
     geodesic_euclid
     geodesic_logeuclid
-
 
 Tangent Space
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -246,3 +242,15 @@ Aproximate Joint Diagonalization
     ajd_pham
     uwedge
 
+Visualization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _viz_api:
+.. currentmodule:: pyriemann.utils.viz
+
+.. autosummary::
+    :toctree: generated/
+
+    plot_confusion_matrix
+    plot_embedding
+    plot_cospectra
+    plot_waveforms

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 sphinx-gallery
 sphinx-bootstrap_theme
 numpydoc
-mne
+mne==0.23.4
 scikit-learn
 seaborn
 pandas

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,8 @@ v0.2.8.dev
 
 - Add new function :func:`pyriemann.datasets.make_gaussian_blobs` for generating random datasets with SPD matrices
 
+- Add an example on ERP visualization
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,7 +30,7 @@ v0.2.8.dev
 
 - Add new function :func:`pyriemann.datasets.make_gaussian_blobs` for generating random datasets with SPD matrices
 
-- Add an example on ERP visualization
+- Add module ``pyriemann.utils.viz`` in API, add :func:`pyriemann.utils.viz.plot_waveforms`, and add an example on ERP visualization
 
 v0.2.7 (June 2021)
 ------------------

--- a/examples/ERP/plot_ERP.py
+++ b/examples/ERP/plot_ERP.py
@@ -40,6 +40,8 @@ epochs = mne.Epochs(
 X = epochs.get_data()
 print('Number of trials:', X.shape[0])
 time = np.linspace(tmin, tmax, num=X.shape[2])
+
+plt.rcParams["figure.figsize"] = (7, 12)
 ylims = []
 
 
@@ -49,14 +51,14 @@ ylims = []
 #
 # This kind of plot is a little bit messy.
 
-fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+
+fig = plot_waveforms(X, 'all', time=time, alpha=0.3)
 fig.suptitle('Plot all trials', fontsize=16)
-ax = plot_waveforms(X, 'all', chax=ax, time=time, alpha=0.3)
 for i_channel in range(n_channels):
-    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
-    ax[i_channel].set_xlim(tmin, tmax)
-    ylims.append(ax[i_channel].get_ylim())
-ax[n_channels - 1].set(xlabel='Time')
+    fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])
+    fig.axes[i_channel].set_xlim(tmin, tmax)
+    ylims.append(fig.axes[i_channel].get_ylim())
+fig.axes[n_channels - 1].set(xlabel='Time')
 plt.show()
 
 
@@ -68,14 +70,13 @@ plt.show()
 # contaminated by artifacts, and they make a symmetric assumption on amplitude
 # distribution.
 
-fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+fig = plot_waveforms(X, 'mean+/-std', time=time)
 fig.suptitle('Plot mean+/-std of trials', fontsize=16)
-ax = plot_waveforms(X, 'mean+/-std', chax=ax, time=time)
 for i_channel in range(n_channels):
-    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
-    ax[i_channel].set_xlim(tmin, tmax)
-    ax[i_channel].set_ylim(ylims[i_channel])
-ax[n_channels - 1].set(xlabel='Time')
+    fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])
+    fig.axes[i_channel].set_xlim(tmin, tmax)
+    fig.axes[i_channel].set_ylim(ylims[i_channel])
+fig.axes[n_channels - 1].set(xlabel='Time')
 plt.show()
 
 
@@ -85,14 +86,12 @@ plt.show()
 #
 # This plot estimates a 2D histogram of trials [1]_.
 
-fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+fig = plot_waveforms(X, 'hist', time=time, n_bins=25, cmap=plt.cm.Greys)
 fig.suptitle('Plot histogram of trials', fontsize=16)
-ax = plot_waveforms(X, 'hist', chax=ax, time=time, n_bins=25,
-                    cmap=plt.cm.Greys)
 for i_channel in range(n_channels):
-    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
-    ax[i_channel].set_ylim(ylims[i_channel])
-ax[n_channels - 1].set(xlabel='Time')
+    fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])
+    fig.axes[i_channel].set_ylim(ylims[i_channel])
+fig.axes[n_channels - 1].set(xlabel='Time')
 plt.show()
 
 

--- a/examples/ERP/plot_ERP.py
+++ b/examples/ERP/plot_ERP.py
@@ -1,6 +1,6 @@
 """
 ===============================================================================
-Display ERP.
+Display ERP
 ===============================================================================
 
 Different ways to display a multichannel event-related potential (ERP).
@@ -13,7 +13,7 @@ Different ways to display a multichannel event-related potential (ERP).
 import numpy as np
 import mne
 from matplotlib import pyplot as plt
-from pyriemann.utils.viz import plot_erp
+from pyriemann.utils.viz import plot_waveforms
 
 
 ###############################################################################
@@ -51,7 +51,7 @@ ylims = []
 
 fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
 fig.suptitle('Plot all trials', fontsize=16)
-ax = plot_erp(X, display='all', chax=ax, t=time, alpha=0.3)
+ax = plot_waveforms(X, 'all', chax=ax, time=time, alpha=0.3)
 for i_channel in range(n_channels):
     ax[i_channel].set(ylabel=raw.ch_names[i_channel])
     ax[i_channel].set_xlim(tmin, tmax)
@@ -70,7 +70,7 @@ plt.show()
 
 fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
 fig.suptitle('Plot mean+/-std of trials', fontsize=16)
-plot_erp(X, display='mean+/-std', chax=ax, t=time)
+ax = plot_waveforms(X, 'mean+/-std', chax=ax, time=time)
 for i_channel in range(n_channels):
     ax[i_channel].set(ylabel=raw.ch_names[i_channel])
     ax[i_channel].set_xlim(tmin, tmax)
@@ -87,7 +87,8 @@ plt.show()
 
 fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
 fig.suptitle('Plot histogram of trials', fontsize=16)
-plot_erp(X, display='hist', chax=ax, t=time, n_bins=25, cmap=plt.cm.Greys)
+ax = plot_waveforms(X, 'hist', chax=ax, time=time, n_bins=25,
+                    cmap=plt.cm.Greys)
 for i_channel in range(n_channels):
     ax[i_channel].set(ylabel=raw.ch_names[i_channel])
     ax[i_channel].set_ylim(ylims[i_channel])

--- a/examples/ERP/plot_ERP.py
+++ b/examples/ERP/plot_ERP.py
@@ -37,9 +37,9 @@ tmin, tmax = -0.1, 0.8
 epochs = mne.Epochs(
     raw, mne.read_events(event_fname), {'vis_l': 3}, tmin, tmax, proj=False,
     baseline=None, preload=True, verbose=False)
-X = epochs.get_data()
+X = 5e5 * epochs.get_data()
 print('Number of trials:', X.shape[0])
-time = np.linspace(tmin, tmax, num=X.shape[2])
+times = np.linspace(tmin, tmax, num=X.shape[2])
 
 plt.rcParams["figure.figsize"] = (7, 12)
 ylims = []
@@ -51,7 +51,7 @@ ylims = []
 #
 # This kind of plot is a little bit messy.
 
-fig = plot_waveforms(X, 'all', time=time, alpha=0.3)
+fig = plot_waveforms(X, 'all', times=times, alpha=0.3)
 fig.suptitle('Plot all trials', fontsize=16)
 for i_channel in range(n_channels):
     fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])
@@ -69,7 +69,7 @@ plt.show()
 # contaminated by artifacts, and they make a symmetric assumption on amplitude
 # distribution.
 
-fig = plot_waveforms(X, 'mean+/-std', time=time)
+fig = plot_waveforms(X, 'mean+/-std', times=times)
 fig.suptitle('Plot mean+/-std of trials', fontsize=16)
 for i_channel in range(n_channels):
     fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])
@@ -85,7 +85,7 @@ plt.show()
 #
 # This plot estimates a 2D histogram of trials [1]_.
 
-fig = plot_waveforms(X, 'hist', time=time, n_bins=25, cmap=plt.cm.Greys)
+fig = plot_waveforms(X, 'hist', times=times, n_bins=25, cmap=plt.cm.Greys)
 fig.suptitle('Plot histogram of trials', fontsize=16)
 for i_channel in range(n_channels):
     fig.axes[i_channel].set(ylabel=raw.ch_names[i_channel])

--- a/examples/ERP/plot_ERP.py
+++ b/examples/ERP/plot_ERP.py
@@ -24,7 +24,6 @@ from pyriemann.utils.viz import plot_waveforms
 data_path = mne.datasets.sample.data_path()
 raw_fname = data_path + "/MEG/sample/sample_audvis_filt-0-40_raw.fif"
 event_fname = data_path + "/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif"
-tmin, tmax = -0.1, 0.8
 
 # Read raw data, select occipital channels and high-pass filter signal
 raw = mne.io.Raw(raw_fname, preload=True, verbose=False)
@@ -34,6 +33,7 @@ n_channels = len(raw.ch_names)
 raw.filter(1.0, None, method="iir")
 
 # Read epochs and get responses to left visual field stimulus
+tmin, tmax = -0.1, 0.8
 epochs = mne.Epochs(
     raw, mne.read_events(event_fname), {'vis_l': 3}, tmin, tmax, proj=False,
     baseline=None, preload=True, verbose=False)
@@ -50,7 +50,6 @@ ylims = []
 # ---------------
 #
 # This kind of plot is a little bit messy.
-
 
 fig = plot_waveforms(X, 'all', time=time, alpha=0.3)
 fig.suptitle('Plot all trials', fontsize=16)

--- a/examples/ERP/plot_ERP.py
+++ b/examples/ERP/plot_ERP.py
@@ -1,0 +1,103 @@
+"""
+===============================================================================
+Display ERP.
+===============================================================================
+
+Different ways to display a multichannel event-related potential (ERP).
+
+"""
+# Authors: Quentin Barthélemy
+#
+# License: BSD (3-clause)
+
+import numpy as np
+import mne
+from matplotlib import pyplot as plt
+from pyriemann.utils.viz import plot_erp
+
+
+###############################################################################
+# Load EEG data
+# -------------
+
+# Set filenames
+data_path = mne.datasets.sample.data_path()
+raw_fname = data_path + "/MEG/sample/sample_audvis_filt-0-40_raw.fif"
+event_fname = data_path + "/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif"
+tmin, tmax = -0.1, 0.8
+
+# Read raw data, select occipital channels and high-pass filter signal
+raw = mne.io.Raw(raw_fname, preload=True, verbose=False)
+raw.pick_channels(['EEG 057', 'EEG 058', 'EEG 059'], ordered=True)
+raw.rename_channels({'EEG 057': 'O1', 'EEG 058': 'Oz', 'EEG 059': 'O2'})
+n_channels = len(raw.ch_names)
+raw.filter(1.0, None, method="iir")
+
+# Read epochs and get responses to left visual field stimulus
+epochs = mne.Epochs(
+    raw, mne.read_events(event_fname), {'vis_l': 3}, tmin, tmax, proj=False,
+    baseline=None, preload=True, verbose=False)
+X = epochs.get_data()
+print('Number of trials:', X.shape[0])
+time = np.linspace(tmin, tmax, num=X.shape[2])
+ylims = []
+
+
+###############################################################################
+# Plot all trials
+# ---------------
+#
+# This kind of plot is a little bit messy.
+
+fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+fig.suptitle('Plot all trials', fontsize=16)
+ax = plot_erp(X, display='all', chax=ax, t=time, alpha=0.3)
+for i_channel in range(n_channels):
+    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
+    ax[i_channel].set_xlim(tmin, tmax)
+    ylims.append(ax[i_channel].get_ylim())
+ax[n_channels - 1].set(xlabel='Time')
+plt.show()
+
+
+###############################################################################
+# Plot central tendency and dispersion of trials
+# ----------------------------------------------
+#
+# This kind of plot is well-spread, but mean and standard deviation can be
+# contaminated by artifacts, and they make a symmetric assumption on amplitude
+# distribution.
+
+fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+fig.suptitle('Plot mean+/-std of trials', fontsize=16)
+plot_erp(X, display='mean+/-std', chax=ax, t=time)
+for i_channel in range(n_channels):
+    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
+    ax[i_channel].set_xlim(tmin, tmax)
+    ax[i_channel].set_ylim(ylims[i_channel])
+ax[n_channels - 1].set(xlabel='Time')
+plt.show()
+
+
+###############################################################################
+# Plot histogram of trials
+# ------------------------
+#
+# This plot estimates a 2D histogram of trials [1]_.
+
+fig, ax = plt.subplots(nrows=n_channels, ncols=1, figsize=(7, 12))
+fig.suptitle('Plot histogram of trials', fontsize=16)
+plot_erp(X, display='hist', chax=ax, t=time, n_bins=25, cmap=plt.cm.Greys)
+for i_channel in range(n_channels):
+    ax[i_channel].set(ylabel=raw.ch_names[i_channel])
+    ax[i_channel].set_ylim(ylims[i_channel])
+ax[n_channels - 1].set(xlabel='Time')
+plt.show()
+
+
+###############################################################################
+# References
+# ----------
+# .. [1] A. Souloumiac and B. Rivet, "Improved estimation of EEG evoked
+#    potentials by jitter compensation and enhancing spatial filters", ICASSP,
+#    2013.

--- a/examples/ERP/plot_embedding_MEG.py
+++ b/examples/ERP/plot_embedding_MEG.py
@@ -1,6 +1,6 @@
 """
 =====================================================================
-Embedding ERP EEG data in 2D Euclidean space with Laplacian Eigenmaps
+Embedding ERP MEG data in 2D Euclidean space with Laplacian Eigenmaps
 =====================================================================
 
 Spectral embedding via Laplacian Eigenmaps of a set of ERP data.

--- a/pyriemann/utils/viz.py
+++ b/pyriemann/utils/viz.py
@@ -149,7 +149,7 @@ def plot_erp(X, display='all', *, chax=0, t=None, **kwargs):
         color_mean = kwargs.get('color_mean', 'k')
         color_std = kwargs.get('color_std', 'gray')
         ax.plot(t, mean, color=color_mean, linewidth=linewidth)
-        ax.fill_between(t, mean - std, mean + std, color=color_std) 
+        ax.fill_between(t, mean - std, mean + std, color=color_std)
 
     def _plot_erp_hist(ax, t, X, **kwargs):
         n_bins = kwargs.get('n_bins', 50)

--- a/pyriemann/utils/viz.py
+++ b/pyriemann/utils/viz.py
@@ -113,7 +113,9 @@ def plot_cospectra(cosp, freqs, *, ylabels=None, title="Cospectra"):
     return fig
 
 
-def plot_waveforms(X, display, *, times=None, **kwargs):
+def plot_waveforms(X, display, *, times=None, color='gray', alpha=0.5,
+                   linewidth=1.5, color_mean='k', color_std='gray', n_bins=50,
+                   cmap=None):
     ''' Display repetitions of a multichannel waveform.
 
     Parameters
@@ -129,7 +131,6 @@ def plot_waveforms(X, display, *, times=None, **kwargs):
         * 'hist' for the 2D histogram of the repetitions.
     time : None | ndarray, shape (n_times,) (default None)
         Values to display on x-axis.
-
     color : matplotlib color, optional
         Color of the lines, when ``display=all``.
     alpha : float, optional
@@ -174,28 +175,21 @@ def plot_waveforms(X, display, *, times=None, **kwargs):
     channels = np.arange(n_channels)
 
     if display == 'all':
-        color = kwargs.get('color', 'gray')
-        alpha = kwargs.get('alpha', 0.5)
         for (channel, ax) in zip(channels, axes):
             for i_rep in range(n_reps):
                 ax.plot(times, X[i_rep, channel], c=color, alpha=alpha)
 
     elif display in ['mean', 'mean+/-std']:
-        linewidth = kwargs.get('linewidth', 1.5)
-        color_mean = kwargs.get('color_mean', 'k')
         mean = np.mean(X, axis=0)
         for (channel, ax) in zip(channels, axes):
             ax.plot(times, mean[channel], c=color_mean, lw=linewidth)
         if display == 'mean+/-std':
-            color_std = kwargs.get('color_std', 'gray')
             std = np.std(X, axis=0)
             for (channel, ax) in zip(channels, axes):
                 ax.fill_between(times, mean[channel] - std[channel],
                                 mean[channel] + std[channel], color=color_std)
 
     elif display == 'hist':
-        n_bins = kwargs.get('n_bins', 50)
-        cmap = kwargs.get('cmap', plt.cm.Greys)
         times_rep = np.repeat(times[np.newaxis, :], n_reps, axis=0)
         for (channel, ax) in zip(channels, axes):
             ax.hist2d(times_rep.ravel(), X[:, channel, :].ravel(),

--- a/pyriemann/utils/viz.py
+++ b/pyriemann/utils/viz.py
@@ -1,5 +1,4 @@
 """Helpers for vizualization."""
-import numbers
 import pandas as pd
 import numpy as np
 from sklearn.metrics import confusion_matrix

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -45,4 +45,7 @@ def test_plot_waveforms(display):
     """Test plot_waveforms"""
     n_matrices, n_channels, n_times = 16, 3, 50
     X = np.random.randn(n_matrices, n_channels, n_times)
-    plot_waveforms(X, display, chax=0)
+    plot_waveforms(X, display)
+
+    X = np.random.randn(n_matrices, 1, n_times)
+    plot_waveforms(X, display)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -46,6 +46,7 @@ def test_plot_waveforms(display):
     n_matrices, n_channels, n_times = 16, 3, 50
     X = np.random.randn(n_matrices, n_channels, n_times)
     plot_waveforms(X, display)
+    plot_waveforms(X, display, times=np.arange(n_times))
 
     X = np.random.randn(n_matrices, 1, n_times)
     plot_waveforms(X, display)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -6,7 +6,7 @@ from pyriemann.utils.viz import (
     plot_confusion_matrix,
     plot_embedding,
     plot_cospectra,
-    plot_erp,
+    plot_waveforms
 )
 
 
@@ -40,9 +40,9 @@ def test_cospectra():
 
 
 @requires_matplotlib
-@pytest.mark.parametrize("display", ["all", "mean+/-std", "hist"])
-def test_erp(display):
-    """Test plot_erp"""
-    n_matrices, n_channels, n_times = 16, 3, 100
+@pytest.mark.parametrize("display", ["all", "mean", "mean+/-std", "hist"])
+def test_plot_waveforms(display):
+    """Test plot_waveforms"""
+    n_matrices, n_channels, n_times = 16, 3, 50
     X = np.random.randn(n_matrices, n_channels, n_times)
-    plot_erp(X, display=display, chax=0)
+    plot_waveforms(X, display, chax=0)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -6,6 +6,7 @@ from pyriemann.utils.viz import (
     plot_confusion_matrix,
     plot_embedding,
     plot_cospectra,
+    plot_erp,
 )
 
 
@@ -36,3 +37,12 @@ def test_cospectra():
     cosp = np.random.randn(n_freqs, n_channels, n_channels)
     freqs = np.random.randn(n_freqs)
     plot_cospectra(cosp, freqs)
+
+
+@requires_matplotlib
+@pytest.mark.parametrize("display", ["all", "mean+/-std", "hist"])
+def test_erp(display):
+    """Test plot_erp"""
+    n_matrices, n_channels, n_times = 16, 3, 100
+    X = np.random.randn(n_matrices, n_channels, n_times)
+    plot_erp(X, display=display, chax=0)


### PR DESCRIPTION
This PR:
- adds `plot_erp` and complete test;
- add an example on ERP display, especially with 2D histogram.

It also renames the ERP example on embedding, because the script selects MEG channels instead of EEG ones. @plcrodrigues 