### PR TITLE
Correct documentation

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -15,7 +15,7 @@ jobs:
           pre-build-command: |
             apt-get update
             pip install -e .
-            pip install -r doc/doc-requirements.txt
+            pip install -r doc/requirements.txt
       - name:  Upload generated HTML as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,7 @@ sphinx_gallery_conf = {
 }
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-autodoc_default_flags = ['inherited-members']
+autodoc_default_options = {'inherited-members': True}
 
 autosummary_generate = True
 numpydoc_show_class_members = False

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -361,7 +361,7 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         """Partially fit the potato from covariance matrices.
 
         This partial fit can be used to update dynamic or semi-dymanic online
-        potatoes with clean EEG [2]_.
+        potatoes with clean EEG.
 
         Parameters
         ----------
@@ -605,7 +605,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         """Partially fit the potato field from covariance matrices.
 
         This partial fit can be used to update dynamic or semi-dymanic online
-        potatoes with clean EEG [1]_.
+        potatoes with clean EEG.
 
         Parameters
         ----------


### PR DESCRIPTION
Surprisingly, online documentation does not include last merged functions and examples.
I have corrected some errors. Maybe there are others left.

1) Error on requirements filename for documentation

`ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'doc/doc-requirements.txt'`

2) Warning for deprecated parameter

`RemovedInSphinx30Warning: autodoc_default_flags is now deprecated. Please use autodoc_default_options instead.`

See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_options

3) Minor warning: unresolved references in `partial_fit` of RP and RPF


