### PR TITLE
Speedup for means

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -70,7 +70,7 @@ v0.2.8.dev
 
 - Improve base functions to process ndarrays of SPD matrices
 
-- Enhance means functions, with faster implementations
+- Enhance means functions, with faster implementations and warning when convergence is not reached
 
 v0.2.7 (June 2021)
 ------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -70,6 +70,8 @@ v0.2.8.dev
 
 - Improve base functions to process ndarrays of SPD matrices
 
+- Enhance means functions, with faster implementations
+
 v0.2.7 (June 2021)
 ------------------
 


### PR DESCRIPTION
Using einsum and new base functions #186, this PR accelerates SPD matrix means.
Also, it uses weights when initializing LogDet, Riemannian, Wasserstein means on Euclidean mean.

Comparison on Riemannian (top fig) and LogEuclidean (bottom fig) means before and after PR, repeated 50 times.

![pr_XXX_comp_means_riemann](https://user-images.githubusercontent.com/5346669/178329552-074c35aa-bb3e-4818-85f0-61a02d3db135.png)


![pr_XXX_comp_means_logeuclid](https://user-images.githubusercontent.com/5346669/178329623-fe7f2a94-bc82-4d2c-8657-66d4e5e2f41e.png)

Hoping that this PR fills a little bit of the gap with geomstats f*** fast implementation. @sylvchev @nguigs
https://github.com/nguigs/geomstats/blob/nguigs-pyriemann/notebooks/SPD%20-%20PyRiemann.ipynb
