### PR TITLE
Display animated figures in the documentation, 2nd part

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 seaborn
 pandas
 joblib
+ipython

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -252,6 +252,7 @@ def online_detect(t):
     p_ep.set_color(ep_colors_)
     return pl_sig0, pl_sig1, p_rp, p_ep
 
+
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_detect,

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -19,7 +19,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_rgb
 from matplotlib.animation import FuncAnimation
-from IPython.display import HTML
 
 from mne.datasets import sample
 from mne.io import read_raw_fif
@@ -268,8 +267,12 @@ potato = FuncAnimation(fig, online_detect,
 plt.show()
 
 # Plot only 10s, for animated documentation
-plt.rcParams["animation.embed_limit"] = 10
-HTML(potato.to_jshtml(fps=5, default_mode='loop'))
+try:
+    from IPython.display import HTML
+    plt.rcParams["animation.embed_limit"] = 10
+    HTML(potato.to_jshtml(fps=5, default_mode='loop'))
+except ImportError:
+    raise ImportError("Install IPython to plot animation in documentation")
 
 
 ###############################################################################

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -19,6 +19,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_rgb
 from matplotlib.animation import FuncAnimation
+from IPython.display import HTML
 
 from mne.datasets import sample
 from mne.io import read_raw_fif
@@ -251,16 +252,23 @@ def online_detect(t):
     p_ep.set_color(ep_colors_)
     return pl_sig0, pl_sig1, p_rp, p_ep
 
-
-###############################################################################
-# Plot online detection (a dynamic display is required)
-
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_detect,
                        frames=range(train_covs, test_covs_max),
                        interval=interval_display, blit=False, repeat=False)
+
+
+###############################################################################
+
+# Plot online detection
+
+# Plot complete visu: a dynamic display is required
 plt.show()
+
+# Plot only 10s, for animated documentation
+plt.rcParams["animation.embed_limit"] = 10
+HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 
 
 ###############################################################################

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -269,10 +269,11 @@ plt.show()
 # Plot only 10s, for animated documentation
 try:
     from IPython.display import HTML
-    plt.rcParams["animation.embed_limit"] = 10
-    HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 except ImportError:
     raise ImportError("Install IPython to plot animation in documentation")
+
+plt.rcParams["animation.embed_limit"] = 10
+HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 
 
 ###############################################################################

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -259,6 +259,7 @@ def online_detect(t):
     pl3[0].set_data(covs_t, covs_p)
     return pl, pl2, pl3
 
+
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_detect,

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -276,10 +276,11 @@ plt.show()
 # Plot only 10s, for animated documentation
 try:
     from IPython.display import HTML
-    plt.rcParams["animation.embed_limit"] = 10
-    HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 except ImportError:
     raise ImportError("Install IPython to plot animation in documentation")
+
+plt.rcParams["animation.embed_limit"] = 10
+HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 
 
 ###############################################################################

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -14,7 +14,6 @@ detect artifacts in online processing. It is compared to the Riemannian Potato
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
-from IPython.display import HTML
 
 from mne.datasets import eegbci
 from mne.io import read_raw_edf
@@ -275,8 +274,12 @@ potato = FuncAnimation(fig, online_detect,
 plt.show()
 
 # Plot only 10s, for animated documentation
-plt.rcParams["animation.embed_limit"] = 10
-HTML(potato.to_jshtml(fps=5, default_mode='loop'))
+try:
+    from IPython.display import HTML
+    plt.rcParams["animation.embed_limit"] = 10
+    HTML(potato.to_jshtml(fps=5, default_mode='loop'))
+except ImportError:
+    raise ImportError("Install IPython to plot animation in documentation")
 
 
 ###############################################################################

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -14,6 +14,7 @@ detect artifacts in online processing. It is compared to the Riemannian Potato
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
+from IPython.display import HTML
 
 from mne.datasets import eegbci
 from mne.io import read_raw_edf
@@ -258,16 +259,23 @@ def online_detect(t):
     pl3[0].set_data(covs_t, covs_p)
     return pl, pl2, pl3
 
-
-###############################################################################
-# Plot online detection (a dynamic display is required)
-
 interval_display = 1.0  # can be changed for a slower display
 
 potato = FuncAnimation(fig, online_detect,
                        frames=range(train_covs, test_covs_max),
                        interval=interval_display, blit=False, repeat=False)
+
+
+###############################################################################
+
+# Plot online detection
+
+# Plot complete visu: a dynamic display is required
 plt.show()
+
+# Plot only 10s, for animated documentation
+plt.rcParams["animation.embed_limit"] = 10
+HTML(potato.to_jshtml(fps=5, default_mode='loop'))
 
 
 ###############################################################################


### PR DESCRIPTION
This PR completes the too quickly merged PR #161.

I have not found how to avoid figure to be plotted twice in the documentation.
However, I think that it is better to have a double plot, with the second one animated, rather than nothing.