### PR TITLE
Update classifier comparison, adding different metrics and computational times

### DIFF
--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -260,8 +260,7 @@ plot_classifiers("euclid")
 ###############################################################################
 # References
 # ----------
-# .. [1] https://scikit-learn.org/stable/auto_examples/classification/\
-#    plot_classifier_comparison.html
+# .. [1] https://scikit-learn.org/stable/auto_examples/classification/plot_classifier_comparison.html  # noqa
 # .. [2] S. Chevallier, E. Kalunga, Q. Barthélemy and E. Monacelli. "Review of
 #    Riemannian distances and divergences, applied to SSVEP-based BCI",
 #    Neuroinformatics, 2021

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -28,7 +28,12 @@ from matplotlib.colors import ListedColormap
 from sklearn.model_selection import train_test_split
 
 from pyriemann.datasets import make_covariances, make_gaussian_blobs
-from pyriemann.classification import MDM, KNearestNeighbor, SVC, MeanField
+from pyriemann.classification import (
+    MDM,
+    KNearestNeighbor,
+    SVC,
+    MeanField,
+)
 
 
 ###############################################################################
@@ -171,6 +176,7 @@ def plot_classifiers(metric):
 
     plt.show()
 
+
 ###############################################################################
 # Classifiers and Datasets
 # ------------------------
@@ -179,13 +185,13 @@ names = [
     "MDM",
     "k-NN",
     "SVC",
-    "MeanField"
+    "MeanField",
 ]
 classifiers = [
     MDM(),
     KNearestNeighbor(n_neighbors=3),
     SVC(probability=True),
-    MeanField(power_list=[-1, -0.25, 0, 0.25, 1])
+    MeanField(power_list=[-1, -0.25, 0, 0.25, 1]),
 ]
 n_classifs = len(classifiers)
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -3,10 +3,10 @@
 Classifier comparison
 ===============================================================================
 
-A comparison of several Riemannian classifiers on low-dimensional synthetic
-datasets, adapted to SPD matrices from [1]_.
+A comparison of several classifiers on low-dimensional synthetic datasets,
+adapted to SPD matrices from [1]_.
 The point of this example is to illustrate the nature of decision boundaries
-of different classifiers.
+of different classifiers, used with different metrics [2]_.
 This should be taken with a grain of salt, as the intuition conveyed by
 these examples does not necessarily carry over to real datasets.
 
@@ -20,6 +20,7 @@ set.
 # License: BSD (3-clause)
 
 from functools import partial
+from time import time
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -41,11 +42,142 @@ def get_proba(cov_00, cov_01, cov_11, clf):
         return clf.predict_proba(cov[np.newaxis, ...])[0, 1]
 
 
+def plot_classifiers(metric):
+    figure = plt.figure(figsize=(12, 10))
+    figure.suptitle(f"Compare classifiers with metric='{metric}'", fontsize=16)
+    i = 1
+
+    # iterate over datasets
+    for ds_cnt, (X, y) in enumerate(datasets):
+        # split dataset into training and test part
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.4, random_state=42
+        )
+
+        x_min, x_max = X[:, 0, 0].min(), X[:, 0, 0].max()
+        y_min, y_max = X[:, 0, 1].min(), X[:, 0, 1].max()
+        z_min, z_max = X[:, 1, 1].min(), X[:, 1, 1].max()
+
+        # just plot the dataset first
+        ax = plt.subplot(n_datasets, n_classifs + 1, i, projection='3d')
+        if ds_cnt == 0:
+            ax.set_title("Input data")
+        # Plot the training points
+        ax.scatter(
+            X_train[:, 0, 0],
+            X_train[:, 0, 1],
+            X_train[:, 1, 1],
+            c=y_train,
+            cmap=cm_bright,
+            edgecolors="k"
+        )
+        # Plot the testing points
+        ax.scatter(
+            X_test[:, 0, 0],
+            X_test[:, 0, 1],
+            X_test[:, 1, 1],
+            c=y_test,
+            cmap=cm_bright,
+            alpha=0.6,
+            edgecolors="k"
+        )
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        ax.set_zlim(z_min, z_max)
+        ax.set_xticklabels(())
+        ax.set_yticklabels(())
+        ax.set_zticklabels(())
+        i += 1
+
+        rx = np.arange(x_min, x_max, (x_max - x_min) / 50)
+        ry = np.arange(y_min, y_max, (y_max - y_min) / 50)
+        rz = np.arange(z_min, z_max, (z_max - z_min) / 50)
+
+        print(f"Dataset n°{ds_cnt+1}")
+
+        # iterate over classifiers
+        for name, clf in zip(names, classifiers):
+            ax = plt.subplot(n_datasets, n_classifs + 1, i, projection='3d')
+
+            clf.set_params(**{'metric': metric})
+            t0 = time()
+            clf.fit(X_train, y_train)
+            t1 = time() - t0
+
+            t0 = time()
+            score = clf.score(X_test, y_test)
+            t2 = time() - t0
+
+            print(
+                f" {name}:\n  training time={t1:.5f}\n  test time    ={t2:.5f}"
+            )
+
+            # Plot the decision boundaries for horizontal 2D planes going
+            # through the mean value of the third coordinates
+            xx, yy = np.meshgrid(rx, ry)
+            zz = get_proba(xx, yy, X[:, 1, 1].mean()*np.ones_like(xx), clf=clf)
+            zz = np.ma.masked_where(~np.isfinite(zz), zz)
+            ax.contourf(xx, yy, zz, zdir='z', offset=z_min, cmap=cm, alpha=0.5)
+
+            xx, zz = np.meshgrid(rx, rz)
+            yy = get_proba(xx, X[:, 0, 1].mean()*np.ones_like(xx), zz, clf=clf)
+            yy = np.ma.masked_where(~np.isfinite(yy), yy)
+            ax.contourf(xx, yy, zz, zdir='y', offset=y_max, cmap=cm, alpha=0.5)
+
+            yy, zz = np.meshgrid(ry, rz)
+            xx = get_proba(X[:, 0, 0].mean()*np.ones_like(yy), yy, zz, clf=clf)
+            xx = np.ma.masked_where(~np.isfinite(xx), xx)
+            ax.contourf(xx, yy, zz, zdir='x', offset=x_min, cmap=cm, alpha=0.5)
+
+            # Plot the training points
+            ax.scatter(
+                X_train[:, 0, 0],
+                X_train[:, 0, 1],
+                X_train[:, 1, 1],
+                c=y_train,
+                cmap=cm_bright,
+                edgecolors="k"
+            )
+            # Plot the testing points
+            ax.scatter(
+                X_test[:, 0, 0],
+                X_test[:, 0, 1],
+                X_test[:, 1, 1],
+                c=y_test,
+                cmap=cm_bright,
+                edgecolors="k",
+                alpha=0.6
+            )
+
+            if ds_cnt == 0:
+                ax.set_title(name)
+            ax.text(
+                1.3 * x_max,
+                y_min,
+                z_min,
+                ("%.2f" % score).lstrip("0"),
+                size=15,
+                horizontalalignment="right",
+                verticalalignment="bottom"
+            )
+            ax.set_xlim(x_min, x_max)
+            ax.set_ylim(y_min, y_max)
+            ax.set_zlim(z_min, z_max)
+            ax.set_xticks(())
+            ax.set_yticks(())
+            ax.set_zticks(())
+
+            i += 1
+
+    plt.show()
+
 ###############################################################################
+# Classifiers and Datasets
+# ------------------------
 
 names = [
     "MDM",
-    "Nearest Neighbors",
+    "k-NN",
     "SVC",
     "MeanField"
 ]
@@ -99,119 +231,24 @@ cm_bright = ListedColormap(["#FF0000", "#0000FF"])
 
 
 ###############################################################################
+# Classifiers with Riemannian metric
+# ----------------------------------
 
-figure = plt.figure(figsize=(15, 10))
-i = 1
-# iterate over datasets
-for ds_cnt, (X, y) in enumerate(datasets):
-    # split dataset into training and test part
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.4, random_state=42
-    )
+plot_classifiers("riemann")
 
-    x_min, x_max = X[:, 0, 0].min(), X[:, 0, 0].max()
-    y_min, y_max = X[:, 0, 1].min(), X[:, 0, 1].max()
-    z_min, z_max = X[:, 1, 1].min(), X[:, 1, 1].max()
 
-    # just plot the dataset first
-    ax = plt.subplot(n_datasets, n_classifs + 1, i, projection='3d')
-    if ds_cnt == 0:
-        ax.set_title("Input data")
-    # Plot the training points
-    ax.scatter(
-        X_train[:, 0, 0],
-        X_train[:, 0, 1],
-        X_train[:, 1, 1],
-        c=y_train,
-        cmap=cm_bright,
-        edgecolors="k"
-    )
-    # Plot the testing points
-    ax.scatter(
-        X_test[:, 0, 0],
-        X_test[:, 0, 1],
-        X_test[:, 1, 1],
-        c=y_test,
-        cmap=cm_bright,
-        alpha=0.6,
-        edgecolors="k"
-    )
-    ax.set_xlim(x_min, x_max)
-    ax.set_ylim(y_min, y_max)
-    ax.set_zlim(z_min, z_max)
-    ax.set_xticklabels(())
-    ax.set_yticklabels(())
-    ax.set_zticklabels(())
-    i += 1
+###############################################################################
+# Classifiers with Log-Euclidean metric
+# -------------------------------------
 
-    rx = np.arange(x_min, x_max, (x_max - x_min) / 50)
-    ry = np.arange(y_min, y_max, (y_max - y_min) / 50)
-    rz = np.arange(z_min, z_max, (z_max - z_min) / 50)
+plot_classifiers("logeuclid")
 
-    # iterate over classifiers
-    for name, clf in zip(names, classifiers):
-        ax = plt.subplot(n_datasets, n_classifs + 1, i, projection='3d')
-        clf.fit(X_train, y_train)
-        score = clf.score(X_test, y_test)
 
-        # Plot the decision boundaries for horizontal 2D planes going through
-        # the mean value of the third coordinates
-        xx, yy = np.meshgrid(rx, ry)
-        zz = get_proba(xx, yy, X[:, 1, 1].mean() * np.ones_like(xx), clf=clf)
-        zz = np.ma.masked_where(~np.isfinite(zz), zz)
-        ax.contourf(xx, yy, zz, zdir='z', offset=z_min, cmap=cm, alpha=0.5)
+###############################################################################
+# Classifiers with Euclidean metric
+# ---------------------------------
 
-        xx, zz = np.meshgrid(rx, rz)
-        yy = get_proba(xx, X[:, 0, 1].mean() * np.ones_like(xx), zz, clf=clf)
-        yy = np.ma.masked_where(~np.isfinite(yy), yy)
-        ax.contourf(xx, yy, zz, zdir='y', offset=y_max, cmap=cm, alpha=0.5)
-
-        yy, zz = np.meshgrid(ry, rz)
-        xx = get_proba(X[:, 0, 0].mean() * np.ones_like(yy), yy, zz, clf=clf)
-        xx = np.ma.masked_where(~np.isfinite(xx), xx)
-        ax.contourf(xx, yy, zz, zdir='x', offset=x_min, cmap=cm, alpha=0.5)
-
-        # Plot the training points
-        ax.scatter(
-            X_train[:, 0, 0],
-            X_train[:, 0, 1],
-            X_train[:, 1, 1],
-            c=y_train,
-            cmap=cm_bright,
-            edgecolors="k"
-        )
-        # Plot the testing points
-        ax.scatter(
-            X_test[:, 0, 0],
-            X_test[:, 0, 1],
-            X_test[:, 1, 1],
-            c=y_test,
-            cmap=cm_bright,
-            edgecolors="k",
-            alpha=0.6
-        )
-
-        if ds_cnt == 0:
-            ax.set_title(name)
-        ax.text(
-            1.3 * x_max,
-            y_min,
-            z_min,
-            ("%.2f" % score).lstrip("0"),
-            size=15,
-            horizontalalignment="right",
-            verticalalignment="bottom"
-        )
-        ax.set_xlim(x_min, x_max)
-        ax.set_ylim(y_min, y_max)
-        ax.set_zlim(z_min, z_max)
-        ax.set_xticks(())
-        ax.set_yticks(())
-        ax.set_zticks(())
-
-        i += 1
-
-plt.show()
+plot_classifiers("euclid")
 
 
 ###############################################################################
@@ -219,3 +256,6 @@ plt.show()
 # ----------
 # .. [1] https://scikit-learn.org/stable/auto_examples/classification/\
 #    plot_classifier_comparison.html
+# .. [2] S. Chevallier, E. Kalunga, Q. Barthélemy and E. Monacelli. "Review of
+#    Riemannian distances and divergences, applied to SSVEP-based BCI",
+#    Neuroinformatics, 2021


### PR DESCRIPTION
This PR updates the example on classifier comparison:
- classifiers are compared for `riemann`, `logeuclid` and `euclid` metrics;
- training and test times are printed.

Related to #52.