### PR TITLE
Riemannian Locally Linear Embedding

### DIFF
--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -1,14 +1,20 @@
 """Embedding covariance matrices via manifold learning techniques."""
 
 import numpy as np
+from scipy.linalg import solve
+from scipy.sparse import csr_matrix
+
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.manifold import spectral_embedding
 from sklearn.manifold._locally_linear import null_space
 
-from pyriemann.utils.mean import mean_riemann
-
-from pyriemann.utils.base import logm, invsqrtm
-from sklearn.base import BaseEstimator
-from sklearn.manifold import spectral_embedding
+from .utils.mean import mean_riemann
+from .utils.base import logm, invsqrtm
 from .utils.distance import pairwise_distance
+
+
+
+
 
 
 class Embedding(BaseEstimator):
@@ -107,20 +113,6 @@ class Embedding(BaseEstimator):
         """
         self.fit(X)
         return self.embedding_
-
-
-import numpy as np
-from scipy.linalg import eigh, svd, qr, solve
-from scipy.sparse import eye, csr_matrix
-from scipy.sparse.linalg import eigsh
-
-from sklearn.base import BaseEstimator, TransformerMixin, _UnstableArchMixin
-from sklearn.utils import check_random_state, check_array
-from sklearn.utils._arpack import _init_arpack_v0
-from sklearn.utils.extmath import stable_cumsum
-from sklearn.utils.validation import check_is_fitted
-from sklearn.utils.validation import FLOAT_DTYPES
-from sklearn.neighbors import NearestNeighbors
 
 
 class RiemannLLE(BaseEstimator, TransformerMixin):

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -113,8 +113,9 @@ class Embedding(BaseEstimator):
 class RiemannLLE(BaseEstimator, TransformerMixin):
     """Riemannian Locally Linear Embedding (LLE).
 
-    Riemannian LLE as proposed in [1]_. LLE is a non-linear, neighborhood-preserving
-    dimensionality reduction algorithm which consists of three main steps:
+    Riemannian LLE as proposed in [1]_. LLE is a non-linear,
+    neighborhood-preserving dimensionality reduction algorithm which
+    consists of three main steps:
     For each point x,
     1.  find its k nearest neighbors KNN(x) and
     2.  calculate the best reconstruction of x based on its KNN.
@@ -137,7 +138,7 @@ class RiemannLLE(BaseEstimator, TransformerMixin):
     reg : float, default: 1e-3
         Regularization parameter.
     **kwargs
-        Keyword arguments passed to sklearn.manifold._locally_linear.null_space.
+        Keyword arguments passed to sklearn.manifold._locally_linear.null_space
 
     Notes
     -----
@@ -150,7 +151,8 @@ class RiemannLLE(BaseEstimator, TransformerMixin):
         and Pattern Recognition, June 2008
     """
 
-    def __init__(self, n_components=2, n_neighbors=5, n_jobs=1, reg=1e-3, **kwargs):
+    def __init__(self, n_components=2, n_neighbors=5,
+                 n_jobs=1, reg=1e-3, **kwargs):
         self.n_components = n_components
         self.n_neighbors = n_neighbors
         self.n_jobs = n_jobs
@@ -172,11 +174,12 @@ class RiemannLLE(BaseEstimator, TransformerMixin):
 
         """
         self.data = X
-        self.embedding, self.reconstruction_error = riemann_lle(X,
-                                                                self.n_components,
-                                                                self.n_neighbors,
-                                                                self.reg,
-                                                                self.null_space_args)
+        self.embedding, self.reconstruction_error = \
+            riemann_lle(X,
+                        self.n_components,
+                        self.n_neighbors,
+                        self.reg,
+                        self.null_space_args)
         return self
 
     def transform(self, X, y=None):

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from .mean import mean_riemann
+from .base import sqrtm, invsqrtm, powm, logm, expm
+
+
+def inner_product(A, B, Cref):
+    """Inner product of symmetric matrices A and B on the tangent space of Cref.
+
+    Parameters
+    ----------
+    A : ndarray, shape (n_channels, n_channels)
+        First symmetric matrix to calculate inner product.
+    B : ndarray, shape (n_channels, n_channels)
+        Second symmetric matrix to calculate inner product.
+    Cref : ndarray, shape (n_channels, n_channels)
+        Reference point for the tangent space and inner product calculation.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.8
+    """
+    Cref_inv = powm(Cref, -1)
+    return np.trace(Cref_inv@A@Cref_inv@B)
+
+
+def kernel_riemann(X, Y=None, Cref=None):
+    r""" Calculates the Kernel matrix K of inner products of two sets
+     X and Y of SPD matrices on tangent space of C by calculating pairwise
+
+    .. math::
+        K_{i,j} =
+        {tr}(\log(C^{-1/2}X_i C^{-1/2})\log(C^{-1/2}Y_j C^{-1/2}))
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_matrices, n_channels, n_channels)
+        First set of SPD matrices.
+    Y : ndarray, shape (n_matrices, n_channels, n_channels), optional
+        Second set of SPD matrices. If None, Y is set to X.
+    Cref : ndarray, shape (n_channels, n_channels), optional
+        Reference point for the tangent space and inner product calculation.
+        If None, Cref is calculated as the Riemannian mean of X.
+
+    Returns
+    ----------
+    K : ndarray, shape (n_matrices, n_matrices)
+        The kernel matrix of X and Y.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.8
+    """
+    if Cref is None:
+        G = mean_riemann(X)
+        G_invsq = invsqrtm(G)
+
+    else:
+        G_invsq = invsqrtm(Cref)
+
+    n_matrices_X, n_channels, n_channels = X.shape
+
+    # tangent space projection
+    X_ = np.matmul(G_invsq, np.matmul(X, G_invsq))
+    X_ = np.array([logm(X_[index]) for index in range(n_matrices_X)])
+
+    if isinstance(Y, type(None)):
+        Y_ = X_
+
+    else:
+        n_matrices_Y, n_channels, n_channels = Y.shape
+
+        Y = np.matmul(G_invsq, np.matmul(Y, G_invsq))
+        Y_ = np.array([logm(Y[index]) for index in range(n_matrices_Y)])
+
+    # calculate scalar products
+    # for i in range(n_matrices_X):
+    #     for j in range(n_matrices_Y):
+    #         res[i][j] = np.trace(X_[i] @ Y_[j])
+    # einsum does same as that just a looooooot faster
+
+    res = np.einsum('abc,dbc->ad', X_, Y_)
+
+    return res

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -1,27 +1,7 @@
 import numpy as np
 
 from .mean import mean_riemann
-from .base import sqrtm, invsqrtm, powm, logm, expm
-
-
-def inner_product(A, B, Cref):
-    """Inner product of symmetric matrices A and B on the tangent space of Cref.
-
-    Parameters
-    ----------
-    A : ndarray, shape (n_channels, n_channels)
-        First symmetric matrix to calculate inner product.
-    B : ndarray, shape (n_channels, n_channels)
-        Second symmetric matrix to calculate inner product.
-    Cref : ndarray, shape (n_channels, n_channels)
-        Reference point for the tangent space and inner product calculation.
-
-    Notes
-    -----
-    .. versionadded:: 0.2.8
-    """
-    Cref_inv = powm(Cref, -1)
-    return np.trace(Cref_inv@A@Cref_inv@B)
+from .base import invsqrtm, logm
 
 
 def kernel_riemann(X, Y=None, Cref=None):
@@ -60,25 +40,24 @@ def kernel_riemann(X, Y=None, Cref=None):
 
     n_matrices_X, n_channels, n_channels = X.shape
 
-    # tangent space projection
     X_ = np.matmul(G_invsq, np.matmul(X, G_invsq))
     X_ = np.array([logm(X_[index]) for index in range(n_matrices_X)])
 
-    if isinstance(Y, type(None)):
+    if isinstance(Y, type(None)) or np.array_equal(X, Y):
         Y_ = X_
 
     else:
         n_matrices_Y, n_channels, n_channels = Y.shape
 
-        Y = np.matmul(G_invsq, np.matmul(Y, G_invsq))
-        Y_ = np.array([logm(Y[index]) for index in range(n_matrices_Y)])
+        Y_ = np.matmul(G_invsq, np.matmul(Y, G_invsq))
+        Y_ = np.array([logm(Y_[index]) for index in range(n_matrices_Y)])
 
     # calculate scalar products
     # for i in range(n_matrices_X):
     #     for j in range(n_matrices_Y):
-    #         res[i][j] = np.trace(X_[i] @ Y_[j])
+    #         K[i][j] = np.trace(X_[i] @ Y_[j])
     # einsum does same as that just a looooooot faster
 
-    res = np.einsum('abc,dbc->ad', X_, Y_)
+    K = np.einsum('abc,dbc->ad', X_, Y_)
 
-    return res
+    return K

--- a/tests/test_utils_kernel.py
+++ b/tests/test_utils_kernel.py
@@ -4,10 +4,9 @@ from pyriemann.utils.base import logm
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
-import pytest
 
-from pyriemann.utils.test import (is_sym_pos_def as is_spd,
-                                  is_sym_pos_semi_def as is_spsd)
+from pyriemann.utils.test import is_sym_pos_semi_def as is_spsd
+
 
 def test_riemann_kernel(rndstate, get_covmats):
     """Test Riemannian Kernel build"""

--- a/tests/test_utils_kernel.py
+++ b/tests/test_utils_kernel.py
@@ -1,0 +1,33 @@
+from pyriemann.utils.kernel import kernel_riemann
+from pyriemann.utils.mean import mean_riemann
+from pyriemann.utils.base import logm
+
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+import numpy as np
+import pytest
+
+from pyriemann.utils.test import (is_sym_pos_def as is_spd,
+                                  is_sym_pos_semi_def as is_spsd)
+
+def test_riemann_kernel(rndstate, get_covmats):
+    """Test Riemannian Kernel"""
+    n_trials, n_channels = 5, 3
+    cov = get_covmats(n_trials, n_channels,)
+    K = kernel_riemann(cov, cov, np.eye(n_channels))
+    assert is_spsd(K)
+
+    log_cov = np.array([logm(c) for c in cov])
+    tensor = np.tensordot(log_cov, log_cov.T, axes=1)
+    K1 = np.trace(tensor, axis1=1, axis2=2)
+    assert_array_almost_equal(K, K1)
+
+
+def test_riemann_kernel_cref(rndstate, get_covmats):
+    """Test Riemannian Kernel"""
+    n_trials, n_channels = 5, 3
+    cov = get_covmats(n_trials, n_channels,)
+    cref = mean_riemann(cov)
+    K = kernel_riemann(cov, cov)
+    K1 = kernel_riemann(cov, cov, cref)
+    assert_array_equal(K, K1)
+

--- a/tests/test_utils_kernel.py
+++ b/tests/test_utils_kernel.py
@@ -10,9 +10,9 @@ from pyriemann.utils.test import (is_sym_pos_def as is_spd,
                                   is_sym_pos_semi_def as is_spsd)
 
 def test_riemann_kernel(rndstate, get_covmats):
-    """Test Riemannian Kernel"""
+    """Test Riemannian Kernel build"""
     n_trials, n_channels = 5, 3
-    cov = get_covmats(n_trials, n_channels,)
+    cov = get_covmats(n_trials, n_channels)
     K = kernel_riemann(cov, cov, np.eye(n_channels))
     assert is_spsd(K)
 
@@ -23,11 +23,20 @@ def test_riemann_kernel(rndstate, get_covmats):
 
 
 def test_riemann_kernel_cref(rndstate, get_covmats):
-    """Test Riemannian Kernel"""
+    """Test Riemannian Kernel reference"""
     n_trials, n_channels = 5, 3
-    cov = get_covmats(n_trials, n_channels,)
+    cov = get_covmats(n_trials, n_channels)
     cref = mean_riemann(cov)
     K = kernel_riemann(cov, cov)
     K1 = kernel_riemann(cov, cov, cref)
     assert_array_equal(K, K1)
 
+
+def test_riemann_kernel_x_y(rndstate, get_covmats):
+    """Test Riemannian Kernel reference"""
+    n_trials, n_channels = 5, 3
+    cov = get_covmats(n_trials, n_channels)
+    cov2 = get_covmats(n_trials+1, n_channels)
+    K = kernel_riemann(cov, cov2)
+
+    assert K.shape == (n_trials, n_trials + 1)


### PR DESCRIPTION
As promised, this implements a new embedding method, Locally Linear Embedding using the Riemannian distance (as in [http://www.cis.jhu.edu/~rvidal/publications/cvpr08-Riemannian.pdf](url)). 

There are a few conceptual things to discuss here:

1.  kernel.py: I made a new file in utils as there could be several kernel methods depending on the metric and there are other use cases for the kernel. There could be a generic kernel function consisting of ts-projection and scalar product calculation but it would be rather slow, so I wrote this one standalone. 
2. Should the two functions (riemann_lle and barycenter_weights) that are used in RiemannLLE be moved to another file in utils?
3. with another embedding method present, should Embedding be renamed to SpectralEmbedding?
4. I relied heavily on preexisting code from skelarn for the riemann_lle and barycenter_weights functions. Is there a way this needs to be quoted? I only mentioned it in the notes.