### PR TITLE
Remove check and processing from __init__

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -210,7 +210,7 @@ Kernels
     kernel_euclid
     kernel_logeuclid
 
-Mean
+Means
 ~~~~~~~~~~~~~~~~~~~~~~
 .. _mean_api:
 .. currentmodule:: pyriemann.utils.mean
@@ -232,7 +232,7 @@ Mean
     maskedmean_riemann
     nanmean_riemann
 
-Geodesic
+Geodesics
 ~~~~~~~~~~~~~~~~~~~~~~
 .. _geodesic_api:
 .. currentmodule:: pyriemann.utils.geodesic
@@ -282,9 +282,9 @@ Aproximate Joint Diagonalization
     ajd_pham
     uwedge
 
-Matrix Test
+Matrix Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. _test_api:
+.. _mat_test_api:
 .. currentmodule:: pyriemann.utils.test
 
 .. autosummary::

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -138,10 +138,6 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         self.estimator = estimator
         self.svd = svd
 
-        if svd is not None:
-            if not isinstance(svd, int):
-                raise TypeError('svd must be None or int')
-
     def fit(self, X, y):
         """Fit.
 
@@ -159,6 +155,9 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         self : ERPCovariances instance
             The ERPCovariances instance.
         """
+        if self.svd is not None:
+            if not isinstance(self.svd, int):
+                raise TypeError('svd must be None or int')
         if self.classes is not None:
             classes = self.classes
         else:

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -7,7 +7,7 @@ from sklearn.svm import SVR as sklearnSVR
 from sklearn.utils.extmath import softmax
 
 from .utils.kernel import kernel
-from .classification import MDM
+from .classification import MDM, _check_metric
 from .utils.mean import mean_covariance
 
 
@@ -181,7 +181,6 @@ class KNearestNeighborRegressor(MDM):
 
     def __init__(self, n_neighbors=5, metric='riemann'):
         """Init."""
-        # store params for cloning purpose
         self.n_neighbors = n_neighbors
         super().__init__(metric=metric)
 
@@ -200,6 +199,7 @@ class KNearestNeighborRegressor(MDM):
         self : KNearestNeighborRegressor instance
             The KNearestNeighborRegressor instance.
         """
+        self.metric_mean, self.metric_dist = _check_metric(self.metric)
         self.values_ = y
         self.covmeans_ = X
 

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -177,12 +177,8 @@ class BilinearFilter(BaseEstimator, TransformerMixin):
 
     def __init__(self, filters, log=False):
         """Init."""
-        if not isinstance(filters, np.ndarray):
-            raise TypeError('filters must be an array.')
         self.filters_ = filters
         self.filters = filters
-        if not isinstance(log, bool):
-            raise TypeError('log must be a boolean')
         self.log = log
 
     def fit(self, X, y):
@@ -200,6 +196,10 @@ class BilinearFilter(BaseEstimator, TransformerMixin):
         self : BilinearFilter instance
             The BilinearFilter instance.
         """
+        if not isinstance(self.filters, np.ndarray):
+            raise TypeError('filters must be an array.')
+        if not isinstance(self.log, bool):
+            raise TypeError('log must be a boolean')
         self.filters_ = self.filters
         return self
 
@@ -290,13 +290,8 @@ class CSP(BilinearFilter):
 
     def __init__(self, nfilter=4, metric='euclid', log=True):
         """Init."""
-        if not isinstance(nfilter, int):
-            raise TypeError('nfilter must be an integer')
         self.nfilter = nfilter
-        _check_mean_method(metric)
         self.metric = metric
-        if not isinstance(log, bool):
-            raise TypeError('log must be a boolean')
         self.log = log
 
     def fit(self, X, y):
@@ -314,6 +309,12 @@ class CSP(BilinearFilter):
         self : CSP instance
             The CSP instance.
         """
+        if not isinstance(self.nfilter, int):
+            raise TypeError('nfilter must be an integer')
+        _check_mean_method(self.metric)
+        if not isinstance(self.log, bool):
+            raise TypeError('log must be a boolean')
+
         if not isinstance(X, (np.ndarray, list)):
             raise TypeError('X must be an array.')
         if not isinstance(y, (np.ndarray, list)):

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -5,7 +5,7 @@ import numpy as np
 from .utils.utils import check_version
 from .utils.distance import distance, pairwise_distance
 from .utils.mean import mean_covariance
-from .classification import MDM
+from .classification import MDM, _check_metric
 
 if check_version('sklearn', '0.18'):
     from sklearn.model_selection import cross_val_score
@@ -365,6 +365,9 @@ class PermutationDistance(BasePermutation):
     def __init_transform(self, X):
         """Init tr"""
         self.mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
+        self.mdm.metric_mean, self.mdm.metric_dist = _check_metric(
+            self.metric
+        )
         if self.mode == 'ftest':
             self.global_mean = mean_covariance(X, metric=self.mdm.metric_mean)
         elif self.mode == 'pairwise':

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -303,6 +303,7 @@ def test_svc_kernel_callable(get_covmats, get_labels, metric):
     pickle.dumps(rsvc)
     pickle.dumps(rsvc_1)
 
+
 @pytest.mark.parametrize("method_label", ["sum_means", "inf_means"])
 def test_meanfield(get_covmats, get_labels, method_label):
     n_matrices, n_channels, n_classes = 6, 3, 2

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -194,10 +194,13 @@ def test_tsclassifier_fit(get_covmats, get_labels):
     clf.fit(covmats, labels).predict(covmats)
 
 
-def test_tsclassifier_init_error():
+def test_tsclassifier_clf_error(get_covmats, get_labels):
     """Test TS if not Classifier"""
+    n_matrices, n_channels, n_classes = 6, 3, 2
+    covmats = get_covmats(n_matrices, n_channels)
+    labels = get_labels(n_matrices, n_classes)
     with pytest.raises(TypeError):
-        TSclassifier(clf=Covariances())
+        TSclassifier(clf=Covariances()).fit(covmats, labels)
 
 
 def test_svc_params():
@@ -299,3 +302,16 @@ def test_svc_kernel_callable(get_covmats, get_labels, metric):
     # check if pickleable
     pickle.dumps(rsvc)
     pickle.dumps(rsvc_1)
+
+@pytest.mark.parametrize("method_label", ["sum_means", "inf_means"])
+def test_meanfield(get_covmats, get_labels, method_label):
+    n_matrices, n_channels, n_classes = 6, 3, 2
+    covmats = get_covmats(n_matrices, n_channels)
+    labels = get_labels(n_matrices, n_classes)
+    mf = MeanField(method_label=method_label).fit(covmats, labels)
+    pred = mf.predict(covmats)
+    assert pred.shape == (n_matrices,)
+    proba = mf.predict_proba(covmats)
+    assert proba.shape == (n_matrices, n_classes)
+    transf = mf.transform(covmats)
+    assert transf.shape == (n_matrices, n_classes)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -80,10 +80,13 @@ def test_erp_covariances_classes(rndstate, get_labels):
     assert is_spsd(covmats)
 
 
-def test_erp_covariances_svd_error(rndstate):
-    # assert raise svd
+def test_erp_covariances_svd_error(rndstate, get_labels):
+    """ assert raise svd """
+    n_matrices, n_channels, n_times, n_classes = 4, 3, 50, 2
+    x = rndstate.randn(n_matrices, n_channels, n_times)
+    labels = get_labels(n_matrices, n_classes)
     with pytest.raises(TypeError):
-        ERPCovariances(svd="42")
+        ERPCovariances(svd="42").fit(x, labels)
 
 
 @pytest.mark.parametrize("est", estim)

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -134,7 +134,7 @@ class TestSpatialFilters(SpatialFiltersTestCase):
         sf.fit(X_new, labels)
 
 
-def test_Xdawn_baselinecov(rndstate, get_labels):
+def test_xdawn_baselinecov(rndstate, get_labels):
     """Test cov precomputation"""
     n_matrices, n_channels, n_times = 6, 5, 100
     n_classes, default_nfilter = 2, 4
@@ -151,7 +151,7 @@ def test_Xdawn_baselinecov(rndstate, get_labels):
 @pytest.mark.parametrize("nfilter", [3, 4])
 @pytest.mark.parametrize("metric", get_metrics())
 @pytest.mark.parametrize("log", [True, False])
-def test_CSP_init(nfilter, metric, log, get_covmats, get_labels):
+def test_csp_init(nfilter, metric, log, get_covmats, get_labels):
     n_classes, n_matrices, n_channels = 2, 6, 3
     covmats = get_covmats(n_matrices, n_channels)
     labels = get_labels(n_matrices, n_classes)
@@ -166,18 +166,24 @@ def test_CSP_init(nfilter, metric, log, get_covmats, get_labels):
     assert csp.patterns_.shape == (n_channels, n_channels)
 
 
-def test_BilinearFilter_filter_error():
+def test_bilinearfilter_filter_error(get_covmats, get_labels):
+    n_classes, n_matrices, n_channels = 2, 6, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    labels = get_labels(n_matrices, n_classes)
     with pytest.raises(TypeError):
-        BilinearFilter("foo")
+        BilinearFilter("foo").fit(covmats, labels)
 
 
-def test_BilinearFilter_log_error():
+def test_bilinearfilter_log_error(get_covmats, get_labels):
+    n_classes, n_matrices, n_channels = 2, 6, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    labels = get_labels(n_matrices, n_classes)
     with pytest.raises(TypeError):
-        BilinearFilter(np.eye(3), log="foo")
+        BilinearFilter(np.eye(3), log="foo").fit(covmats, labels)
 
 
 @pytest.mark.parametrize("log", [True, False])
-def test_BilinearFilter_log(log, get_covmats, get_labels):
+def test_bilinearfilter_log(log, get_covmats, get_labels):
     n_classes, n_matrices, n_channels = 2, 6, 3
     covmats = get_covmats(n_matrices, n_channels)
     labels = get_labels(n_matrices, n_classes)
@@ -189,7 +195,7 @@ def test_BilinearFilter_log(log, get_covmats, get_labels):
         assert Xtr.shape == (n_matrices, n_channels, n_channels)
 
 
-def test_AJDC_init():
+def test_ajdc_init():
     ajdc = AJDC(fmin=1, fmax=32, fs=64)
     assert ajdc.window == 128
     assert ajdc.overlap == 0.5
@@ -197,7 +203,7 @@ def test_AJDC_init():
     assert ajdc.verbose
 
 
-def test_AJDC_fit(rndstate):
+def test_ajdc_fit(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
@@ -205,7 +211,7 @@ def test_AJDC_fit(rndstate):
     assert ajdc.backward_filters_.shape == (n_channels, ajdc.n_sources_)
 
 
-def test_AJDC_fit_error(rndstate):
+def test_ajdc_fit_error(rndstate):
     n_conditions, n_channels, n_times = 3, 8, 512
     ajdc = AJDC()
     with pytest.raises(ValueError):  # unequal # of conditions
@@ -224,7 +230,7 @@ def test_AJDC_fit_error(rndstate):
         )
 
 
-def test_AJDC_transform_error(rndstate):
+def test_ajdc_transform_error(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
@@ -236,7 +242,7 @@ def test_AJDC_transform_error(rndstate):
         ajdc.transform(rndstate.randn(n_matrices, n_channels + 1, 1))
 
 
-def test_AJDC_fit_variable_input(rndstate):
+def test_ajdc_fit_variable_input(rndstate):
     n_subjects, n_cond, n_chan, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_cond, n_chan, n_times)
     ajdc = AJDC()
@@ -257,7 +263,7 @@ def test_AJDC_fit_variable_input(rndstate):
     ajdc.fit(X)
 
 
-def test_AJDC_inverse_transform(rndstate):
+def test_ajdc_inverse_transform(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
     ajdc = AJDC().fit(X)
@@ -278,7 +284,7 @@ def test_AJDC_inverse_transform(rndstate):
         ajdc.inverse_transform(Xt, supp=1)
 
 
-def test_AJDC_expl_var(rndstate):
+def test_ajdc_expl_var(rndstate):
     # Test get_src_expl_var
     n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)


### PR DESCRIPTION
Many `__init__` contain check and processing of input parameters.

For example, `MyClassifier.set_params('metric': metric)` does not change the metric used for classification.

These checks have been moved into `fit()`. Tests have been updated.