### PR TITLE
Add correlation normalization

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -36,6 +36,8 @@ v0.2.8.dev
 
 - Add masked and NaN means with Riemannian metric: :func:`pyriemann.utils.mean.maskedmean_riemann` and :func:`pyriemann.utils.mean.nanmean_riemann`
 
+- Add ``corr`` option in :func:`pyriemann.utils.covariance.normalize`, to normalize covariance into correlation matrices
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -448,7 +448,7 @@ def coherence(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None,
 
 
 def normalize(X, norm):
-    """Normalize a set of square matrices, using trace or determinant.
+    """Normalize a set of square matrices, using corr, trace or determinant.
 
     Parameters
     ----------
@@ -456,8 +456,13 @@ def normalize(X, norm):
         The set of square matrices, at least 2D ndarray. Matrices must be
         invertible for determinant-normalization.
 
-    norm : {"trace", "determinant"}
-        The type of normalization.
+    norm : {"corr", "trace", "determinant"}
+        The type of normalization:
+
+        * 'corr': normalized matrices are correlation matrices, with values in
+          [-1, 1] and diagonal values equal to 1;
+        * 'trace': trace of normalized matrices is 1;
+        * 'determinant': determinant of normalized matrices is +/- 1.
 
     Returns
     -------
@@ -467,7 +472,10 @@ def normalize(X, norm):
     if not is_square(X):
         raise ValueError('Matrices must be square')
 
-    if norm == "trace":
+    if norm == "corr":
+        stddev = np.sqrt(np.abs(np.diagonal(X, axis1=-2, axis2=-1)))
+        denom = np.expand_dims(stddev, axis=-2) * stddev[..., np.newaxis]
+    elif norm == "trace":
         denom = np.trace(X, axis1=-2, axis2=-1)
     elif norm == "determinant":
         denom = np.abs(np.linalg.det(X)) ** (1 / X.shape[-1])
@@ -477,6 +485,10 @@ def normalize(X, norm):
     while denom.ndim != X.ndim:
         denom = denom[..., np.newaxis]
     Xn = X / denom
+
+    if norm == "corr":
+        np.clip(Xn, -1, 1, out=Xn)
+
     return Xn
 
 

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -275,28 +275,42 @@ def test_covariances_coherence(coh, rndstate):
             assert c[0, 3, foi] == pytest.approx(0.0)
 
 
-def test_normalize(rndstate):
-    """Test normalize"""
-    n_conds, n_matrices, n_channels = 15, 20, 3
+@pytest.mark.parametrize('norm', ['corr', 'trace', 'determinant'])
+def test_normalize_shapes(norm, rndstate):
+    """Test normalize shapes"""
+    n_conds, n_matrices, n_channels = 15, 10, 3
 
     # test a 2d array, ie a single square matrix
     mat = rndstate.randn(n_channels, n_channels)
-    mat_n = normalize(mat, "trace")
+    mat_n = normalize(mat, norm)
     assert mat.shape == mat_n.shape
     # test a 3d array, ie a group of square matrices
     mat = rndstate.randn(n_matrices, n_channels, n_channels)
-    mat_n = normalize(mat, "determinant")
+    mat_n = normalize(mat, norm)
     assert mat.shape == mat_n.shape
     # test a 4d array, ie a group of groups of square matrices
     mat = rndstate.randn(n_conds, n_matrices, n_channels, n_channels)
-    mat_n = normalize(mat, "trace")
+    mat_n = normalize(mat, norm)
     assert mat.shape == mat_n.shape
+
+
+def test_normalize_values(rndstate, get_covmats):
+    """Test normalize values"""
+    n_matrices, n_channels = 20, 3
+
+    # after corr-normalization => diags = 1 and values in [-1, 1]
+    mat = get_covmats(n_channels, n_channels)
+    mat_cn = normalize(mat, "corr")
+    assert_array_almost_equal(np.ones(mat_cn.shape[:-1]),
+                              np.diagonal(mat_cn, axis1=-2, axis2=-1))
+    assert np.all(-1 <= mat_cn) and np.all(mat_cn <= 1)
 
     # after trace-normalization => trace equal to 1
     mat = rndstate.randn(n_matrices, n_channels, n_channels)
     mat_tn = normalize(mat, "trace")
     assert_array_almost_equal(np.ones(mat_tn.shape[0]),
                               np.trace(mat_tn, axis1=-2, axis2=-1))
+
     # after determinant-normalization => determinant equal to +/- 1
     mat_dn = normalize(mat, "determinant")
     assert_array_almost_equal(np.ones(mat_dn.shape[0]),


### PR DESCRIPTION
This PR:
- adds a new covariance normalization "corr", providing correlation matrices, with values in [-1, 1] and diagonal values equal to 1;
- completes doc and tests.