### PR TITLE
Update to Python-3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install .[tests]
     - name: Lint with flake8
       run: |
-        flake8 examples tests pyriemann
+        flake8 examples tests pyriemann setup.py
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -5,36 +5,45 @@ from setuptools import setup, find_packages
 
 # get the version (don't import mne here, so dependencies are not needed)
 version = None
-with open(op.join('pyriemann', '_version.py'), 'r') as fid:
+with open(op.join("pyriemann", "_version.py"), "r") as fid:
     for line in (line.strip() for line in fid):
-        if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('\'')
+        if line.startswith("__version__"):
+            version = line.split("=")[1].strip().strip("'")
             break
 if version is None:
-    raise RuntimeError('Could not determine version')
+    raise RuntimeError("Could not determine version")
 
-with open('README.md', 'r', encoding="utf8") as fid:
+with open("README.md", "r", encoding="utf8") as fid:
     long_description = fid.read()
 
-setup(name='pyriemann',
-      version=version,
-      description='Riemannian Geometry for python',
-      url='https://pyriemann.readthedocs.io',
-      author='Alexandre Barachant',
-      author_email='alexandre.barachant@gmail.com',
-      license='BSD (3-clause)',
-      packages=find_packages(),
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      project_urls={
-          'Documentation': 'https://pyriemann.readthedocs.io',
-          'Source': 'https://github.com/pyRiemann/pyRiemann',
-          'Tracker': 'https://github.com/pyRiemann/pyRiemann/issues/',
-      },
-      platforms='any',
-      python_requires=">=3.6",
-      install_requires=['numpy', 'scipy', 'scikit-learn',  'joblib', 'pandas'],
-      extras_require={'docs': ['sphinx-gallery', 'sphinx-bootstrap_theme', 'numpydoc', 'mne', 'seaborn'],
-                      'tests': ['pytest', 'seaborn', 'flake8']},
-      zip_safe=False,
+setup(
+    name="pyriemann",
+    version=version,
+    description="Riemannian Geometry for python",
+    url="https://pyriemann.readthedocs.io",
+    author="Alexandre Barachant",
+    author_email="alexandre.barachant@gmail.com",
+    license="BSD (3-clause)",
+    packages=find_packages(),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    project_urls={
+        "Documentation": "https://pyriemann.readthedocs.io",
+        "Source": "https://github.com/pyRiemann/pyRiemann",
+        "Tracker": "https://github.com/pyRiemann/pyRiemann/issues/",
+    },
+    platforms="any",
+    python_requires=">=3.7",
+    install_requires=["numpy", "scipy", "scikit-learn", "joblib", "pandas"],
+    extras_require={
+        "docs": [
+            "sphinx-gallery",
+            "sphinx-bootstrap_theme",
+            "numpydoc",
+            "mne",
+            "seaborn",
+        ],
+        "tests": ["pytest", "seaborn", "flake8"],
+    },
+    zip_safe=False,
 )


### PR DESCRIPTION
Test and configuration still support python-3.6, while this version is deprecated. Time to move to 3.7 and try testing pyriemann against python-3.9.