### PR TITLE
Clean and complete tests

### DIFF
--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -691,9 +691,8 @@ class Shrinkage(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    .. [1] https://scikit-learn.org/stable/modules/generated/sklearn. \
-        covariance.shrunk_covariance.html
-    """
+    .. [1] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.shrunk_covariance.html
+    """  # noqa
 
     def __init__(self, shrinkage=0.1):
         """Init."""

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -98,7 +98,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
         if Cx is None:
             # FIXME : too many reshape operation
             tmp = X.transpose((1, 2, 0))
-            Cx = np.matrix(self.estimator_fn(
+            Cx = np.asarray(self.estimator_fn(
                 tmp.reshape(n_channels, n_times * n_trials)
             ))
 
@@ -110,7 +110,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
             P = np.mean(X[y == c, :, :], axis=0)
 
             # Covariance matrix of the prototyper response & signal
-            C = np.matrix(self.estimator_fn(P))
+            C = np.asarray(self.estimator_fn(P))
 
             # Spatial filters
             evals, evecs = eigh(C, Cx)

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -428,7 +428,7 @@ class PermutationDistance(BasePermutation):
         pattern = np.zeros((n_samples, n_samples))
         for classe in classes:
             ix = (y == classe)
-            pattern += (np.outer(ix, ix) / np.float(ix.sum()))
+            pattern += (np.outer(ix, ix) / ix.sum())
 
         within_ss = (X * pattern).sum() / 2
 

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -73,7 +73,7 @@ def distance_kullback(A, B):
     """
     n, _ = A.shape
     logdet = np.log(np.linalg.det(B) / np.linalg.det(A))
-    kl = np.trace(np.dot(np.linalg.inv(B), A)) - n + logdet
+    kl = np.trace(np.linalg.inv(B) @ A) - n + logdet
     return 0.5 * kl
 
 
@@ -176,7 +176,7 @@ def distance_wasserstein(A, B):
     Compute the Wasserstein distance between two SPD matrices A and B:
 
     .. math::
-        d(A,B) = \sqrt{ \text{tr}(A + B - 2(A^{1/2}BA^{1/2})^{1/2}) }
+        d(A,B) = \sqrt{ \text{tr}(A + B - 2(B^{1/2} A B^{1/2})^{1/2}) }
 
     Parameters
     ----------

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -241,12 +241,18 @@ def test_coherences(coh, rndstate):
     x = rndstate.randn(n_matrices, n_channels, n_times)
 
     cov = Coherences(coh=coh)
+    assert cov.get_params() == dict(
+        window=128, overlap=0.75, fs=None, fmin=None, fmax=None, coh=coh
+    )
+
+    if coh == 'lagged':
+        cov.set_params(**{'fs' : 128, 'fmin': 1, 'fmax': 63})
+        n_freqs = 63
+    else:
+        n_freqs = 65
+
     cov.fit(x)
     covmats = cov.fit_transform(x)
-    assert cov.get_params() == dict(
-        window=128, overlap=0.75, fmin=None, fmax=None, fs=None, coh=coh
-    )
-    n_freqs = 65
     assert covmats.shape == (n_matrices, n_channels, n_channels, n_freqs)
     if coh in ["ordinary", "instantaneous"]:
         assert is_spsd(covmats.transpose(0, 3, 1, 2))

--- a/tests/test_utils_base.py
+++ b/tests/test_utils_base.py
@@ -46,5 +46,6 @@ def test_check_raise():
     C = 2*np.ones((10, 3, 3))
     # This is an indirect check, the riemannian mean must crash when the
     # matrices are not SPD.
-    with pytest.raises(ValueError):
-        mean_riemann(C)
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError):
+            mean_riemann(C)

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -62,12 +62,44 @@ def test_distance_func_eye(dist):
 
 
 @pytest.mark.parametrize("dist", get_dist_func())
-def test_distance_func_rand(dist, get_covmats):
+def test_distance_func_geodesic(dist, get_covmats):
     n_matrices, n_channels = 2, 6
     covmats = get_covmats(n_matrices, n_channels)
     A, C = covmats[0], covmats[1]
     B = geodesic(A, C, alpha=0.5)
     assert dist(A, B) < dist(A, C)
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_func_separability(dist, get_covmats):
+    n_matrices, n_channels = 1, 6
+    covmats = get_covmats(n_matrices, n_channels)
+    assert dist(covmats[0], covmats[0]) == approx(0, abs=1e-7)
+
+
+@pytest.mark.parametrize(
+    "dist", [
+        distance_euclid,
+        distance_harmonic,
+        distance_logdet,
+        distance_logeuclid,
+        distance_riemann,
+        distance_wasserstein,
+    ]
+)
+def test_distance_func_symmetry(dist, get_covmats):
+    n_matrices, n_channels = 2, 5
+    covmats = get_covmats(n_matrices, n_channels)
+    A, B = covmats[0], covmats[1]
+    assert dist(A, B) == approx(dist(B, A))
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_func_triangle_inequality(dist, get_covmats):
+    n_matrices, n_channels = 3, 4
+    covmats = get_covmats(n_matrices, n_channels)
+    A, B, C = covmats[0], covmats[1], covmats[2]
+    assert dist(A, B) <= dist(A, C) + dist(C, B)
 
 
 def test_distance_logdet_implementation(get_covmats):
@@ -85,6 +117,13 @@ def test_distance_wrapper(dist, dfunc, get_covmats):
     covmats = get_covmats(n_matrices, n_channels)
     A, B = covmats[0], covmats[1]
     assert distance(A, B, metric=dist) == dfunc(A, B)
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_wrapper_between_set_and_matrix(dist, get_covmats):
+    n_matrices, n_channels = 10, 4
+    covmats = get_covmats(n_matrices, n_channels)
+    assert distance(covmats, covmats[-1], metric=dist).shape == (n_matrices, 1)
 
 
 def test_pairwise_distance_matrix(get_covmats):


### PR DESCRIPTION
This PR removes hundreds of warnings during tests:

spatialfilters: replace np.matrix by np.asarray

stats: remove cast by np.float, legacy from Python 2 (this modif removes 180 warnings during tests)

test_utils.distance: add test on function `distance` when applied between a set and a matrix;
add tests for separability, symmetry (excluding divergences) and triangle inequality.

test_utils.covariances: remove warnings raised by lagged coherence, when computed for DC and Nyquist bins.