### PR TITLE
Add covariances_X

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -150,6 +150,8 @@ Covariance preprocessing
     :toctree: generated/
 
     covariances
+    covariances_EP
+    covariances_X
     cross_spectrum
     cospectrum
     coherence

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -32,6 +32,8 @@ v0.2.8.dev
 
 - Add module ``pyriemann.utils.viz`` in API, add :func:`pyriemann.utils.viz.plot_waveforms`, and add an example on ERP visualization
 
+- Add a special form covariance matrix :func:`pyriemann.utils.covariance.covariances_X`
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -3,7 +3,7 @@
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.manifold import spectral_embedding
-from pyriemann.utils.distance import pairwise_distance
+from .utils.distance import pairwise_distance
 
 
 class Embedding(BaseEstimator):
@@ -65,8 +65,8 @@ class Embedding(BaseEstimator):
 
         Parameters
         ----------
-        X : ndarray, shape (n_trials, n_channels, n_channels)
-            ndarray of SPD matrices.
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            SPD matrices.
 
         Returns
         -------
@@ -91,12 +91,13 @@ class Embedding(BaseEstimator):
 
         Parameters
         ----------
-        X : ndarray, shape (n_trials, n_channels, n_channels)
-            ndarray of SPD matrices.
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            SPD matrices.
 
         Returns
         -------
-        X_new: array-like, shape (n_samples, n_components)
+        X_new: array-like, shape (n_matrices, n_components)
+            Coordinates of embedded matrices.
 
         """
         self.fit(X)

--- a/pyriemann/preprocessing.py
+++ b/pyriemann/preprocessing.py
@@ -104,7 +104,7 @@ class Whitening(BaseEstimator, TransformerMixin):
             dim_red_val = self.dim_red.get(dim_red_key)
 
             eigvals, eigvecs = eigh(Xm, eigvals_only=False)
-            eigvals = eigvals[::-1]         # eigvals in descending order
+            eigvals = eigvals[::-1]       # sort eigvals in descending order
             eigvecs = np.fliplr(eigvecs)  # idem for eigvecs
 
             if dim_red_key == 'n_components':

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -64,7 +64,7 @@ def distance_riemann(A, B):
     r"""Riemannian distance between two covariance matrices A and B.
 
     .. math::
-        d = {\left( \sum_i \log(\lambda_i)^2 \right)}^{-1/2}
+        d = {\left( \sum_i \log(\lambda_i)^2 \right)}^{1/2}
 
     where :math:`\lambda_i` are the joint eigenvalues of A and B
 


### PR DESCRIPTION
This PR:
- adds a special form covariance matrix, embedding input X (for a future _signal geometric mean_);
- renames variable `n_trials` into `n_matrices`;
- completes tests, completes doc, and cleans code.

M. Congedo and A. Barachant, "A special form of SPD covariance matrix for interpretation and visualization of data manipulated with Riemannian geometry", AIP Conference Proceedings 1641, 2015