### PR TITLE
speedup for make_gaussian_blobs

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -64,6 +64,10 @@ v0.2.8.dev
 
 - Add :func:`pyriemann.utils.distance.distance_harmonic`, and sort functions by their names in code, doc and tests
 
+- Parallelize functions for dataset generation: :func:`pyriemann.datasets.make_gaussian_blobs`
+
+- Fix dispersion when generating datasets: :func:`pyriemann.datasets.sample_gaussian_spd`
+
 v0.2.7 (June 2021)
 ------------------
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -224,11 +224,11 @@ datasets = [
     ),
     make_gaussian_blobs(
         2*n_matrices, n_channels, random_state=rs, class_sep=1., class_disp=.2,
-        n_jobs=-1
+        n_jobs=4
     ),
     make_gaussian_blobs(
         2*n_matrices, n_channels, random_state=rs, class_sep=.5, class_disp=.5,
-        mat_std=.1, n_jobs=-1
+        mat_std=.1, n_jobs=4
     )
 ]
 n_datasets = len(datasets)

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -223,11 +223,12 @@ datasets = [
         y
     ),
     make_gaussian_blobs(
-        2*n_matrices, n_channels, random_state=rs, class_sep=1., class_disp=.2
+        2*n_matrices, n_channels, random_state=rs, class_sep=1., class_disp=.2,
+        n_jobs=-1
     ),
     make_gaussian_blobs(
         2*n_matrices, n_channels, random_state=rs, class_sep=.5, class_disp=.5,
-        mat_std=.1
+        mat_std=.1, n_jobs=-1
     )
 ]
 n_datasets = len(datasets)

--- a/examples/simulated/plot_toy_classification.py
+++ b/examples/simulated/plot_toy_classification.py
@@ -45,7 +45,8 @@ for delta in deltas_array:
                                n_dim=n_dim,
                                class_sep=delta,
                                class_disp=sigma,
-                               random_state=random_state)
+                               random_state=random_state,
+                               n_jobs=-1)
 
     # which classifier to consider
     clf = MDM()

--- a/examples/simulated/plot_toy_classification.py
+++ b/examples/simulated/plot_toy_classification.py
@@ -46,7 +46,7 @@ for delta in deltas_array:
                                class_sep=delta,
                                class_disp=sigma,
                                random_state=random_state,
-                               n_jobs=-1)
+                               n_jobs=4)
 
     # which classifier to consider
     clf = MDM()

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -33,7 +33,7 @@ def _pdf_r(r, sigma):
         raise ValueError(f'sigma must be a positive number (Got {sigma})')
 
     n_dim = len(r)
-    partial_1 = -np.sum(r**2) / sigma**2
+    partial_1 = -np.sum(r**2) / (2 * sigma**2)
     partial_2 = 0
     for i in range(n_dim):
         for j in range(i + 1, n_dim):

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -130,7 +130,7 @@ def _slice_sampling(ptarget, n_samples, x0, n_burnin=20, thin=10,
         expect the whole sampling procedure to take longer.
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
-    n_jobs : int, (default: 1)
+    n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 
@@ -151,20 +151,12 @@ def _slice_sampling(ptarget, n_samples, x0, n_burnin=20, thin=10,
 
     rs = check_random_state(random_state)
     w = 1.0  # initial bracket width
-    # xt = np.copy(x0)
 
-    # n_dim = len(x0)
     n_samples_total = (n_samples + n_burnin) * thin
 
-    # TODO, move loop
-    if n_jobs == 1:
-        samples = []
-        for _ in range(n_samples_total):
-            samples.append(_slice_one_sample(ptarget, x0, w, rs))
-    else:
-        samples = Parallel(n_jobs=n_jobs)(
-            delayed(_slice_one_sample)(ptarget, x0, w, rs)
-            for _ in range(n_samples_total))
+    samples = Parallel(n_jobs=n_jobs)(
+        delayed(_slice_one_sample)(ptarget, x0, w, rs)
+        for _ in range(n_samples_total))
 
     samples = np.array(samples)[(n_burnin * thin):][::thin]
 
@@ -189,7 +181,7 @@ def _sample_parameter_r(n_samples, n_dim, sigma, random_state=None, n_jobs=1):
         Dispersion of the Riemannian Gaussian distribution.
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
-    n_jobs : int, (default: 1)
+    n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 
@@ -265,7 +257,7 @@ def _sample_gaussian_spd_centered(
         Dispersion of the Riemannian Gaussian distribution.
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
-    n_jobs : int, (default: 1)
+    n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 
@@ -325,7 +317,7 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None, n_jobs=1):
         Dispersion of the Riemannian Gaussian distribution.
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
-    n_jobs : int, (default: 1)
+    n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -101,7 +101,7 @@ def _slice_one_sample(ptarget, x0, w, rs):
 
 
 def _slice_sampling(ptarget, n_samples, x0, n_burnin=20, thin=10,
-                     random_state=None, n_jobs=1):
+                    random_state=None, n_jobs=1):
     """Slice sampling procedure.
 
     Implementation of a slice sampling algorithm for sampling from any target

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -53,8 +53,8 @@ def _slice_one_sample(ptarget, x0, w, rs):
         Initial state for the MCMC procedure. Note that the shape of this array
         defines the dimensionality n_dim of the data points to be sampled.
     w : float
-        Initial bracket width
-    rs : int, RandomState instance or None (default: None)
+        Initial bracket width.
+    rs : int, RandomState instance or None
         Pass an int for reproducible output across multiple function calls.
 
     """

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -57,6 +57,10 @@ def _slice_one_sample(ptarget, x0, w, rs):
     rs : int, RandomState instance or None
         Pass an int for reproducible output across multiple function calls.
 
+    Returns
+    -------
+    sample : ndarray, shape (n_dim,)
+        Sample from the target pdf.
     """
     xt = np.copy(x0)
     n_dim = len(x0)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -347,12 +347,14 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None, n_jobs=1):
     """
 
     n_dim = mean.shape[0]
+    # dispersion is corrected w.r.t. dimension
     samples_centered = _sample_gaussian_spd_centered(
         n_matrices=n_matrices,
         n_dim=n_dim,
-        sigma=sigma,
+        sigma=sigma / np.sqrt(n_dim),
         random_state=random_state,
-        n_jobs=n_jobs)
+        n_jobs=n_jobs,
+    )
 
     # apply the parallel transport to mean on each of the samples
     mean_sqrt = sqrtm(mean)

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -105,7 +105,7 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         Mean of random values to generate matrices.
     mat_std : float, default=1.0
         Standard deviation of random values to generate matrices.
-    n_jobs : int, (default: 1)
+    n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -70,7 +70,7 @@ def make_masks(n_masks, n_dim0, n_dim1_min, rs):
         Masks.
     """
     masks = []
-    for i in range(n_masks):
+    for _ in range(n_masks):
         n_dim1 = rs.randint(n_dim1_min, n_dim0, size=1)[0]
         mask, _ = np.linalg.qr(rs.randn(n_dim0, n_dim1))
         masks.append(mask)
@@ -79,7 +79,7 @@ def make_masks(n_masks, n_dim0, n_dim1_min, rs):
 
 def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
                         return_centers=False, random_state=None, *,
-                        mat_mean=.0, mat_std=1.):
+                        mat_mean=.0, mat_std=1., n_jobs=1):
     """Generate SPD dataset with two classes sampled from Riemannian Gaussian.
 
     Generate a dataset with SPD matrices drawn from two Riemannian Gaussian
@@ -105,6 +105,9 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         Mean of random values to generate matrices.
     mat_std : float, default=1.0
         Standard deviation of random values to generate matrices.
+    n_jobs : int, (default: 1)
+        The number of jobs to use for the computation. This works by computing
+        each of the class centroid in parallel. If -1 all CPUs are used.
 
     Returns
     -------
@@ -136,8 +139,8 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         n_matrices=n_matrices,
         mean=C0,
         sigma=class_disp,
-        random_state=random_state
-    )
+        random_state=random_state,
+        n_jobs=n_jobs)
     y0 = np.zeros(n_matrices)
 
     # generate dataset for class 1
@@ -147,8 +150,8 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         n_matrices=n_matrices,
         mean=C1,
         sigma=class_disp,
-        random_state=random_state
-    )
+        random_state=random_state,
+        n_jobs=n_jobs)
     y1 = np.ones(n_matrices)
 
     X = np.concatenate([X0, X1])

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -7,11 +7,14 @@ from pyriemann.utils.distance import distance_riemann
 from pyriemann.utils.test import is_sym_pos_def as is_spd
 
 
-def test_sample_gaussian_spd():
+@pytest.mark.parametrize("n_jobs", [1, -1])
+def test_sample_gaussian_spd(n_jobs):
     """Test Riemannian Gaussian sampling."""
-    n_matrices, n_dim, sigma = 50, 16, 2.
+    n_matrices, n_dim, sigma = 10, 8, 1.
     mean = np.eye(n_dim)
-    X = sample_gaussian_spd(n_matrices, mean, sigma, random_state=42)
+    X = sample_gaussian_spd(
+        n_matrices, mean, sigma, random_state=42, n_jobs=n_jobs
+        )
     assert X.shape == (n_matrices, n_dim, n_dim)  # X shape mismatch
     assert is_spd(X)  # X is an array of SPD matrices
 
@@ -24,12 +27,17 @@ def test_generate_random_spd_matrix():
     assert is_spd(X)  # X is a SPD matrix
 
 
-def test_sigma_gaussian_spd():
+@pytest.mark.parametrize("n_jobs", [1, -1])
+def test_sigma_gaussian_spd(n_jobs):
     """Test sigma parameter from Riemannian Gaussian sampling."""
-    n_matrices, n_dim, sig_1, sig_2 = 50, 8, 1., 2.
+    n_matrices, n_dim, sig_1, sig_2 = 10, 8, 1., 2.
     mean = np.eye(n_dim)
-    X1 = sample_gaussian_spd(n_matrices, mean, sig_1, random_state=42)
-    X2 = sample_gaussian_spd(n_matrices, mean, sig_2, random_state=66)
+    X1 = sample_gaussian_spd(
+        n_matrices, mean, sig_1, random_state=42, n_jobs=n_jobs
+        )
+    X2 = sample_gaussian_spd(
+        n_matrices, mean, sig_2, random_state=66, n_jobs=n_jobs
+        )
     avg_d1 = np.mean([distance_riemann(X1_i, mean) for X1_i in X1])
     avg_d2 = np.mean([distance_riemann(X2_i, mean) for X2_i in X2])
     assert avg_d1 < avg_d2


### PR DESCRIPTION
`make_gaussian_blobs` is a really nice addition to pyRiemann, but it is computationally expensive. The complexity depends mainly on the number of matrices to generate. The sampling code is a loop that generate one matrix at each iteration. As the samples are indenpendent, we could easily parallelize the process to reduce computation time. This is the object of this PR.

NB: this could reduce a lot the doc building time:
```
computation time summary:
    - ../examples/simulated/plot_classifier_comparison.py:                235.60 sec   0.0 MB
    - ../examples/stats/plot_oneWay_Manova.py:                             67.49 sec   0.0 MB
    - ../examples/artifacts/plot_detect_riemannian_potato_field_EEG.py:    49.95 sec   0.0 MB
    - ../examples/artifacts/plot_detect_riemannian_potato_EEG.py:          37.31 sec   0.0 MB
    - ../examples/simulated/plot_toy_classification.py:                    15.94 sec   0.0 MB
    - ../examples/ERP/plot_classify_MEG_mdm.py:                            11.12 sec   0.0 MB
    - ../examples/ERP/plot_embedding_MEG.py:                               11.03 sec   0.0 MB
...
```