### PR TITLE
Add masked and NaN means

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -133,6 +133,7 @@ Datasets
     make_gaussian_blobs
     make_outliers
     make_covariances
+    make_masks
     sample_gaussian_spd
     generate_random_spd_matrix 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -193,6 +193,8 @@ Mean
     mean_alm
     mean_harmonic
     mean_kullback_sym
+    maskedmean_riemann
+    nanmean_riemann
 
 Geodesic
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,6 +34,8 @@ v0.2.8.dev
 
 - Add a special form covariance matrix :func:`pyriemann.utils.covariance.covariances_X`
 
+- Add masked and NaN means with Riemannian metric: :func:`pyriemann.utils.mean.maskedmean_riemann` and :func:`pyriemann.utils.mean.nanmean_riemann`
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -72,7 +72,7 @@ C_nanriem = nanmean_riemann(covmats)
 
 # Riemannian mean, after matrix deletion: average non-corrupted matrices
 isnan = np.isnan(np.sum(covmats, axis=(1, 2)))
-covmats_ = np.delete(covmats, np.where(isnan == True), axis=0)
+covmats_ = np.delete(covmats, np.where(isnan), axis=0)
 perc = len(covmats_) / n_matrices * 100
 print("Percentage of non-corrupted matrices: {:.2f} %".format(perc))
 C_mdriem = mean_riemann(covmats_)

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -33,7 +33,7 @@ C_ref = mean_riemann(covmats)
 n_corrup_channels_max = n_channels // 2
 
 all_n_corrup_channels, all_corrup_channels = np.zeros(n_matrices), []
-for i in range(len(covmats)):
+for i in range(n_matrices):
     n_corrupt_channels = rs.randint(n_corrup_channels_max, size=1)
     corrup_channels = rs.randint(n_channels, size=n_corrupt_channels)
     for chan in corrup_channels:

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -1,0 +1,100 @@
+"""
+===============================================================================
+Estimate covariance mean with NaN values
+===============================================================================
+
+Estimate the mean of covariance matrices corrupted by NaN values [1]_.
+"""
+# Author: Quentin Barthélemy, Sylvain Chevallier and Florian Yger
+#
+# License: BSD (3-clause)
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from pyriemann.datasets import make_covariances
+from pyriemann.utils.mean import mean_riemann, nanmean_riemann
+from pyriemann.utils.distance import distance_riemann
+
+
+###############################################################################
+# Generate data
+# -------------
+
+rs = np.random.RandomState(42)
+n_matrices, n_channels = 100, 10
+covmats = make_covariances(n_matrices, n_channels, rs,
+                           evals_mean=100., evals_std=20.)
+
+# Compute true Riemannian mean
+C_ref = mean_riemann(covmats)
+
+# Corrupt data randomly
+n_corrup_channels_max = n_channels // 2
+
+all_n_corrup_channels, all_corrup_channels = np.zeros(n_matrices), []
+for i in range(len(covmats)):
+    n_corrupt_channels = rs.randint(n_corrup_channels_max, size=1)
+    corrup_channels = rs.randint(n_channels, size=n_corrupt_channels)
+    for chan in corrup_channels:
+        covmats[i, chan] = np.nan
+        covmats[i, :, chan] = np.nan
+        all_corrup_channels.append(chan)
+    all_n_corrup_channels[i] = n_corrupt_channels
+
+
+fig, ax = plt.subplots(nrows=1, ncols=1)
+ax.set(title='Histogram of the number of corrupted channels',
+       xlabel='Channel count')
+plt.hist(all_n_corrup_channels, bins=np.arange(n_corrup_channels_max + 1) - .5)
+plt.show()
+
+
+###############################################################################
+
+
+fig, ax = plt.subplots(nrows=1, ncols=1)
+ax.set(title='Histogram of the indices of corrupted channels',
+       xlabel='Channel index')
+plt.hist(all_corrup_channels, bins=np.arange(n_channels + 1) - .5)
+plt.show()
+
+
+###############################################################################
+# Estimate covariance means
+# -------------------------
+
+# Euclidean NaN-mean
+C_naneucl = np.nanmean(covmats, axis=0)
+
+# Riemannian NaN-mean
+C_nanriem = nanmean_riemann(covmats)
+
+# Riemannian mean, after matrix deletion: average non-corrupted matrices
+isnan = np.isnan(np.sum(covmats, axis=(1, 2)))
+covmats_ = np.delete(covmats, np.where(isnan == True), axis=0)
+perc = len(covmats_) / n_matrices * 100
+print("Percentage of non-corrupted matrices: {:.2f} %".format(perc))
+C_mdriem = mean_riemann(covmats_)
+
+
+###############################################################################
+# Compare covariance means
+# ------------------------
+
+d_naneucl = distance_riemann(C_ref, C_naneucl)
+print("Euclidean NaN-mean, dist = {:.3f}".format(d_naneucl))
+
+d_nanriem = distance_riemann(C_ref, C_nanriem)
+print("Riemannian NaN-mean, dist = {:.3f}".format(d_nanriem))
+
+d_mdriem = distance_riemann(C_ref, C_mdriem)
+print("Riemannian mean, after matrix deletion, dist = {:.3f}".format(d_mdriem))
+
+
+###############################################################################
+# References
+# ----------
+# .. [1] F. Yger, S. Chevallier, Q. Barthélemy, S. Sra. "Geodesically-convex
+#    optimization for averaging partially observed covariance matrices", ACML
+#    2021.

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -20,35 +20,47 @@ from pyriemann.utils.distance import distance_riemann
 
 
 ###############################################################################
+
+
+def corrupt(covmats, n_corrup_channels_max, rs):
+    n_matrices, n_channels, _ = covmats.shape
+    all_n_corrup_channels, all_corrup_channels = np.zeros(n_matrices), []
+    for i_matrix in range(n_matrices):
+        n_corrupt_channels = rs.randint(n_corrup_channels_max + 1, size=1)
+        corrup_channels = rs.choice(
+            np.arange(0, n_channels), size=n_corrupt_channels, replace=False)
+        for i_channel in corrup_channels:
+            covmats[i_matrix, i_channel] = np.nan
+            covmats[i_matrix, :, i_channel] = np.nan
+            all_corrup_channels.append(i_channel)
+        all_n_corrup_channels[i_matrix] = n_corrupt_channels
+    return covmats, all_n_corrup_channels, all_corrup_channels
+
+
+###############################################################################
 # Generate data
 # -------------
 
 rs = np.random.RandomState(42)
 n_matrices, n_channels = 100, 10
-covmats = make_covariances(n_matrices, n_channels, rs,
-                           evals_mean=100., evals_std=20.)
+covmats = make_covariances(
+    n_matrices, n_channels, rs, evals_mean=100., evals_std=20.)
 
-# Compute true Riemannian mean
+# Compute the reference, the Riemannian mean on all covariance matrices
 C_ref = mean_riemann(covmats)
 
 # Corrupt data randomly
 n_corrup_channels_max = n_channels // 2
+print("Maximum number of corrupted channels: {} over {}".format(
+    n_corrup_channels_max, n_channels))
 
-all_n_corrup_channels, all_corrup_channels = np.zeros(n_matrices), []
-for i in range(n_matrices):
-    n_corrupt_channels = rs.randint(n_corrup_channels_max, size=1)
-    corrup_channels = rs.randint(n_channels, size=n_corrupt_channels)
-    for chan in corrup_channels:
-        covmats[i, chan] = np.nan
-        covmats[i, :, chan] = np.nan
-        all_corrup_channels.append(chan)
-    all_n_corrup_channels[i] = n_corrupt_channels
-
+covmats, all_n_corrup_channels, all_corrup_channels = corrupt(
+    covmats, n_corrup_channels_max, rs)
 
 fig, ax = plt.subplots(nrows=1, ncols=1)
 ax.set(title='Histogram of the number of corrupted channels',
-       xlabel='Channel count')
-plt.hist(all_n_corrup_channels, bins=np.arange(n_corrup_channels_max + 1) - .5)
+       xlabel='Channel count', ylabel='Occurrences')
+plt.hist(all_n_corrup_channels, bins=np.arange(n_corrup_channels_max + 2) - .5)
 plt.show()
 
 
@@ -57,7 +69,7 @@ plt.show()
 
 fig, ax = plt.subplots(nrows=1, ncols=1)
 ax.set(title='Histogram of the indices of corrupted channels',
-       xlabel='Channel index')
+       xlabel='Channel index', ylabel='Occurrences')
 plt.hist(all_corrup_channels, bins=np.arange(n_channels + 1) - .5)
 plt.show()
 
@@ -65,11 +77,13 @@ plt.show()
 ###############################################################################
 # Estimate covariance means
 # -------------------------
+#
 # Riemannian mean could only be computed on full-rank matrices. A common
 # strategy is called matrix deletion, that is removing all matrices with
-# corrupted channels. This results in discarding useful information
-# as uncorrupted channels are removed from the computation of the mean.
-# Nan-mean use as much information as possible to estimate the mean.
+# corrupted channels before computing mean.
+# This results in discarding useful information as uncorrupted channels are
+# removed from the computation of the mean.
+# Nan-mean uses as much information as possible to estimate the mean [1]_.
 
 # Euclidean NaN-mean
 C_naneucl = np.nanmean(covmats, axis=0)
@@ -77,68 +91,73 @@ C_naneucl = np.nanmean(covmats, axis=0)
 # Riemannian NaN-mean
 C_nanriem = nanmean_riemann(covmats)
 
-# Riemannian mean, after matrix deletion: average non-corrupted matrices
+# Riemannian mean, after matrix deletion: average only uncorrupted matrices
 isnan = np.isnan(np.sum(covmats, axis=(1, 2)))
 covmats_ = np.delete(covmats, np.where(isnan), axis=0)
 perc = len(covmats_) / n_matrices * 100
-print("Percentage of non-corrupted matrices: {:.2f} %".format(perc))
+print("Percentage of uncorrupted matrices: {:.2f} %".format(perc))
 C_mdriem = mean_riemann(covmats_)
 
 
 ###############################################################################
 # Compare covariance means
 # ------------------------
+#
+# Compare distances between the different means and the reference.
 
 d_naneucl = distance_riemann(C_ref, C_naneucl)
-print(f"Euclidean NaN-mean, distance to uncorrupted mean = {d_naneucl:.3f}")
+print(f"Euclidean NaN-mean, distance to ref = {d_naneucl:.3f}")
 
 d_nanriem = distance_riemann(C_ref, C_nanriem)
-print(f"Riemannian NaN-mean, distance to uncorrupted mean = {d_nanriem:.3f}")
+print(f"Riemannian NaN-mean, distance to ref = {d_nanriem:.3f}")
 
 d_mdriem = distance_riemann(C_ref, C_mdriem)
-print(f"Riemannian mean with deletion, distance to mean = {d_mdriem:.3f}")
+print(f"Riemannian mean after deletion, distance to ref = {d_mdriem:.3f}")
+
+# Riemannian NaN-mean gives the best result, and Riemannian mean after matrix
+# deletion is worst than Euclidean NaN-mean.
 
 
 ###############################################################################
-# Plot influence of corrupted channels
-# ------------------------------------
+# Evaluate influence of corrupted channels
+# ----------------------------------------
 #
+# Repeat the previous experiment, varying the maximum number of corrupted
+# channels [1]_.
 
-covmats_orig = make_covariances(n_matrices, n_channels, rs,
-                                evals_mean=100., evals_std=20.)
+covmats_orig = make_covariances(
+    n_matrices, n_channels, rs, evals_mean=100., evals_std=20.)
 C_ref = mean_riemann(covmats_orig)
 
 df = []
-for j, nc in enumerate(range(1,  n_channels // 2 + 1)):
-    n_corrup_channels_max = nc
+for n_corrup_channels_max in range(0, n_channels // 2 + 1):
     covmats = np.copy(covmats_orig)
+    covmats, _, _ = corrupt(covmats, n_corrup_channels_max, rs)
 
-    for i in range(n_matrices):
-        n_corrupt_channels = rs.randint(n_corrup_channels_max, size=1)
-        corrup_channels = rs.randint(n_channels, size=n_corrupt_channels)
-        for chan in corrup_channels:
-            covmats[i, chan] = np.nan
-            covmats[i, :, chan] = np.nan
     C_naneucl = np.nanmean(covmats, axis=0)
     C_nanriem = nanmean_riemann(covmats)
     isnan = np.isnan(np.sum(covmats, axis=(1, 2)))
     covmats_ = np.delete(covmats, np.where(isnan), axis=0)
     C_mdriem = mean_riemann(covmats_)
-    res_ne = {'corrupt': nc,
-              'mean': 'NaN euclidean',
-              'dist': distance_riemann(C_ref, C_naneucl)}
-    res_nr = {'corrupt': nc,
-              'mean': 'NaN Riemannian',
-              'dist': distance_riemann(C_ref, C_nanriem)}
-    res_rm = {'corrupt': nc,
-              'mean': 'Riemannian (with deletion)',
-              'dist': distance_riemann(C_ref, C_mdriem)}
-    df += [res_ne, res_nr, res_rm]
+
+    res_naneucl = {'n_corrupt': n_corrup_channels_max,
+                   'dist': distance_riemann(C_ref, C_naneucl),
+                   'Means': 'Euclidean NaN-mean'}
+    res_nanriem = {'n_corrupt': n_corrup_channels_max,
+                   'dist': distance_riemann(C_ref, C_nanriem),
+                   'Means': 'Riemannian NaN-mean'}
+    res_mdriem = {'n_corrupt': n_corrup_channels_max,
+                  'dist': distance_riemann(C_ref, C_mdriem),
+                  'Means': 'Riemannian mean after deletion'}
+    df += [res_naneucl, res_nanriem, res_mdriem]
 df = pd.DataFrame(df)
 
-g = sns.catplot(data=df, x="corrupt", y="dist", hue="mean", kind="point")
-g.set_axis_labels("Number of corrupted channels", "Distance to reference")
-g.set_titles("Influence of corrupted channels")
+g = sns.catplot(data=df, x="n_corrupt", y="dist", hue="Means", kind="point",
+                legend_out=False)
+g.set(title="Influence of corrupted channels")
+g.set_axis_labels("Maximum number of corrupted channels",
+                  "Distance to reference")
+plt.tight_layout()
 plt.show()
 
 

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -63,6 +63,11 @@ plt.show()
 ###############################################################################
 # Estimate covariance means
 # -------------------------
+# Riemannian mean could only be computed on full-rank matrices. A common
+# strategy is called matrix deletion, that is removing all matrices with
+# corrupted channels. This results in discarding useful information
+# as uncorrupted channels are removed from the computation of the mean.
+# Nan-mean use as much information as possible to estimate the mean.
 
 # Euclidean NaN-mean
 C_naneucl = np.nanmean(covmats, axis=0)
@@ -83,13 +88,13 @@ C_mdriem = mean_riemann(covmats_)
 # ------------------------
 
 d_naneucl = distance_riemann(C_ref, C_naneucl)
-print("Euclidean NaN-mean, dist = {:.3f}".format(d_naneucl))
+print("Euclidean NaN-mean, distance to uncorrupted mean = {:.3f}".format(d_naneucl))
 
 d_nanriem = distance_riemann(C_ref, C_nanriem)
-print("Riemannian NaN-mean, dist = {:.3f}".format(d_nanriem))
+print("Riemannian NaN-mean, distance to uncorrupted mean = {:.3f}".format(d_nanriem))
 
 d_mdriem = distance_riemann(C_ref, C_mdriem)
-print("Riemannian mean, after matrix deletion, dist = {:.3f}".format(d_mdriem))
+print("Riemannian mean, after matrix deletion, distance to uncorrupted mean = {:.3f}".format(d_mdriem))
 
 
 ###############################################################################

--- a/examples/signal/plot_nanmean.py
+++ b/examples/signal/plot_nanmean.py
@@ -88,13 +88,13 @@ C_mdriem = mean_riemann(covmats_)
 # ------------------------
 
 d_naneucl = distance_riemann(C_ref, C_naneucl)
-print("Euclidean NaN-mean, distance to uncorrupted mean = {:.3f}".format(d_naneucl))
+print(f"Euclidean NaN-mean, distance to uncorrupted mean = {d_naneucl:.3f}")
 
 d_nanriem = distance_riemann(C_ref, C_nanriem)
-print("Riemannian NaN-mean, distance to uncorrupted mean = {:.3f}".format(d_nanriem))
+print(f"Riemannian NaN-mean, distance to uncorrupted mean = {d_nanriem:.3f}")
 
 d_mdriem = distance_riemann(C_ref, C_mdriem)
-print("Riemannian mean, after matrix deletion, distance to uncorrupted mean = {:.3f}".format(d_mdriem))
+print(f"Riemannian mean with deletion, distance to mean = {d_mdriem:.3f}")
 
 
 ###############################################################################

--- a/pyriemann/__init__.py
+++ b/pyriemann/__init__.py
@@ -8,6 +8,7 @@ from . import clustering
 from . import stats
 from . import embedding
 from . import preprocessing
+from . import datasets
 
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     'stats',
     'embedding',
     'preprocessing',
+    'datasets',
 ]

--- a/pyriemann/datasets/__init__.py
+++ b/pyriemann/datasets/__init__.py
@@ -1,9 +1,11 @@
 from .sampling import sample_gaussian_spd, generate_random_spd_matrix
-from .simulated import make_covariances, make_gaussian_blobs, make_outliers
+from .simulated import (make_covariances, make_masks, make_gaussian_blobs,
+                        make_outliers)
 
 
 __all__ = ["sample_gaussian_spd",
            "generate_random_spd_matrix",
            "make_covariances",
+           "make_masks",
            "make_gaussian_blobs",
            "make_outliers"]

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -49,11 +49,30 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False,
         return covmats
 
 
-def make_masks(n_matrices, n_channels, n_channels_red, rs):
+def make_masks(n_masks, n_dim0, n_dim1_min, rs):
+    """Generate a set of masks, defined as semi-orthogonal matrices.
+
+    Parameters
+    ----------
+    n_masks : int
+        Number of masks to generate.
+    n_dim0 : int
+        First dimension of masks.
+    n_dim1_min : int
+        Minimal value for second dimension of masks.
+    rs : RandomState instance
+        Random state for reproducible output across multiple function calls.
+
+    Returns
+    -------
+    masks : list of n_masks ndarray of shape (n_dim0, n_dim1_i), \
+            with different n_dim1_i, such that n_dim1_min <= n_dim1_i <= n_dim0
+        Masks.
+    """
     masks = []
-    for i in range(n_matrices):
-        n_channels_2 = rs.randint(n_channels_red, n_channels, size=1)[0]
-        mask, _ = np.linalg.qr(rs.randn(n_channels, n_channels_2))
+    for i in range(n_masks):
+        n_dim1 = rs.randint(n_dim1_min, n_dim0, size=1)[0]
+        mask, _ = np.linalg.qr(rs.randn(n_dim0, n_dim1))
         masks.append(mask)
     return masks
 

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -6,7 +6,8 @@ from ..utils.base import powm, sqrtm
 from .sampling import generate_random_spd_matrix, sample_gaussian_spd
 
 
-def make_covariances(n_matrices, n_channels, rs, return_params=False):
+def make_covariances(n_matrices, n_channels, rs, return_params=False,
+                     evals_mean=2.0, evals_std=0.1):
     """Generate a set of covariances matrices, with the same eigenvectors.
 
     Parameters
@@ -19,6 +20,10 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False):
         Random state for reproducible output across multiple function calls.
     return_params : bool (default False)
         If True, then return parameters.
+    evals_mean : float (default 2.0)
+        Mean of eigen values.
+    evals_std : float (default 0.1)
+        Standard deviation of eigen values.
 
     Returns
     -------
@@ -31,7 +36,7 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False):
         Eigen vectors used for all covariance matrices.
         Only returned if ``return_params=True``.
     """
-    evals = 2.0 + 0.1 * rs.randn(n_matrices, n_channels)
+    evals = np.abs(evals_mean + evals_std * rs.randn(n_matrices, n_channels))
     evecs = 2 * rs.rand(n_channels, n_channels) - 1
     evecs /= np.linalg.norm(evecs, axis=1)[:, np.newaxis]
 

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -37,8 +37,7 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False,
         Only returned if ``return_params=True``.
     """
     evals = np.abs(evals_mean + evals_std * rs.randn(n_matrices, n_channels))
-    evecs, _ = np.linalg.qr(rs.rand(n_channels, n_channels))
-    evecs /= np.linalg.norm(evecs, axis=1)[:, np.newaxis]
+    evecs, _ = np.linalg.qr(rs.randn(n_channels, n_channels))
 
     covmats = np.empty((n_matrices, n_channels, n_channels))
     for i in range(n_matrices):
@@ -48,6 +47,15 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False,
         return covmats, evals, evecs
     else:
         return covmats
+
+
+def make_masks(n_matrices, n_channels, n_channels_red, rs):
+    masks = []
+    for i in range(n_matrices):
+        n_channels_2 = rs.randint(n_channels_red, n_channels, size=1)[0]
+        mask, _ = np.linalg.qr(rs.randn(n_channels, n_channels_2))
+        masks.append(mask)
+    return masks
 
 
 def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -37,7 +37,7 @@ def make_covariances(n_matrices, n_channels, rs, return_params=False,
         Only returned if ``return_params=True``.
     """
     evals = np.abs(evals_mean + evals_std * rs.randn(n_matrices, n_channels))
-    evecs = 2 * rs.rand(n_channels, n_channels) - 1
+    evecs, _ = np.linalg.qr(rs.rand(n_channels, n_channels))
     evecs /= np.linalg.norm(evecs, axis=1)[:, np.newaxis]
 
     covmats = np.empty((n_matrices, n_channels, n_channels))

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -518,7 +518,7 @@ def maskedmean_riemann(covmats, masks, tol=10e-9, maxiter=50, init=None,
     covmats : ndarray, shape (n_matrices, n_channels, n_channels)
         Covariance matrices.
     masks : list of n_matrices ndarray of shape (n_channels, n_channels_i), \
-            with different n_channels_i <= n_channels
+            with different n_channels_i, such that n_channels_i <= n_channels
         Masks, defined as semi-orthogonal matrices. See [1]_.
     tol : float (default 10e-9)
         The tolerance to stop the gradient descent.

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -31,7 +31,7 @@ def mean_riemann(covmats, tol=10e-9, maxiter=50, init=None,
     .. math::
         \mathbf{C} = \arg\min{(\sum_i \delta_R ( \mathbf{C} , \mathbf{C}_i)^2)}
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the gradient descent. If None the Arithmetic mean is used
@@ -81,7 +81,7 @@ def mean_logeuclid(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \exp{(\frac{1}{N} \sum_i \log{\mathbf{C}_i})}
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
@@ -103,7 +103,7 @@ def mean_kullback_sym(covmats, sample_weight=None):
     This mean is the geometric mean between the Arithmetic and the Harmonic
     mean, as shown in [1]_.
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
@@ -128,7 +128,7 @@ def mean_harmonic(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \left(\frac{1}{N} \sum_i {\mathbf{C}_i}^{-1}\right)^{-1}
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
@@ -152,7 +152,7 @@ def mean_logdet(covmats, tol=10e-5, maxiter=50, init=None, sample_weight=None):
     .. math::
         \mathbf{C} = \left(\sum_i \left( 0.5 \mathbf{C} + 0.5 \mathbf{C}_i \right)^{-1} \right)^{-1}
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the iterative procedure. If None the Arithmetic mean is used
@@ -196,7 +196,7 @@ def mean_wasserstein(covmats, tol=10e-4, maxiter=50, init=None,
 
     with :math:`\mathbf{K} = \mathbf{C}^{1/2}`.
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the iterative procedure. If None the Arithmetic mean is used
@@ -244,7 +244,7 @@ def mean_euclid(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \frac{1}{N} \sum_i \mathbf{C}_i
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
@@ -257,7 +257,7 @@ def mean_ale(covmats, tol=10e-7, maxiter=50, sample_weight=None):
     """Return the mean covariance matrix according using the AJD-based
     log-Euclidean Mean (ALE). See [1].
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param sample_weight: the weight of each matrix
@@ -321,7 +321,7 @@ def mean_alm(covmats, tol=1e-14, maxiter=100,
     Bruno Iannazzo, http://bezout.dm.unipi.it/software/mmtoolbox/
     Extremely slow, due to the recursive formulation.
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop iterations
     :param maxiter: maximum number of iteration, default 100
     :param verbose: indicate when reaching maxiter
@@ -369,7 +369,7 @@ def mean_identity(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \mathbf{I}_d
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :returns: the identity matrix of size n_channels
 
     """
@@ -380,7 +380,7 @@ def mean_identity(covmats, sample_weight=None):
 def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
     """Return the mean covariance matrix according to the metric
 
-    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
     :param metric: the metric (default 'riemann'), can be : 'riemann',
         'logeuclid', 'euclid', 'logdet', 'identity', 'wasserstein', 'ale',
         'alm', 'harmonic', 'kullback_sym' or a callable function
@@ -428,7 +428,7 @@ def _get_mask_from_nan(covmat):
     nan_row = np.all(np.isnan(covmat), axis=1)
     if not np.array_equal(nan_col, nan_row):
         raise ValueError('Nan values are not symmetric.')
-    nan_inds = np.where(nan_col == True)
+    nan_inds = np.where(nan_col)
     subcovmat_ = np.delete(covmat, nan_inds, axis=0)
     subcovmat = np.delete(subcovmat_, nan_inds, axis=1)
     if np.any(np.isnan(subcovmat)):

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -26,26 +26,27 @@ def mean_riemann(covmats, tol=10e-9, maxiter=50, init=None,
     r"""Return the mean covariance matrix according to the Riemannian metric.
 
     The procedure is similar to a gradient descent minimizing the sum of
-    riemannian distance to the mean.
+    Riemannian distances to the mean.
 
     .. math::
         \mathbf{C} = \arg\min{(\sum_i \delta_R ( \mathbf{C} , \mathbf{C}_i)^2)}
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the gradient descent. If None the Arithmetic mean is used
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
     :returns: the mean covariance matrix
 
     """  # noqa
     # init
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     if init is None:
         C = np.mean(covmats, axis=0)
     else:
         C = init
+
     k = 0
     nu = 1.0
     tau = np.finfo(np.float64).max
@@ -57,8 +58,8 @@ def mean_riemann(covmats, tol=10e-9, maxiter=50, init=None,
         Cm12 = invsqrtm(C)
         J = np.zeros((n_channels, n_channels))
 
-        for index in range(n_trials):
-            tmp = np.dot(np.dot(Cm12, covmats[index, :, :]), Cm12)
+        for index in range(n_matrices):
+            tmp = np.dot(np.dot(Cm12, covmats[index]), Cm12)
             J += sample_weight[index] * logm(tmp)
 
         crit = np.linalg.norm(J, ord='fro')
@@ -80,17 +81,17 @@ def mean_logeuclid(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \exp{(\frac{1}{N} \sum_i \log{\mathbf{C}_i})}
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
-    :param sample_weight: the weight of each sample
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
     """
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     T = np.zeros((n_channels, n_channels))
-    for index in range(n_trials):
-        T += sample_weight[index] * logm(covmats[index, :, :])
+    for index in range(n_matrices):
+        T += sample_weight[index] * logm(covmats[index])
     C = expm(T)
 
     return C
@@ -102,8 +103,8 @@ def mean_kullback_sym(covmats, sample_weight=None):
     This mean is the geometric mean between the Arithmetic and the Harmonic
     mean, as shown in [1]_.
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
-    :param sample_weight: the weight of each sample
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
@@ -127,17 +128,17 @@ def mean_harmonic(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \left(\frac{1}{N} \sum_i {\mathbf{C}_i}^{-1}\right)^{-1}
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
-    :param sample_weight: the weight of each sample
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
     """
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     T = np.zeros((n_channels, n_channels))
-    for index in range(n_trials):
-        T += sample_weight[index] * np.linalg.inv(covmats[index, :, :])
+    for index in range(n_matrices):
+        T += sample_weight[index] * np.linalg.inv(covmats[index])
     C = np.linalg.inv(T)
 
     return C
@@ -151,17 +152,17 @@ def mean_logdet(covmats, tol=10e-5, maxiter=50, init=None, sample_weight=None):
     .. math::
         \mathbf{C} = \left(\sum_i \left( 0.5 \mathbf{C} + 0.5 \mathbf{C}_i \right)^{-1} \right)^{-1}
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the iterative procedure. If None the Arithmetic mean is used
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
     """  # noqa
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     if init is None:
         C = np.mean(covmats, axis=0)
     else:
@@ -195,11 +196,11 @@ def mean_wasserstein(covmats, tol=10e-4, maxiter=50, init=None,
 
     with :math:`\mathbf{K} = \mathbf{C}^{1/2}`.
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
     :param init: A covariance matrix used to initialize the iterative procedure. If None the Arithmetic mean is used
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
@@ -210,7 +211,7 @@ def mean_wasserstein(covmats, tol=10e-4, maxiter=50, init=None,
         (IRS), 2011 Proceedings International.
     """  # noqa
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     if init is None:
         C = np.mean(covmats, axis=0)
     else:
@@ -243,8 +244,8 @@ def mean_euclid(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \frac{1}{N} \sum_i \mathbf{C}_i
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
-    :param sample_weight: the weight of each sample
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
@@ -256,10 +257,10 @@ def mean_ale(covmats, tol=10e-7, maxiter=50, sample_weight=None):
     """Return the mean covariance matrix according using the AJD-based
     log-Euclidean Mean (ALE). See [1].
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop the gradient descent
     :param maxiter: The maximum number of iteration, default 50
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
@@ -275,7 +276,7 @@ def mean_ale(covmats, tol=10e-7, maxiter=50, sample_weight=None):
 
     """
     sample_weight = _get_sample_weight(sample_weight, covmats)
-    n_trials, n_channels, _ = covmats.shape
+    n_matrices, n_channels, _ = covmats.shape
     crit = np.inf
     k = 0
 
@@ -320,11 +321,11 @@ def mean_alm(covmats, tol=1e-14, maxiter=100,
     Bruno Iannazzo, http://bezout.dm.unipi.it/software/mmtoolbox/
     Extremely slow, due to the recursive formulation.
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param tol: the tolerance to stop iterations
     :param maxiter: maximum number of iteration, default 100
     :param verbose: indicate when reaching maxiter
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
 
     :returns: the mean covariance matrix
 
@@ -340,15 +341,15 @@ def mean_alm(covmats, tol=1e-14, maxiter=100,
     sample_weight = _get_sample_weight(sample_weight, covmats)
     C = covmats
     C_iter = np.zeros_like(C)
-    n_trials = covmats.shape[0]
-    if n_trials == 2:
+    n_matrices = covmats.shape[0]
+    if n_matrices == 2:
         alpha = sample_weight[1] / sample_weight[0] / 2
         X = geodesic_riemann(covmats[0], covmats[1], alpha=alpha)
         return X
     else:
         for k in range(maxiter):
-            for h in range(n_trials):
-                s = np.mod(np.arange(h, h + n_trials - 1) + 1, n_trials)
+            for h in range(n_matrices):
+                s = np.mod(np.arange(h, h + n_matrices - 1) + 1, n_matrices)
                 C_iter[h] = mean_alm(C[s], sample_weight=sample_weight[s])
 
             norm_iter = np.linalg.norm(C_iter[0] - C[0], 2)
@@ -368,7 +369,7 @@ def mean_identity(covmats, sample_weight=None):
     .. math::
         \mathbf{C} = \mathbf{I}_d
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :returns: the identity matrix of size n_channels
 
     """
@@ -379,13 +380,13 @@ def mean_identity(covmats, sample_weight=None):
 def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
     """Return the mean covariance matrix according to the metric
 
-    :param covmats: Covariance matrices set, (n_trials, n_channels, n_channels)
+    :param covmats: Covariance matrices set, (n_matrices, n_channels, n_channels)
     :param metric: the metric (default 'riemann'), can be : 'riemann',
         'logeuclid', 'euclid', 'logdet', 'identity', 'wasserstein', 'ale',
         'alm', 'harmonic', 'kullback_sym' or a callable function
-    :param sample_weight: the weight of each sample
+    :param sample_weight: the weight of each matrix
     :param args: the argument passed to the sub function
-    :returns: the mean covariance matrix
+    :returns: the mean covariance matrix, (n_channels, n_channels)
 
     """
     if callable(metric):
@@ -417,3 +418,152 @@ def _check_mean_method(method):
     elif not hasattr(method, '__call__'):
         raise ValueError('mean method must be a function or a string.')
     return method
+
+
+###############################################################################
+
+
+def _get_mask_from_nan(covmat):
+    nan_col = np.all(np.isnan(covmat), axis=0)
+    nan_row = np.all(np.isnan(covmat), axis=1)
+    if not np.array_equal(nan_col, nan_row):
+        raise ValueError('Nan values are not symmetric.')
+    nan_inds = np.where(nan_col == True)
+    subcovmat_ = np.delete(covmat, nan_inds, axis=0)
+    subcovmat = np.delete(subcovmat_, nan_inds, axis=1)
+    if np.any(np.isnan(subcovmat)):
+        raise ValueError('Nan values must fill rows and columns.')
+    mask = np.delete(np.eye(covmat.shape[0]), nan_inds, axis=1)
+    return mask
+
+
+def _get_masks_from_nan(covmats):
+    masks = []
+    for i in range(len(covmats)):
+        masks.append(_get_mask_from_nan(covmats[i]))
+    return masks
+
+
+def _apply_masks(covmats, masks):
+    maskedcovmats = []
+    for i in range(len(covmats)):
+        maskedcovmats.append(masks[i].T @ covmats[i] @ masks[i])
+    return maskedcovmats
+
+
+def nanmean_riemann(covmats, tol=10e-9, maxiter=50, init=None,
+                    sample_weight=None):
+    """Return the Riemannian NaN-mean of covariance matrices.
+
+    The Riemannian NaN-mean is the masked Riemannian mean applied to covariance
+    matrices corrupted by symmetric NaN values [1]_.
+
+    Parameters
+    ----------
+    covmats : ndarray, shape (n_matrices, n_channels, n_channels)
+        Covariance matrices, potentially corrupted by symmetric NaN values [1]_
+    tol : float (default 10e-9)
+        The tolerance to stop the gradient descent.
+    maxiter : int (default 50)
+        The maximum number of iteration.
+    init : None | ndarray, shape (n_channels, n_channels) (default None)
+        A covariance matrix used to initialize the gradient descent.
+        If None the Identity is used.
+    sample_weight : None | ndarray, shape (n_matrices) (default None)
+        The weight of each matrix.
+
+    Returns
+    -------
+    C : ndarray, shape (n_channels, n_channels)
+        Riemannian NaN-mean.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.8
+
+    References
+    ----------
+    .. [1] F. Yger, S. Chevallier, Q. Barthélemy, S. Sra. "Geodesically-convex
+        optimization for averaging partially observed covariance matrices",
+        ACML 2021.
+    """
+    masks = _get_masks_from_nan(covmats)
+    covmats = np.nan_to_num(covmats)  # avoid nan contamination in matmul
+    C = maskedmean_riemann(covmats, masks, tol=tol, maxiter=maxiter, init=init,
+                           sample_weight=sample_weight)
+    return C
+
+
+def maskedmean_riemann(covmats, masks, tol=10e-9, maxiter=50, init=None,
+                       sample_weight=None):
+    """Return the masked Riemannian mean of covariance matrices.
+
+    Given masks defined as semi-orthogonal matrices, the masked Riemannian mean
+    of covariance matrices is obtained with a gradient descent minimizing the
+    sum of Riemannian distances between masked covariance matrices and the
+    masked mean [1]_.
+
+    Parameters
+    ----------
+    covmats : ndarray, shape (n_matrices, n_channels, n_channels)
+        Covariance matrices.
+    masks : list of n_matrices ndarray of shape (n_channels, n_channels_i), \
+            with different n_channels_i <= n_channels
+        Masks, defined as semi-orthogonal matrices. See [1]_.
+    tol : float (default 10e-9)
+        The tolerance to stop the gradient descent.
+    maxiter : int (default 50)
+        The maximum number of iteration.
+    init : None | ndarray, shape (n_channels, n_channels) (default None)
+        A covariance matrix used to initialize the gradient descent.
+        If None, the Identity is used.
+    sample_weight : None | ndarray, shape (n_matrices) (default None)
+        The weight of each matrix.
+
+    Returns
+    -------
+    C : ndarray, shape (n_channels, n_channels)
+        Masked Riemannian mean.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.8
+
+    References
+    ----------
+    .. [1] F. Yger, S. Chevallier, Q. Barthélemy, S. Sra. "Geodesically-convex
+        optimization for averaging partially observed covariance matrices",
+        ACML 2021.
+    """
+    sample_weight = _get_sample_weight(sample_weight, covmats)
+    maskedcovmats = _apply_masks(covmats, masks)
+    n_matrices, n_channels, _ = covmats.shape
+    if init is None:
+        C = np.mean(covmats, axis=0)
+    else:
+        C = init
+
+    k = 0
+    nu = 1.0
+    tau = np.finfo(np.float64).max
+    crit = np.finfo(np.float64).max
+    while (crit > tol) and (k < maxiter) and (nu > tol):
+        k = k + 1
+        maskedC = _apply_masks(np.tile(C, (n_matrices, 1, 1)), masks)
+        J = np.zeros((n_channels, n_channels))
+        for i in range(n_matrices):
+            C12, Cm12 = sqrtm(maskedC[i]), invsqrtm(maskedC[i])
+            tmp = C12 @ logm(Cm12 @ maskedcovmats[i] @ Cm12) @ C12
+            J += sample_weight[i] * masks[i] @ tmp @ masks[i].T
+        C12, Cm12 = sqrtm(C), invsqrtm(C)
+        C = C12 @ expm(Cm12 @ (nu * J) @ Cm12) @ C12
+
+        crit = np.linalg.norm(J, ord='fro')
+        h = nu * crit
+        if h < tau:
+            nu = 0.95 * nu
+            tau = h
+        else:
+            nu = 0.5 * nu
+
+    return C

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -427,12 +427,12 @@ def _get_mask_from_nan(covmat):
     nan_col = np.all(np.isnan(covmat), axis=0)
     nan_row = np.all(np.isnan(covmat), axis=1)
     if not np.array_equal(nan_col, nan_row):
-        raise ValueError('Nan values are not symmetric.')
+        raise ValueError('NaN values are not symmetric.')
     nan_inds = np.where(nan_col)
     subcovmat_ = np.delete(covmat, nan_inds, axis=0)
     subcovmat = np.delete(subcovmat_, nan_inds, axis=1)
     if np.any(np.isnan(subcovmat)):
-        raise ValueError('Nan values must fill rows and columns.')
+        raise ValueError('NaN values must fill rows and columns.')
     mask = np.delete(np.eye(covmat.shape[0]), nan_inds, axis=1)
     return mask
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from functools import partial
 
-from pyriemann.datasets import make_covariances
+from pyriemann.datasets import make_covariances, make_masks
 
 
 def requires_module(function, name, call=None):
@@ -52,6 +52,14 @@ def get_labels():
         return np.arange(n_classes).repeat(n_trials // n_classes)
 
     return _get_labels
+
+
+@pytest.fixture
+def get_masks(rndstate):
+    def _gen_masks(n_matrices, n_channels):
+        return make_masks(n_matrices, n_channels, n_channels // 2, rndstate)
+
+    return _gen_masks
 
 
 def get_distances():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ def rndstate():
 
 @pytest.fixture
 def get_covmats(rndstate):
-    def _gen_cov(n_trials, n_chan):
-        return make_covariances(n_trials, n_chan, rndstate,
+    def _gen_cov(n_matrices, n_channels):
+        return make_covariances(n_matrices, n_channels, rndstate,
                                 return_params=False)
 
     return _gen_cov
@@ -40,16 +40,17 @@ def get_covmats(rndstate):
 
 @pytest.fixture
 def get_covmats_params(rndstate):
-    def _gen_cov_params(n_trials, n_chan):
-        return make_covariances(n_trials, n_chan, rndstate, return_params=True)
+    def _gen_cov_params(n_matrices, n_channels):
+        return make_covariances(n_matrices, n_channels, rndstate,
+                                return_params=True)
 
     return _gen_cov_params
 
 
 @pytest.fixture
 def get_labels():
-    def _get_labels(n_trials, n_classes):
-        return np.arange(n_classes).repeat(n_trials // n_classes)
+    def _get_labels(n_matrices, n_classes):
+        return np.arange(n_classes).repeat(n_matrices // n_classes)
 
     return _get_labels
 

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -109,7 +109,7 @@ def test_alm_mean_2matrices(get_covmats):
 @pytest.mark.parametrize("init", [True, False])
 def test_riemann_mean_masked_shape(init, get_covmats, get_masks):
     """Test the masked riemann mean"""
-    n_matrices, n_channels = 10, 6
+    n_matrices, n_channels = 10, 4
     covmats = get_covmats(n_matrices, n_channels)
     masks = get_masks(n_matrices, n_channels)
     if init:
@@ -122,7 +122,7 @@ def test_riemann_mean_masked_shape(init, get_covmats, get_masks):
 @pytest.mark.parametrize("init", [True, False])
 def test_riemann_mean_nan_shape(init, get_covmats):
     """Test the riemann nan mean"""
-    n_matrices, n_channels = 10, 6
+    n_matrices, n_channels = 50, 4
     covmats = get_covmats(n_matrices, n_channels)
     emean = np.mean(covmats, axis=0)
     for i in range(n_matrices):

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -13,6 +13,8 @@ from pyriemann.utils.mean import (
     mean_harmonic,
     mean_wasserstein,
     mean_alm,
+    maskedmean_riemann,
+    nanmean_riemann,
 )
 from pyriemann.utils.geodesic import geodesic_riemann
 
@@ -29,12 +31,13 @@ from pyriemann.utils.geodesic import geodesic_riemann
         mean_kullback_sym,
         mean_harmonic,
         mean_wasserstein,
+        nanmean_riemann,
     ],
 )
 def test_mean_shape(mean, get_covmats):
     """Test the shape of mean"""
-    n_trials, n_channels = 5, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 5, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean(covmats)
     assert C.shape == (n_channels, n_channels)
 
@@ -42,8 +45,8 @@ def test_mean_shape(mean, get_covmats):
 @pytest.mark.parametrize("mean", [mean_riemann, mean_logdet])
 def test_mean_shape_with_init(mean, get_covmats):
     """Test the shape of mean with init"""
-    n_trials, n_channels = 5, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 5, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean(covmats, init=covmats[0])
     assert C.shape == (n_channels, n_channels)
 
@@ -51,8 +54,8 @@ def test_mean_shape_with_init(mean, get_covmats):
 @pytest.mark.parametrize("init", [True, False])
 def test_riemann_mean(init, get_covmats_params):
     """Test the riemannian mean"""
-    n_trials, n_channels = 100, 3
-    covmats, diags, A = get_covmats_params(n_trials, n_channels)
+    n_matrices, n_channels = 100, 3
+    covmats, diags, A = get_covmats_params(n_matrices, n_channels)
     if init:
         C = mean_riemann(covmats, init=covmats[0])
     else:
@@ -64,24 +67,24 @@ def test_riemann_mean(init, get_covmats_params):
 
 def test_euclid_mean(get_covmats):
     """Test the euclidean mean"""
-    n_trials, n_channels = 100, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 100, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean_euclid(covmats)
     assert C == approx(covmats.mean(axis=0))
 
 
 def test_identity_mean(get_covmats):
     """Test the identity mean"""
-    n_trials, n_channels = 100, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 100, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean_identity(covmats)
     assert np.all(C == np.eye(n_channels))
 
 
 def test_alm_mean(get_covmats):
     """Test the ALM mean"""
-    n_trials, n_channels = 3, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 3, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C_alm = mean_alm(covmats)
     C_riem = mean_riemann(covmats)
     assert C_alm == approx(C_riem)
@@ -89,18 +92,49 @@ def test_alm_mean(get_covmats):
 
 def test_alm_mean_maxiter(get_covmats):
     """Test the ALM mean with max iteration"""
-    n_trials, n_channels = 3, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 3, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean_alm(covmats, maxiter=1)
     assert C.shape == (n_channels, n_channels)
 
 
-def test_alm_mean_2trials(get_covmats):
-    """Test the ALM mean with 2 trials"""
-    n_trials, n_channels = 2, 3
-    covmats = get_covmats(n_trials, n_channels)
+def test_alm_mean_2matrices(get_covmats):
+    """Test the ALM mean with 2 matrices"""
+    n_matrices, n_channels = 2, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean_alm(covmats)
     assert np.all(C == geodesic_riemann(covmats[0], covmats[1], alpha=0.5))
+
+
+#@pytest.mark.parametrize("init", [True, False])
+#def test_riemann_mean_masked_shape(init, get_covmats):
+#    """Test the masked riemann mean"""
+#    n_matrices, n_channels = 10, 3
+#    covmats = get_covmats(n_matrices, n_channels)
+#    #TODO: masks = get_masks(n_matrices, n_channels)
+#    if init:
+#        C = maskedmean_riemann(covmats, masks, init=covmats[0])
+#    else:
+#        C = maskedmean_riemann(covmats, masks)
+#    assert C.shape == (n_channels, n_channels)
+
+
+@pytest.mark.parametrize("init", [True, False])
+def test_riemann_mean_nan_shape(init, get_covmats):
+    """Test the riemann nan mean"""
+    n_matrices, n_channels = 10, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    emean = np.mean(covmats, axis=0)
+    for i in range(len(covmats)):
+        corrup_channels = np.random.randint(n_channels, size=n_channels // 2)
+        for chan in corrup_channels:
+            covmats[i, chan] = np.nan
+            covmats[i, :, chan] = np.nan
+    if init:
+        C = nanmean_riemann(covmats, init=emean)
+    else:
+        C = nanmean_riemann(covmats)
+    assert C.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize(
@@ -120,8 +154,8 @@ def test_alm_mean_2trials(get_covmats):
 )
 def test_mean_covariance_metric(metric, mean, get_covmats):
     """Test mean_covariance for metric"""
-    n_trials, n_channels = 3, 3
-    covmats = get_covmats(n_trials, n_channels)
+    n_matrices, n_channels = 3, 3
+    covmats = get_covmats(n_matrices, n_channels)
     C = mean_covariance(covmats, metric=metric)
     Ctrue = mean(covmats)
     assert np.all(C == Ctrue)

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -106,17 +106,17 @@ def test_alm_mean_2matrices(get_covmats):
     assert np.all(C == geodesic_riemann(covmats[0], covmats[1], alpha=0.5))
 
 
-#@pytest.mark.parametrize("init", [True, False])
-#def test_riemann_mean_masked_shape(init, get_covmats):
-#    """Test the masked riemann mean"""
-#    n_matrices, n_channels = 10, 3
-#    covmats = get_covmats(n_matrices, n_channels)
-#    #TODO: masks = get_masks(n_matrices, n_channels)
-#    if init:
-#        C = maskedmean_riemann(covmats, masks, init=covmats[0])
-#    else:
-#        C = maskedmean_riemann(covmats, masks)
-#    assert C.shape == (n_channels, n_channels)
+@pytest.mark.parametrize("init", [True, False])
+def test_riemann_mean_masked_shape(init, get_covmats, get_masks):
+    """Test the masked riemann mean"""
+    n_matrices, n_channels = 10, 6
+    covmats = get_covmats(n_matrices, n_channels)
+    masks = get_masks(n_matrices, n_channels)
+    if init:
+        C = maskedmean_riemann(covmats, masks, init=covmats[0])
+    else:
+        C = maskedmean_riemann(covmats, masks)
+    assert C.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("init", [True, False])

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -122,10 +122,10 @@ def test_riemann_mean_masked_shape(init, get_covmats, get_masks):
 @pytest.mark.parametrize("init", [True, False])
 def test_riemann_mean_nan_shape(init, get_covmats):
     """Test the riemann nan mean"""
-    n_matrices, n_channels = 10, 3
+    n_matrices, n_channels = 10, 6
     covmats = get_covmats(n_matrices, n_channels)
     emean = np.mean(covmats, axis=0)
-    for i in range(len(covmats)):
+    for i in range(n_matrices):
         corrup_channels = np.random.randint(n_channels, size=n_channels // 2)
         for chan in corrup_channels:
             covmats[i, chan] = np.nan

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -120,13 +120,13 @@ def test_riemann_mean_masked_shape(init, get_covmats, get_masks):
 
 
 @pytest.mark.parametrize("init", [True, False])
-def test_riemann_mean_nan_shape(init, get_covmats):
+def test_riemann_mean_nan_shape(init, get_covmats, rndstate):
     """Test the riemann nan mean"""
     n_matrices, n_channels = 50, 4
     covmats = get_covmats(n_matrices, n_channels)
     emean = np.mean(covmats, axis=0)
     for i in range(n_matrices):
-        corrup_channels = np.random.randint(n_channels, size=n_channels // 2)
+        corrup_channels = rndstate.randint(n_channels, size=n_channels // 2)
         for chan in corrup_channels:
             covmats[i, chan] = np.nan
             covmats[i, :, chan] = np.nan


### PR DESCRIPTION
This PR aims to:
- add the masked Riemannian mean, for semi-orthogonal masks;
- add the Riemannian NaN-mean, a special case of masked Riemannian mean applied to covariance matrices corrupted by symmetric NaN values (in this case, masks are automatically estimated);
- improve `make_covariances`, ensuring positive eigen values and orthogonal eigen vectors (solve #19 ?);
- add a simple example comparing Euclidean NaN-mean, Riemannian NaN-mean and Riemannian mean after matrix deletion;
- complete tests.

F. Yger, S. Chevallier, Q. Barthélemy, S. Sra. "Geodesically-convex optimization for averaging partially observed covariance matrices", ACML 2021, [PDF](http://proceedings.mlr.press/v129/yger20a/yger20a.pdf)

Disclaimer: this is a pymanopt-free re-implementation of the original work coded with @sylvchev and @ygerf .

For comparison with your method: @ahippert