### PR TITLE
Distance functions able to process ndarray of SPD matrices

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -68,7 +68,7 @@ v0.2.8.dev
 
 - Fix dispersion when generating datasets: :func:`pyriemann.datasets.sample_gaussian_spd`
 
-- Improve base and distance functions to process ndarrays of SPD matrices
+- Enhance base and distance functions, to process ndarrays of SPD matrices
 
 v0.2.7 (June 2021)
 ------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -68,7 +68,7 @@ v0.2.8.dev
 
 - Fix dispersion when generating datasets: :func:`pyriemann.datasets.sample_gaussian_spd`
 
-- Improve base functions to process ndarrays of SPD matrices
+- Improve base and distance functions to process ndarrays of SPD matrices
 
 v0.2.7 (June 2021)
 ------------------

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -191,7 +191,7 @@ classifiers = [
     MDM(),
     KNearestNeighbor(n_neighbors=3),
     SVC(probability=True),
-    MeanField(power_list=[-1, -0.25, 0, 0.25, 1]),
+    MeanField(power_list=[-1, 0, 1]),
 ]
 n_classifs = len(classifiers)
 

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -39,7 +39,7 @@ def distance_euclid(A, B):
     d : ndarray, shape (...,) or float
         Euclidean distance between A and B.
     """
-    return np.linalg.norm(A - B, ord='fro', axis=(-2,-1))
+    return np.linalg.norm(A - B, ord='fro', axis=(-2, -1))
 
 
 def distance_harmonic(A, B):

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -90,7 +90,7 @@ def distance_kullback(A, B):
     """
     n = A.shape[-1]
     tr = np.trace(_recursive(solve, B, A, assume_a='pos'), axis1=-2, axis2=-1)
-    logdet = np.log(np.linalg.det(B) / np.linalg.det(A))
+    logdet = np.linalg.slogdet(B)[1] - np.linalg.slogdet(A)[1]
     return 0.5 * (tr - n + logdet)
 
 

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -54,6 +54,20 @@ def test_check_distance_error():
 
 
 @pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_func_ndarray(dist, get_covmats):
+    n_matrices, n_channels = 5, 3
+    A = get_covmats(n_matrices, n_channels)
+    B = get_covmats(n_matrices, n_channels)
+    assert isinstance(dist(A[0], B[0]), float)  # 2D arrays
+    assert dist(A, B).shape == (n_matrices,)  # 3D arrays
+
+    n_sets = 5
+    C = np.asarray([A for _ in range(n_sets)])
+    D = np.asarray([B for _ in range(n_sets)])
+    assert dist(C, D).shape == (n_sets, n_matrices,)  # 4D arrays
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
 def test_distance_func_eye(dist):
     n_channels = 3
     A = 2 * np.eye(n_channels)
@@ -134,6 +148,11 @@ def test_distance_wrapper_between_set_and_matrix(dist, get_covmats):
     n_matrices, n_channels = 10, 4
     covmats = get_covmats(n_matrices, n_channels)
     assert distance(covmats, covmats[-1], metric=dist).shape == (n_matrices, 1)
+
+    n_sets = 5
+    covs_4d = np.asarray([covmats for _ in range(n_sets)])
+    with pytest.raises(ValueError):
+        distance(covs_4d, covmats, metric=dist)
 
 
 def test_pairwise_distance_matrix(get_covmats):

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -54,6 +54,14 @@ def test_check_distance_error():
 
 
 @pytest.mark.parametrize("dist", get_dist_func())
+def test_distance_error(dist, get_covmats):
+    n_matrices, n_channels = 5, 3
+    A = get_covmats(n_matrices, n_channels)
+    with pytest.raises(ValueError):
+        dist(A, A[0])
+
+
+@pytest.mark.parametrize("dist", get_dist_func())
 def test_distance_func_ndarray(dist, get_covmats):
     n_matrices, n_channels = 5, 3
     A = get_covmats(n_matrices, n_channels)


### PR DESCRIPTION
Using #186, this PR improves distances functions to process ndarray of SPD matrices, and completes tests.

Concerning eigvalsh, [numpy-based eigvalsh](https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvalsh.html) treats `(…, M, M) array` but solves the standard eigenvalue problem, not the generalized one like [scipy-based eigvalsh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eigvalsh.html).

Concerning solve, [numpy-based solve](https://numpy.org/doc/stable/reference/generated/numpy.linalg.solve.html) treats `(…, M, M) array` , but without option `assume_a` like [scipy-based solve](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.solve.html).