### PR TITLE
Add the Minimum Distance to Mean Field classifier

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,7 @@ Classification
     TSclassifier
     KNearestNeighbor
     SVC
+    MeanField
 
 Regression
 --------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -58,6 +58,7 @@ v0.2.8.dev
 
 - Add K-Nearest-Neighbor regressor: :class:`pyriemann.regression.KNearestNeighborRegressor`
 
+- Add Minimum Distance to Mean Field classifier: :class:`pyriemann.classification.MeanField`
 v0.2.7 (June 2021)
 ------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -59,6 +59,7 @@ v0.2.8.dev
 - Add K-Nearest-Neighbor regressor: :class:`pyriemann.regression.KNearestNeighborRegressor`
 
 - Add Minimum Distance to Mean Field classifier: :class:`pyriemann.classification.MeanField`
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -10,7 +10,7 @@ of different classifiers.
 This should be taken with a grain of salt, as the intuition conveyed by
 these examples does not necessarily carry over to real datasets.
 
-The plots show training points in solid colors and testing points
+The 3D plots show training points in solid colors and testing points
 semi-transparent. The lower right shows the classification accuracy on the test
 set.
 
@@ -27,7 +27,7 @@ from matplotlib.colors import ListedColormap
 from sklearn.model_selection import train_test_split
 
 from pyriemann.datasets import make_covariances, make_gaussian_blobs
-from pyriemann.classification import MDM, KNearestNeighbor, SVC
+from pyriemann.classification import MDM, KNearestNeighbor, SVC, MeanField
 
 
 ###############################################################################
@@ -46,12 +46,14 @@ def get_proba(cov_00, cov_01, cov_11, clf):
 names = [
     "MDM",
     "Nearest Neighbors",
-    "SVC"
+    "SVC",
+    "MeanField"
 ]
 classifiers = [
     MDM(),
     KNearestNeighbor(n_neighbors=3),
-    SVC(probability=True)
+    SVC(probability=True),
+    MeanField(power_list=[-1, -0.25, 0, 0.25, 1])
 ]
 n_classifs = len(classifiers)
 
@@ -98,7 +100,7 @@ cm_bright = ListedColormap(["#FF0000", "#0000FF"])
 
 ###############################################################################
 
-figure = plt.figure(figsize=(12, 10))
+figure = plt.figure(figsize=(15, 10))
 i = 1
 # iterate over datasets
 for ds_cnt, (X, y) in enumerate(datasets):

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -753,7 +753,7 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
         to Means Field Classifier", BCI Conference 2019
     """
 
-    def __init__(self, power_list=[-1,0,+1], method_label='sum_means',
+    def __init__(self, power_list=[-1, 0, 1], method_label='sum_means',
                  metric='riemann', n_jobs=1):
         """Init."""
         self.power_list = power_list

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -14,7 +14,7 @@ from sklearn.pipeline import make_pipeline
 from joblib import Parallel, delayed
 
 from .utils.kernel import kernel
-from .utils.mean import mean_covariance
+from .utils.mean import mean_covariance, mean_power
 from .utils.distance import distance
 from .tangentspace import FGDA, TangentSpace
 
@@ -715,3 +715,175 @@ class SVC(sklearnSVC):
         else:
             raise TypeError(f"kernel must be 'precomputed' or callable, is "
                             f"{self.kernel}.")
+
+
+class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
+    """ Mean field classifier
+
+    Classification by Minimum Distance to Mean Field [1]_, using power means.
+
+    Parameters
+    ----------
+    power_list : list of float (default: [-1,0,+1])
+        Exponents of power means.
+    method_label : {'sum_means', 'inf_means'} (default: 'sum_means')
+        Method to combine labels.
+    metric : string | dict (default: 'riemann')
+        The type of metric used for distance estimation during prediction.
+        See `distance` for the list of supported metric.
+
+    Attributes
+    ----------
+    covmeans_ : list of list
+        the class centroids.
+    classes_ : list
+        list of classes.
+
+    See Also
+    --------
+    MDM
+
+    Notes
+    -----
+    .. versionadded:: 0.2.8
+
+    References
+    ----------
+    .. [1] M Congedo, PLC Rodrigues, C Jutten. "The Riemannian Minimum Distance
+        to Means Field Classifier", BCI Conference 2019
+    """
+
+    def __init__(self, power_list=[-1,0,+1], method_label='sum_means',
+                 metric='riemann', n_jobs=1):
+        """Init."""
+        self.power_list = power_list
+        self.method_label = method_label
+        self.metric = metric
+        self.n_jobs = n_jobs
+
+    def fit(self, X, y, sample_weight=None):
+        """Fit (estimates) the centroids.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+        y : ndarray, shape (n_matrices,)
+            Labels corresponding to each matrix.
+        sample_weight : None | ndarray shape (n_matrices,)
+            Weights of each matrix. If None, each matrix is treated with
+            equal weights.
+
+        Returns
+        -------
+        self : MeanField instance
+            The MeanField instance.
+        """
+        self.classes_ = np.unique(y)
+
+        if sample_weight is None:
+            sample_weight = np.ones(X.shape[0])
+
+        self.covmeans_ = {}
+        for p in self.power_list:
+            means_p = {}
+            for ll in self.classes_:
+                means_p[ll] = mean_power(
+                    X[y == ll],
+                    p,
+                    sample_weight=sample_weight[y == ll]
+                )
+            self.covmeans_[p] = means_p
+
+        return self
+
+    def _get_label(self, x, labs_unique):
+        m = np.zeros((len(self.power_list), len(labs_unique)))
+        for ip, p in enumerate(self.power_list):
+            for ill, ll in enumerate(labs_unique):
+                m[ip, ill] = distance(
+                    x, self.covmeans_[p][ll], metric=self.metric)**2
+
+        if self.method_label == 'sum_means':
+            ipmin = np.argmin(np.sum(m, axis=1))
+        elif self.method_label == 'inf_means':
+            ipmin = np.where(m == np.min(m))[0][0]
+        else:
+            raise TypeError('method_label must be sum_means or inf_means')
+
+        y = labs_unique[np.argmin(m[ipmin])]
+        return y
+
+    def predict(self, X):
+        """Get the predictions.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+
+        Returns
+        -------
+        pred : ndarray of int, shape (n_matrices,)
+            Predictions for each matrix according to the closest means field.
+        """
+        labs_unique = sorted(self.covmeans_[self.power_list[0]].keys())
+
+        pred = Parallel(n_jobs=self.n_jobs)(delayed(self._get_label)(
+            x, labs_unique)
+            for x in X)
+        return np.array(pred)
+
+    def _predict_distances(self, X):
+        """Helper to predict the distance. Equivalent to transform."""
+
+        dist = []
+        for x in X:
+            m = {}
+            for p in self.power_list:
+                m[p] = []
+                for ll in self.classes_:
+                    m[p].append(
+                        distance(
+                            x, self.covmeans_[p][ll], metric=self.metric
+                        )**2
+                    )
+            pmin = min(m.items(), key=lambda x: np.sum(x[1]))[0]
+            dist.append(np.array(m[pmin]))
+
+        return np.stack(dist)
+
+    def transform(self, X):
+        """Get the distance to each means field.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+
+        Returns
+        -------
+        dist : ndarray, shape (n_matrices, n_classes)
+            Distance to each means field according to the metric.
+        """
+        return self._predict_distances(X)
+
+    def fit_predict(self, X, y):
+        """Fit and predict in one function."""
+        self.fit(X, y)
+        return self.predict(X)
+
+    def predict_proba(self, X):
+        """Predict proba using softmax.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+
+        Returns
+        -------
+        prob : ndarray, shape (n_matrices, n_classes)
+            Probabilities for each class.
+        """
+        return softmax(-self._predict_distances(X)**2)

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -718,7 +718,7 @@ class SVC(sklearnSVC):
 
 
 class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
-    """ Mean field classifier
+    """Classification by Minimum Distance to Mean Field.
 
     Classification by Minimum Distance to Mean Field [1]_, using power means.
 
@@ -727,7 +727,12 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
     power_list : list of float (default: [-1,0,+1])
         Exponents of power means.
     method_label : {'sum_means', 'inf_means'} (default: 'sum_means')
-        Method to combine labels.
+        Method to combine labels:
+
+        * sum_means: it assigns the covariance to the class whom the sum of
+          distances to means of the field is the lowest;
+        * inf_means: it assigns the covariance to the class of the closest mean
+          of the field.
     metric : string | dict (default: 'riemann')
         The type of metric used for distance estimation during prediction.
         See `distance` for the list of supported metric.

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -444,12 +444,21 @@ def mean_alm(covmats, tol=1e-14, maxiter=100,
 def mean_power(covmats, p, *, sample_weight=None, zeta=10e-10):
     """Power mean of SPD matrices.
 
-    :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
-    :param p: Exponent, in [-1,+1]
-    :param sample_weight: Weight of each matrix
-    :param zeta: Stopping criterion
+    Parameters
+    ----------
+    covmats : ndarray, shape (n_matrices, n_channels, n_channels)
+        Set of SPD matrices.
+    p : float
+        Exponent, in [-1,+1].
+    sample_weight : None | ndarray, shape (n_matrices,) (default None)
+        The weight of each matrix.
+    zeta : float (default 10e-10)
+        Stopping criterion.
 
-    :returns: the mean covariance matrix
+    Returns
+    -------
+    C : ndarray, shape (n_channels, n_channels)
+        Power mean.
 
     Notes
     -----

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -445,7 +445,7 @@ def mean_power(covmats, p, *, sample_weight=None, zeta=10e-10):
     """Power mean of SPD matrices.
 
     :param covmats: Covariance matrices, (n_matrices, n_channels, n_channels)
-    :param p: Exponent, in [-1,0) U (0,1]
+    :param p: Exponent, in [-1,+1]
     :param sample_weight: Weight of each matrix
     :param zeta: Stopping criterion
 
@@ -465,12 +465,11 @@ def mean_power(covmats, p, *, sample_weight=None, zeta=10e-10):
     """
     if not isinstance(p, (int, float)):
         raise ValueError("Power mean only defined for a scalar exponent")
-    if p == 0:
-        raise ValueError("Exponent must be non-zero. Use mean_riemann instead "
-                         "because power mean tends to geometric mean when "
-                         "exponent tends to zero.")
     if p < -1 or 1 < p:
-        raise ValueError("Exponent must be in [-1,0) U (0,1]")
+        raise ValueError("Exponent must be in [-1,+1]")
+
+    if p == 0:
+        return mean_riemann(covmats, sample_weight=sample_weight)
 
     n_matrices, n_channels, _ = covmats.shape
     sample_weight = _get_sample_weight(sample_weight, covmats)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -8,7 +8,8 @@ from pyriemann.classification import (
     FgMDM,
     KNearestNeighbor,
     TSclassifier,
-    SVC
+    SVC,
+    MeanField
 )
 
 from pyriemann.estimation import Covariances
@@ -19,7 +20,7 @@ from sklearn.dummy import DummyClassifier
 from pyriemann.utils.kernel import kernel
 from pyriemann.utils.mean import mean_covariance
 
-rclf = [MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC]
+rclf = [MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC, MeanField]
 
 
 @pytest.mark.parametrize("classif", rclf)
@@ -30,15 +31,14 @@ class ClassifierTestCase:
         labels = get_labels(n_matrices, n_classes)
         self.clf_predict(classif, covmats, labels)
         self.clf_fit_independence(classif, covmats, labels)
-        if classif is (MDM, KNearestNeighbor, SVC):
+        self.clf_predict_proba(classif, covmats, labels)
+        self.clf_populate_classes(classif, covmats, labels)
+        if classif is (MDM, KNearestNeighbor, SVC, MeanField):
             self.clf_fitpredict(classif, covmats, labels)
         if classif in (MDM, FgMDM):
             self.clf_transform(classif, covmats, labels)
-        if classif in (MDM, FgMDM, KNearestNeighbor):
+        if classif in (MDM, FgMDM, KNearestNeighbor, MeanField):
             self.clf_jobs(classif, covmats, labels)
-        if classif in (MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC):
-            self.clf_predict_proba(classif, covmats, labels)
-            self.clf_populate_classes(classif, covmats, labels)
         if classif is (FgMDM, TSclassifier):
             self.clf_tsupdate(classif, covmats, labels)
 
@@ -48,15 +48,14 @@ class ClassifierTestCase:
         labels = get_labels(n_matrices, n_classes)
         self.clf_fit_independence(classif, covmats, labels)
         self.clf_predict(classif, covmats, labels)
-        if classif is (MDM, KNearestNeighbor, SVC):
+        self.clf_predict_proba(classif, covmats, labels)
+        self.clf_populate_classes(classif, covmats, labels)
+        if classif is (MDM, KNearestNeighbor, SVC, MeanField):
             self.clf_fitpredict(classif, covmats, labels)
         if classif in (MDM, FgMDM):
             self.clf_transform(classif, covmats, labels)
-        if classif in (MDM, FgMDM, KNearestNeighbor):
+        if classif in (MDM, FgMDM, KNearestNeighbor, MeanField):
             self.clf_jobs(classif, covmats, labels)
-        if classif in (MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC):
-            self.clf_predict_proba(classif, covmats, labels)
-            self.clf_populate_classes(classif, covmats, labels)
         if classif is (FgMDM, TSclassifier):
             self.clf_tsupdate(classif, covmats, labels)
 

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -119,10 +119,13 @@ def test_power_mean(get_covmats):
     n_matrices, n_channels = 3, 3
     covmats = get_covmats(n_matrices, n_channels)
     C_power_1 = mean_power(covmats, 1)
+    C_power_0 = mean_power(covmats, 0)
     C_power_m1 = mean_power(covmats, -1)
     C_arithm = mean_euclid(covmats)
+    C_geom = mean_riemann(covmats)
     C_harm = mean_harmonic(covmats)
     assert C_power_1 == approx(C_arithm)
+    assert C_power_0 == approx(C_geom)
     assert C_power_m1 == approx(C_harm)
 
 
@@ -180,9 +183,7 @@ def test_power_mean_errors(get_covmats):
 
     with pytest.raises(ValueError):  # exponent is not a scalar
         mean_power(covmats, [1])
-    with pytest.raises(ValueError):  # exponent is not non-zero
-        mean_power(covmats, 0)
-    with pytest.raises(ValueError):  # exponent is not in [-1,0) U (0,1]
+    with pytest.raises(ValueError):  # exponent is not in [-1,1]
         mean_power(covmats, 3)
 
 


### PR DESCRIPTION
This PR:

- implements the MeanField classifier for SPD matrices
(original code from https://github.com/plcrodrigues/means-field-classifier/blob/master/power_means.py#L42);

- updates the behavior of 'mean_power' added in #170, to call `mean_riemann` when p=0 (same behavior as  [power mean in SciPy](http://scipy.github.io/devdocs/reference/generated/scipy.stats.pmean.html) )

- completes tests on classification;

- completes comparison of classifiers.

@Marco-Congedo, I know your are currently working on combining MeanField and ASAP for P300 BCI. Can you review and test this implementation?
