### PR TITLE
Update example on SSVEP and add helpers

### DIFF
--- a/examples/SSVEP/helpers/ssvep_helpers.py
+++ b/examples/SSVEP/helpers/ssvep_helpers.py
@@ -1,4 +1,4 @@
-""" Functions for SSVEP examples """
+""" Local functions for SSVEP examples """
 
 import os
 import numpy as np
@@ -24,8 +24,8 @@ def download_data(subject=1, session=1):
         Path to downloaded data
     """
     DATASET_URL = 'https://zenodo.org/record/2392979/files/'
-    url = '{:s}subject{:02d}_run{:d}_raw.fif'.format(DATASET_URL,
-                                                     subject, session + 1)
+    url = '{:s}subject{:02d}_run{:d}_raw.fif'.format(
+        DATASET_URL, subject, session + 1)
 
     archive_name = url.split('/')[-1]
     dataset_params = {
@@ -41,25 +41,30 @@ def download_data(subject=1, session=1):
     return os.path.join(data_path, archive_name)
 
 
-def bandpass_filter(signal, lowcut, highcut, method="iir"):
+def bandpass_filter(raw, l_freq, h_freq, method="iir", verbose=False):
     """ Band-pass filter a signal using MNE """
-    return signal.copy().filter(l_freq=lowcut, h_freq=highcut,
-                                method=method).get_data()
+    return raw.copy().filter(
+        l_freq=l_freq,
+        h_freq=h_freq,
+        method=method,
+        verbose=verbose
+    ).get_data()
 
 
 def extend_signal(raw, frequencies, freq_band):
     """ Extend a signal with filter bank using MNE """
-    ext_signal = np.vstack([
-        bandpass_filter(raw, lowcut=f-freq_band, highcut=f+freq_band)
+    raw_ext = np.vstack([
+        bandpass_filter(raw, l_freq=f - freq_band, h_freq=f + freq_band)
         for f in frequencies]
     )
 
     info = create_info(
         ch_names=sum(
-            list(map(lambda f: [ch+'-'+str(f)+'Hz' for ch in raw.ch_names],
+            list(map(lambda f: [ch + '-' + str(f) + 'Hz'
+                                for ch in raw.ch_names],
                      frequencies)), []),
         ch_types=['eeg'] * len(raw.ch_names) * len(frequencies),
         sfreq=int(raw.info['sfreq'])
     )
 
-    return RawArray(ext_signal, info)
+    return RawArray(raw_ext, info)

--- a/examples/SSVEP/helpers/ssvep_helpers.py
+++ b/examples/SSVEP/helpers/ssvep_helpers.py
@@ -27,7 +27,7 @@ def download_data(subject=1, session=1):
     url = '{:s}subject{:02d}_run{:d}_raw.fif'.format(
         DATASET_URL, subject, session + 1)
 
-    archive_name = url.split('/')[-1]
+    archive_name = url.split('/')[-4:]
     dataset_params = {
         'dataset_name': "ssvep",
         'archive_name': archive_name,
@@ -38,7 +38,7 @@ def download_data(subject=1, session=1):
     }
     data_path = fetch_dataset(dataset_params)
 
-    return os.path.join(data_path, archive_name)
+    return os.path.join(data_path, *archive_name)
 
 
 def bandpass_filter(raw, l_freq, h_freq, method="iir", verbose=False):

--- a/examples/SSVEP/helpers/ssvep_helpers.py
+++ b/examples/SSVEP/helpers/ssvep_helpers.py
@@ -30,7 +30,7 @@ def download_data(subject=1, session=1):
     archive_name = url.split('/')[-4:]
     dataset_params = {
         'dataset_name': "ssvep",
-        'archive_name': archive_name,
+        'archive_name': '/'.join(archive_name),
         'hash': 'md5:ff7f0361a2d41f8df3fb53b9a9bc1220',
         'url': url,
         'folder_name': 'MNE-ssvepexo-data',


### PR DESCRIPTION
This PR:

- updates example on SSVEP classification by MDM;
- ~uses the first four training sessions, in order to classify 128 trials instead of 32~;
- moves helper functions for SSVEP signal processing into a dedicated sub-module (in order to be re-used by future examples on SSVEP).