### PR TITLE
Add different metrics to tangent space functions

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -255,6 +255,14 @@ Tangent Space
 .. autosummary::
     :toctree: generated/
 
+    exp_map_euclid
+    exp_map_logeuclid
+    exp_map_riemann
+    log_map_euclid
+    log_map_logeuclid
+    log_map_riemann
+    upper
+    unupper
     tangent_space
     untangent_space
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,11 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release.
 
+v0.3.1.dev
+----------
+
+- Add exponential and logarithmic maps for three main metrics, and add option ``metric`` into :func:`pyriemann.utils.tangentspace.tangent_space` and :func:`pyriemann.utils.tangentspace.untangent_space`. :pr:`195` by :user:`qbarthelemy`
+
 v0.3 (July 2022)
 ----------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,9 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.3.1.dev
 ----------
 
-- Add exponential and logarithmic maps for three main metrics, and add option ``metric`` into :func:`pyriemann.utils.tangentspace.tangent_space` and :func:`pyriemann.utils.tangentspace.untangent_space`. :pr:`195` by :user:`qbarthelemy`
+- Add exponential and logarithmic maps for three main metrics: 'euclid', 'logeuclid' and 'riemann'. :pr:`195` by :user:`qbarthelemy`
+
+- Add option ``metric`` into :func:`pyriemann.utils.tangentspace.tangent_space`, :func:`pyriemann.utils.tangentspace.untangent_space` and :class:`pyriemann.tangentspace.TangentSpace`. :pr:`195` by :user:`qbarthelemy`
 
 v0.3 (July 2022)
 ----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,9 +10,11 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.3.1.dev
 ----------
 
-- Add exponential and logarithmic maps for three main metrics: 'euclid', 'logeuclid' and 'riemann'. :pr:`195` by :user:`qbarthelemy`
-
-- Add option ``metric`` into :func:`pyriemann.utils.tangentspace.tangent_space`, :func:`pyriemann.utils.tangentspace.untangent_space` and :class:`pyriemann.tangentspace.TangentSpace`. :pr:`195` by :user:`qbarthelemy`
+- Add exponential and logarithmic maps for three main metrics: 'euclid', 'logeuclid' and 'riemann'.
+:func:`pyriemann.utils.tangentspace.tangent_space` is splitted in two steps: (i) ``log_map_*()`` projecting SPD matrices into tangent space depending on the metric; and (ii) :func:`pyriemann.utils.tangentspace.upper` taking the upper triangular part of matrices.
+Similarly, :func:`pyriemann.utils.tangentspace.untangent_space` is splitted into (i) :func:`pyriemann.utils.tangentspace.unupper` and (ii) ``exp_map_*()``.
+The different metrics for tangent space mapping can now be defined into :class:`pyriemann.tangentspace.TangentSpace`,
+then used for ``transform()`` as well as for ``inverse_transform()``. :pr:`195` by :user:`qbarthelemy`
 
 v0.3 (July 2022)
 ----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,10 +11,10 @@ v0.3.1.dev
 ----------
 
 - Add exponential and logarithmic maps for three main metrics: 'euclid', 'logeuclid' and 'riemann'.
-:func:`pyriemann.utils.tangentspace.tangent_space` is splitted in two steps: (i) ``log_map_*()`` projecting SPD matrices into tangent space depending on the metric; and (ii) :func:`pyriemann.utils.tangentspace.upper` taking the upper triangular part of matrices.
-Similarly, :func:`pyriemann.utils.tangentspace.untangent_space` is splitted into (i) :func:`pyriemann.utils.tangentspace.unupper` and (ii) ``exp_map_*()``.
-The different metrics for tangent space mapping can now be defined into :class:`pyriemann.tangentspace.TangentSpace`,
-then used for ``transform()`` as well as for ``inverse_transform()``. :pr:`195` by :user:`qbarthelemy`
+  :func:`pyriemann.utils.tangentspace.tangent_space` is splitted in two steps: (i) ``log_map_*()`` projecting SPD matrices into tangent space depending on the metric; and (ii) :func:`pyriemann.utils.tangentspace.upper` taking the upper triangular part of matrices.
+  Similarly, :func:`pyriemann.utils.tangentspace.untangent_space` is splitted into (i) :func:`pyriemann.utils.tangentspace.unupper` and (ii) ``exp_map_*()``.
+  The different metrics for tangent space mapping can now be defined into :class:`pyriemann.tangentspace.TangentSpace`,
+  then used for ``transform()`` as well as for ``inverse_transform()``. :pr:`195` by :user:`qbarthelemy`
 
 v0.3 (July 2022)
 ----------------

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3'
+__version__ = '0.3.1.dev'

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -216,7 +216,7 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         estimation, and for tangent space map (see `tangent_space` for the list
         of supported metric).
         The metric could be a dict with three keys, `mean`, `dist` and `map` in
-        order to pass different metrics for the reference matrix estimation, 
+        order to pass different metrics for the reference matrix estimation,
         the distance estimation, and the tangent space mapping.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -53,7 +53,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         The type of metric used for centroid and distance estimation.
         see `mean_covariance` for the list of supported metric.
         the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
+        order to pass different metrics for the centroid estimation and the
         distance estimation. Typical usecase is to pass 'logeuclid' metric for
         the mean in order to boost the computional speed and 'riemann' for the
         distance in order to keep the good sensitivity for the classification.
@@ -211,13 +211,13 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
     Parameters
     ----------
     metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
+        The type of metric used for reference matrix estimation (see
+        `mean_covariance` for the list of supported metric), for distance
+        estimation, and for tangent space map (see `tangent_space` for the list
+        of supported metric).
+        The metric could be a dict with three keys, `mean`, `dist` and `map` in
+        order to pass different metrics for the reference matrix estimation, 
+        the distance estimation, and the tangent space mapping.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
         training and test, as described in [2]_. This is not compatible with
@@ -275,11 +275,10 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         self : FgMDM instance
             The FgMDM instance.
         """
-        self.metric_mean, _ = _check_metric(self.metric)
         self.classes_ = np.unique(y)
 
         self._mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
-        self._fgda = FGDA(metric=self.metric_mean, tsupdate=self.tsupdate)
+        self._fgda = FGDA(metric=self.metric, tsupdate=self.tsupdate)
         cov = self._fgda.fit_transform(X, y)
         self._mdm.fit(cov, y)
         self.classes_ = self._mdm.classes_
@@ -344,15 +343,14 @@ class TSclassifier(BaseEstimator, ClassifierMixin):
     Parameters
     ----------
     metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
+        The type of metric used for reference matrix estimation (see
+        `mean_covariance` for the list of supported metric) and for tangent
+        space map (see `tangent_space` for the list of supported metric).
+        The metric could be a dict with two keys, `mean` and `map` in
+        order to pass different metrics for the reference matrix estimation
+        and the tangent space mapping.
     tsupdate : bool, default=False
-        Activate tangent space update for covariante shift correction between
+        Activate tangent space update for covariate shift correction between
         training and test, as described in [2]. This is not compatible with
         online implementation. Performance are better when the number of
         matrices for prediction is higher.

--- a/pyriemann/utils/tangentspace.py
+++ b/pyriemann/utils/tangentspace.py
@@ -34,6 +34,10 @@ def exp_map_euclid(X, Cref):
     -------
     X_original : ndarray, shape (..., n_channels, n_channels)
         SPD matrices.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     return X + Cref
 
@@ -59,6 +63,10 @@ def exp_map_logeuclid(X, Cref):
     -------
     X_original : ndarray, shape (..., n_channels, n_channels)
         SPD matrices.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     return expm(X + logm(Cref))
 
@@ -74,7 +82,7 @@ def exp_map_riemann(X, Cref, Cm12=False):
         \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2} \exp(\mathbf{X})
         \mathbf{C}_\text{ref}^{1/2}
 
-    When Cm12=True, it returns the full exponential map:
+    When Cm12=True, it returns the full Riemannian exponential map:
 
     .. math::
         \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2}
@@ -88,12 +96,16 @@ def exp_map_riemann(X, Cref, Cm12=False):
     Cref : ndarray, shape (n_channels, n_channels)
         The reference SPD matrix.
     Cm12 : bool, default=False
-        If True, it returns the full exponential map.
+        If True, it returns the full Riemannian exponential map.
 
     Returns
     -------
     X_original : ndarray, shape (..., n_channels, n_channels)
         SPD matrices.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     if Cm12:
         Cm12 = invsqrtm(Cref)
@@ -123,6 +135,10 @@ def log_map_euclid(X, Cref):
     -------
     X_new : ndarray, shape (..., n_channels, n_channels)
         SPD matrices projected in tangent space.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     _check_dimensions(X, Cref)
     return X - Cref
@@ -149,6 +165,10 @@ def log_map_logeuclid(X, Cref):
     -------
     X_new : ndarray, shape (..., n_channels, n_channels)
         SPD matrices projected in tangent space.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     _check_dimensions(X, Cref)
     return logm(X) - logm(Cref)
@@ -165,7 +185,7 @@ def log_map_riemann(X, Cref, C12=False):
         \mathbf{X}_\text{new} = \log ( \mathbf{C}_\text{ref}^{-1/2}
         \mathbf{X} \mathbf{C}_\text{ref}^{-1/2})
 
-    When C12=True, it returns the full logarithmic map:
+    When C12=True, it returns the full Riemannian logarithmic map:
 
     .. math::
         \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2}
@@ -179,12 +199,16 @@ def log_map_riemann(X, Cref, C12=False):
     Cref : ndarray, shape (n_channels, n_channels)
         The reference SPD matrix.
     C12 : bool, default=False
-        If True, it returns the full logarithmic map.
+        If True, it returns the full Riemannian logarithmic map.
 
     Returns
     -------
     X_new : ndarray, shape (..., n_channels, n_channels)
         SPD matrices projected in tangent space.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     _check_dimensions(X, Cref)
     Cm12 = invsqrtm(Cref)
@@ -196,7 +220,7 @@ def log_map_riemann(X, Cref, C12=False):
 
 
 def upper(X):
-    r"""Return the weighted upper triangular part.
+    r"""Return the weighted upper triangular part of symmetric matrices.
 
     This function computes the minimal representation of a matrix in tangent
     space [1]_: it keeps the upper triangular part of the symmetric matrix and
@@ -211,7 +235,11 @@ def upper(X):
     Returns
     -------
     T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
-        Weighted upper triangular parts of matrices.
+        Weighted upper triangular parts of symmetric matrices.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
 
     References
     ----------
@@ -220,7 +248,7 @@ def upper(X):
         Intell, 2008
     """
     n_channels = X.shape[-1]
-    idx = np.triu_indices_from(np.ones((n_channels, n_channels)))
+    idx = np.triu_indices_from(np.empty((n_channels, n_channels)))
     coeffs = (np.sqrt(2) * np.triu(np.ones((n_channels, n_channels)), 1) +
               np.eye(n_channels))[idx]
     T = coeffs * X[..., idx[0], idx[1]]
@@ -230,10 +258,13 @@ def upper(X):
 def unupper(T):
     """Inverse upper function.
 
+    This function is the inverse of upper function: it computes symmetric
+    matrices from their weighted upper triangular parts.
+
     Parameters
     ----------
     T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
-        Weighted upper triangular parts of matrices.
+        Weighted upper triangular parts of symmetric matrices.
 
     Returns
     -------
@@ -243,13 +274,17 @@ def unupper(T):
     See Also
     --------
     upper
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
     """
     dims = T.shape
     n_channels = int((np.sqrt(1 + 8 * dims[-1]) - 1) / 2)
     X = np.empty((*dims[:-1], n_channels, n_channels))
-    idx = np.triu_indices_from(np.ones((n_channels, n_channels)))
+    idx = np.triu_indices_from(np.empty((n_channels, n_channels)))
     X[..., idx[0], idx[1]] = T
-    idx = np.triu_indices_from(np.ones((n_channels, n_channels)), k=1)
+    idx = np.triu_indices_from(np.empty((n_channels, n_channels)), k=1)
     X[..., idx[0], idx[1]] /= np.sqrt(2)
     X[..., idx[1], idx[0]] = X[..., idx[0], idx[1]]
     return X

--- a/pyriemann/utils/tangentspace.py
+++ b/pyriemann/utils/tangentspace.py
@@ -6,11 +6,111 @@ from .base import sqrtm, invsqrtm, logm, expm
 from .mean import mean_covariance
 
 
-def tangent_space(X, Cref):
-    """Project SPD matrices in the tangent space.
+def _check_dimensions(X, Cref):
+    n_channels_1, n_channels_2 = X.shape[-2:]
+    n_channels_3, n_channels_4 = Cref.shape
+    if not (n_channels_1 == n_channels_2 == n_channels_3 == n_channels_4):
+        raise ValueError("Inputs have incompatible dimensions.")
 
-    Project SPD matrices in the tangent space, according to the reference
-    matrix Cref.
+
+def exp_map_euclid(X, Cref):
+    r"""Project matrices back to SPD manifold by Euclidean exponential map.
+
+    The projection of a matrix X back to the SPD manifold with Euclidean
+    exponential map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \mathbf{X} + \mathbf{C}_\text{ref}
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        Matrices in tangent space.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+
+    Returns
+    -------
+    X_original : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    """
+    return X + Cref
+
+
+def exp_map_logeuclid(X, Cref):
+    r"""Project matrices back to SPD manifold by Log-Euclidean exponential map.
+
+    The projection of a matrix X back to the SPD manifold with Log-Euclidean
+    exponential map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \exp(\mathbf{X} + \log(\mathbf{C}_\text{ref}))
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        Matrices in tangent space.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+
+    Returns
+    -------
+    X_original : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    """
+    return expm(X + logm(Cref))
+
+
+def exp_map_riemann(X, Cref, Cm12=False):
+    r"""Project matrices back to SPD manifold by Riemannian exponential map.
+
+    The projection of a matrix X back to the SPD manifold with Riemannian
+    exponential map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2} \exp(\mathbf{X})
+        \mathbf{C}_\text{ref}^{1/2}
+
+    When Cm12=True, it returns the full exponential map:
+
+    .. math::
+        \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2}
+        \exp( \mathbf{C}_\text{ref}^{-1/2} \mathbf{X}
+        \mathbf{C}_\text{ref}^{-1/2}) \mathbf{C}_\text{ref}^{1/2}
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        Matrices in tangent space.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+    Cm12 : bool, default=False
+        If True, it returns the full exponential map.
+
+    Returns
+    -------
+    X_original : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    """
+    if Cm12:
+        Cm12 = invsqrtm(Cref)
+        X = Cm12 @ X @ Cm12
+    C12 = sqrtm(Cref)
+    return C12 @ expm(X) @ C12
+
+
+def log_map_euclid(X, Cref):
+    r"""Project SPD matrices in tangent space by Euclidean logarithmic map.
+
+    The projection of a SPD matrix X in the tangent space by Euclidean
+    logarithmic map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \mathbf{X} - \mathbf{C}_\text{ref}
 
     Parameters
     ----------
@@ -21,58 +121,219 @@ def tangent_space(X, Cref):
 
     Returns
     -------
-    T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
-        Tangent vectors.
-
-    See Also
-    --------
-    untangent_space
+    X_new : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices projected in tangent space.
     """
-    Cm12 = invsqrtm(Cref)
-    tmp = logm(Cm12 @ X @ Cm12)
+    _check_dimensions(X, Cref)
+    return X - Cref
 
+
+def log_map_logeuclid(X, Cref):
+    r"""Project SPD matrices in tangent space by Log-Euclidean logarithmic map.
+
+    The projection of a SPD matrix X in the tangent space by Log-Euclidean
+    logarithmic map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \log(\mathbf{X}) - \log(\mathbf{C}_\text{ref})
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+
+    Returns
+    -------
+    X_new : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices projected in tangent space.
+    """
+    _check_dimensions(X, Cref)
+    return logm(X) - logm(Cref)
+
+
+def log_map_riemann(X, Cref, C12=False):
+    r"""Project SPD matrices in tangent space by Riemannian logarithmic map.
+
+    The projection of a SPD matrix X in the tangent space by Riemannian
+    logarithmic map according to a reference matrix
+    :math:`\mathbf{C}_\text{ref}` is:
+
+    .. math::
+        \mathbf{X}_\text{new} = \log ( \mathbf{C}_\text{ref}^{-1/2}
+        \mathbf{X} \mathbf{C}_\text{ref}^{-1/2})
+
+    When C12=True, it returns the full logarithmic map:
+
+    .. math::
+        \mathbf{X}_\text{new} = \mathbf{C}_\text{ref}^{1/2}
+        \log( \mathbf{C}_\text{ref}^{-1/2} \mathbf{X}
+        \mathbf{C}_\text{ref}^{-1/2}) \mathbf{C}_\text{ref}^{1/2}
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+    C12 : bool, default=False
+        If True, it returns the full logarithmic map.
+
+    Returns
+    -------
+    X_new : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices projected in tangent space.
+    """
+    _check_dimensions(X, Cref)
+    Cm12 = invsqrtm(Cref)
+    X_new = logm(Cm12 @ X @ Cm12)
+    if C12:
+        C12 = sqrtm(Cref)
+        X_new = C12 @ X_new @ C12
+    return X_new
+
+
+def upper(X):
+    r"""Return the weighted upper triangular part.
+
+    This function computes the minimal representation of a matrix in tangent
+    space [1]_: it keeps the upper triangular part of the symmetric matrix and
+    vectorizes it by applying unity weight for diagonal elements and
+    :math:`\sqrt(2)` weight for out-of-diagonal elements.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        Symmetric matrices.
+
+    Returns
+    -------
+    T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
+        Weighted upper triangular parts of matrices.
+
+    References
+    ----------
+    .. [1] O. Tuzel, F. Porikli, P. Meer, "Pedestrian detection via
+        classification on Riemannian manifolds", IEEE Trans Pattern Anal Mach
+        Intell, 2008
+    """
     n_channels = X.shape[-1]
-    idx = np.triu_indices_from(Cref)
+    idx = np.triu_indices_from(np.ones((n_channels, n_channels)))
     coeffs = (np.sqrt(2) * np.triu(np.ones((n_channels, n_channels)), 1) +
               np.eye(n_channels))[idx]
-    T = coeffs * tmp[..., idx[0], idx[1]]
+    T = coeffs * X[..., idx[0], idx[1]]
     return T
 
 
-def untangent_space(T, Cref):
-    """Project tangent vectors back to the manifold.
-
-    Project tangent vectors back to the matrix manifold, according to the
-    reference matrix Cref.
+def unupper(T):
+    """Inverse upper function.
 
     Parameters
     ----------
     T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
-        Tangent vectors.
-    Cref : ndarray, shape (n_channels, n_channels)
-        The reference SPD matrix.
+        Weighted upper triangular parts of matrices.
 
     Returns
     -------
     X : ndarray, shape (..., n_channels, n_channels)
-        SPD matrices.
+        Symmetric matrices.
 
     See Also
     --------
-    tangent_space
+    upper
     """
     dims = T.shape
     n_channels = int((np.sqrt(1 + 8 * dims[-1]) - 1) / 2)
     X = np.empty((*dims[:-1], n_channels, n_channels))
-    idx = np.triu_indices_from(Cref)
+    idx = np.triu_indices_from(np.ones((n_channels, n_channels)))
     X[..., idx[0], idx[1]] = T
-    idx = np.triu_indices_from(Cref, k=1)
+    idx = np.triu_indices_from(np.ones((n_channels, n_channels)), k=1)
     X[..., idx[0], idx[1]] /= np.sqrt(2)
     X[..., idx[1], idx[0]] = X[..., idx[0], idx[1]]
-
-    C12 = sqrtm(Cref)
-    X = C12 @ expm(X) @ C12
     return X
+
+
+def tangent_space(X, Cref, *, metric='riemann'):
+    """Transform SPD matrices into tangent vectors.
+
+    Transform SPD matrices into tangent vectors, according to a reference
+    matrix Cref and to a specific logarithmic map.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+    metric : string, default='riemann'
+        The metric used for logarithmic map, can be: 'euclid', 'logeuclid',
+        'riemann'.
+
+    Returns
+    -------
+    T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
+        Tangent vectors.
+
+    See Also
+    --------
+    log_map_euclid
+    log_map_logeuclid
+    log_map_riemann
+    upper
+    """
+    options = {
+        'euclid': log_map_euclid,
+        'logeuclid': log_map_logeuclid,
+        'riemann': log_map_riemann,
+    }
+    X_ = options[metric](X, Cref)
+    T = upper(X_)
+
+    return T
+
+
+def untangent_space(T, Cref, *, metric='riemann'):
+    """Transform tangent vectors back to SPD matrices.
+
+    Transform tangent vectors back to SPD matrices, according to a reference
+    matrix Cref and to a specific exponential map.
+
+    Parameters
+    ----------
+    T : ndarray, shape (..., n_channels * (n_channels + 1) / 2)
+        Tangent vectors.
+    Cref : ndarray, shape (n_channels, n_channels)
+        The reference SPD matrix.
+    metric : string, default='riemann'
+        The metric used for exponential map, can be: 'euclid', 'logeuclid',
+        'riemann'.
+
+    Returns
+    -------
+    X : ndarray, shape (..., n_channels, n_channels)
+        SPD matrices.
+
+    See Also
+    --------
+    unupper
+    exp_map_euclid
+    exp_map_logeuclid
+    exp_map_riemann
+    """
+    X_ = unupper(T)
+    options = {
+        'euclid': exp_map_euclid,
+        'logeuclid': exp_map_logeuclid,
+        'riemann': exp_map_riemann,
+    }
+    X = options[metric](X_, Cref)
+
+    return X
+
+
+###############################################################################
 
 
 def transport(Covs, Cref, metric='riemann'):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -182,7 +182,7 @@ def test_metric_str(classif, metric, get_covmats, get_labels):
     clf = classif(metric=metric)
 
     if classif in [SVC, FgMDM, TSclassifier] \
-        and metric not in ['riemann', 'euclid', 'logeuclid']:
+            and metric not in ['riemann', 'euclid', 'logeuclid']:
         with pytest.raises((KeyError, ValueError)):
             clf.fit(covmats, labels).predict(covmats)
     else:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -3,6 +3,13 @@ import pickle
 from conftest import get_distances, get_means, get_metrics
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
+from pytest import approx
+from sklearn.dummy import DummyClassifier
+
+from pyriemann.estimation import Covariances
+from pyriemann.utils.kernel import kernel
+from pyriemann.utils.mean import mean_covariance
 from pyriemann.classification import (
     MDM,
     FgMDM,
@@ -11,14 +18,6 @@ from pyriemann.classification import (
     SVC,
     MeanField
 )
-
-from pyriemann.estimation import Covariances
-import pytest
-from pytest import approx
-from sklearn.dummy import DummyClassifier
-
-from pyriemann.utils.kernel import kernel
-from pyriemann.utils.mean import mean_covariance
 
 rclf = [MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC, MeanField]
 
@@ -33,7 +32,7 @@ class ClassifierTestCase:
         self.clf_fit_independence(classif, covmats, labels)
         self.clf_predict_proba(classif, covmats, labels)
         self.clf_populate_classes(classif, covmats, labels)
-        if classif is (MDM, KNearestNeighbor, SVC, MeanField):
+        if classif in (MDM, KNearestNeighbor, MeanField):
             self.clf_fitpredict(classif, covmats, labels)
         if classif in (MDM, FgMDM):
             self.clf_transform(classif, covmats, labels)
@@ -50,7 +49,7 @@ class ClassifierTestCase:
         self.clf_fit_independence(classif, covmats, labels)
         self.clf_predict_proba(classif, covmats, labels)
         self.clf_populate_classes(classif, covmats, labels)
-        if classif is (MDM, KNearestNeighbor, SVC, MeanField):
+        if classif in (MDM, KNearestNeighbor, MeanField):
             self.clf_fitpredict(classif, covmats, labels)
         if classif in (MDM, FgMDM):
             self.clf_transform(classif, covmats, labels)
@@ -114,62 +113,26 @@ class TestClassifier(ClassifierTestCase):
         clf.fit(covmats, labels).predict(covmats)
 
 
-@pytest.mark.parametrize("classif", [MDM, FgMDM, TSclassifier])
+@pytest.mark.parametrize("classif", rclf)
 @pytest.mark.parametrize("mean", ["faulty", 42])
 @pytest.mark.parametrize("dist", ["not_real", 27])
 def test_metric_dict_error(classif, mean, dist, get_covmats, get_labels):
+    n_matrices, n_channels, n_classes = 6, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = classif(metric={"mean": mean, "distance": dist})
     with pytest.raises((TypeError, KeyError)):
-        n_matrices, n_channels, n_classes = 6, 3, 2
-        labels = get_labels(n_matrices, n_classes)
-        covmats = get_covmats(n_matrices, n_channels)
-        clf = classif(metric={"mean": mean, "distance": dist})
         clf.fit(covmats, labels).predict(covmats)
-
-
-@pytest.mark.parametrize("metric_mean", get_means())
-@pytest.mark.parametrize("metric_dist", get_distances())
-def test_metric_MDM(metric_mean, metric_dist, get_covmats, get_labels):
-    n_matrices, n_channels, n_classes = 4, 3, 2
-    labels = get_labels(n_matrices, n_classes)
-    covmats = get_covmats(n_matrices, n_channels)
-    clf = MDM(metric={"mean": metric_mean, "distance": metric_dist})
-    clf.fit(covmats, labels).predict(covmats)
-
-
-@pytest.mark.parametrize("metric_mean", get_means())
-@pytest.mark.parametrize("metric_dist", get_distances())
-@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
-def test_metric_FgMDM(metric_mean, metric_dist, metric_map, get_covmats,
-                      get_labels):
-    n_matrices, n_channels, n_classes = 4, 3, 2
-    labels = get_labels(n_matrices, n_classes)
-    covmats = get_covmats(n_matrices, n_channels)
-    clf = FgMDM(metric={
-        "mean": metric_mean,
-        "distance": metric_dist,
-        "map": metric_map
-    })
-    clf.fit(covmats, labels).predict(covmats)
-
-
-@pytest.mark.parametrize("metric_mean", get_means())
-@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
-def test_metric_TSclassifier(metric_mean, metric_map, get_covmats, get_labels):
-    n_matrices, n_channels, n_classes = 4, 3, 2
-    labels = get_labels(n_matrices, n_classes)
-    covmats = get_covmats(n_matrices, n_channels)
-    clf = TSclassifier(metric={"mean": metric_mean, "map": metric_map})
-    clf.fit(covmats, labels).predict(covmats)
 
 
 @pytest.mark.parametrize("classif", rclf)
 @pytest.mark.parametrize("metric", [42, "faulty", {"foo": "bar"}])
-def test_metric_wrong_keys(classif, metric, get_covmats, get_labels):
+def test_metric_errors(classif, metric, get_covmats, get_labels):
+    n_matrices, n_channels, n_classes = 6, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = classif(metric=metric)
     with pytest.raises((TypeError, KeyError, ValueError)):
-        n_matrices, n_channels, n_classes = 6, 3, 2
-        labels = get_labels(n_matrices, n_classes)
-        covmats = get_covmats(n_matrices, n_channels)
-        clf = classif(metric=metric)
         clf.fit(covmats, labels).predict(covmats)
 
 
@@ -189,14 +152,40 @@ def test_metric_str(classif, metric, get_covmats, get_labels):
         clf.fit(covmats, labels).predict(covmats)
 
 
-@pytest.mark.parametrize("dist", ["not_real", 42])
-def test_knn_dict_dist(dist, get_covmats, get_labels):
-    with pytest.raises(KeyError):
-        n_matrices, n_channels, n_classes = 6, 3, 2
-        labels = get_labels(n_matrices, n_classes)
-        covmats = get_covmats(n_matrices, n_channels)
-        clf = KNearestNeighbor(metric={"distance": dist})
-        clf.fit(covmats, labels).predict(covmats)
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_dist", get_distances())
+def test_metric_mdm(metric_mean, metric_dist, get_covmats, get_labels):
+    n_matrices, n_channels, n_classes = 4, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = MDM(metric={"mean": metric_mean, "distance": metric_dist})
+    clf.fit(covmats, labels).predict(covmats)
+
+
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_dist", get_distances())
+@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
+def test_metric_fgmdm(metric_mean, metric_dist, metric_map, get_covmats,
+                      get_labels):
+    n_matrices, n_channels, n_classes = 4, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = FgMDM(metric={
+        "mean": metric_mean,
+        "distance": metric_dist,
+        "map": metric_map
+    })
+    clf.fit(covmats, labels).predict(covmats)
+
+
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
+def test_metric_tsclassifier(metric_mean, metric_map, get_covmats, get_labels):
+    n_matrices, n_channels, n_classes = 4, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = TSclassifier(metric={"mean": metric_mean, "map": metric_map})
+    clf.fit(covmats, labels).predict(covmats)
 
 
 def test_1nn(get_covmats, get_labels):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -182,7 +182,7 @@ def test_metric_str(classif, metric, get_covmats, get_labels):
     clf = classif(metric=metric)
 
     if classif in [SVC, FgMDM, TSclassifier] \
-    and metric not in ['riemann', 'euclid', 'logeuclid']:
+        and metric not in ['riemann', 'euclid', 'logeuclid']:
         with pytest.raises((KeyError, ValueError)):
             clf.fit(covmats, labels).predict(covmats)
     else:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -126,14 +126,39 @@ def test_metric_dict_error(classif, mean, dist, get_covmats, get_labels):
         clf.fit(covmats, labels).predict(covmats)
 
 
-@pytest.mark.parametrize("classif", [MDM, FgMDM])
-@pytest.mark.parametrize("mean", get_means())
-@pytest.mark.parametrize("dist", get_distances())
-def test_metric_dist(classif, mean, dist, get_covmats, get_labels):
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_dist", get_distances())
+def test_metric_MDM(metric_mean, metric_dist, get_covmats, get_labels):
     n_matrices, n_channels, n_classes = 4, 3, 2
     labels = get_labels(n_matrices, n_classes)
     covmats = get_covmats(n_matrices, n_channels)
-    clf = classif(metric={"mean": mean, "distance": dist})
+    clf = MDM(metric={"mean": metric_mean, "distance": metric_dist})
+    clf.fit(covmats, labels).predict(covmats)
+
+
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_dist", get_distances())
+@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
+def test_metric_FgMDM(metric_mean, metric_dist, metric_map, get_covmats,
+                      get_labels):
+    n_matrices, n_channels, n_classes = 4, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = FgMDM(metric={
+        "mean": metric_mean,
+        "distance": metric_dist,
+        "map": metric_map
+    })
+    clf.fit(covmats, labels).predict(covmats)
+
+
+@pytest.mark.parametrize("metric_mean", get_means())
+@pytest.mark.parametrize("metric_map", ["euclid", "logeuclid", "riemann"])
+def test_metric_TSclassifier(metric_mean, metric_map, get_covmats, get_labels):
+    n_matrices, n_channels, n_classes = 4, 3, 2
+    labels = get_labels(n_matrices, n_classes)
+    covmats = get_covmats(n_matrices, n_channels)
+    clf = TSclassifier(metric={"mean": metric_mean, "map": metric_map})
     clf.fit(covmats, labels).predict(covmats)
 
 
@@ -156,8 +181,9 @@ def test_metric_str(classif, metric, get_covmats, get_labels):
     covmats = get_covmats(n_matrices, n_channels)
     clf = classif(metric=metric)
 
-    if classif is SVC and metric not in ['riemann', 'euclid', 'logeuclid']:
-        with pytest.raises(ValueError):
+    if classif in [SVC, FgMDM, TSclassifier] \
+    and metric not in ['riemann', 'euclid', 'logeuclid']:
+        with pytest.raises((KeyError, ValueError)):
             clf.fit(covmats, labels).predict(covmats)
     else:
         clf.fit(covmats, labels).predict(covmats)

--- a/tests/test_utils_tangent_space.py
+++ b/tests/test_utils_tangent_space.py
@@ -3,7 +3,7 @@ import numpy as np
 from pyriemann.utils.tangentspace import (
     exp_map_euclid, exp_map_logeuclid, exp_map_riemann,
     log_map_euclid, log_map_logeuclid, log_map_riemann,
-    tangent_space, untangent_space, transport
+    upper, unupper, tangent_space, untangent_space, transport
 )
 import pytest
 from pytest import approx
@@ -24,6 +24,19 @@ def test_maps_shape(fun_map, get_covmats):
     covmats_4d = np.asarray([covmats for _ in range(n_sets)])
     Xt = fun_map(covmats_4d, np.eye(n_channels))
     assert Xt.shape == (n_sets, n_matrices, n_channels, n_channels)
+
+
+def test_upper_and_unupper(get_covmats):
+    """Test upper and unupper should be the same"""
+    n_matrices, n_channels = 10, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    covmats_ut = unupper(upper(covmats))
+    assert covmats_ut == approx(covmats)
+
+    n_sets = 2
+    covmats_4d = np.asarray([covmats for _ in range(n_sets)])
+    covmats_4d_ut = unupper(upper(covmats_4d))
+    assert covmats_4d_ut == approx(covmats_4d)
 
 
 @pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])

--- a/tests/test_utils_tangent_space.py
+++ b/tests/test_utils_tangent_space.py
@@ -1,52 +1,75 @@
 from conftest import get_metrics
 import numpy as np
 from pyriemann.utils.tangentspace import (
+    exp_map_euclid, exp_map_logeuclid, exp_map_riemann,
+    log_map_euclid, log_map_logeuclid, log_map_riemann,
     tangent_space, untangent_space, transport
 )
 import pytest
 from pytest import approx
 
 
-def test_tangent_space_shape(get_covmats):
+@pytest.mark.parametrize(
+    "fun_map", [exp_map_euclid, exp_map_logeuclid, exp_map_riemann,
+                log_map_euclid, log_map_logeuclid, log_map_riemann]
+)
+def test_maps_shape(fun_map, get_covmats):
+    """Test log and exp maps"""
+    n_matrices, n_channels = 6, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    Xt = fun_map(covmats, np.eye(n_channels))
+    assert Xt.shape == (n_matrices, n_channels, n_channels)
+
+    n_sets = 2
+    covmats_4d = np.asarray([covmats for _ in range(n_sets)])
+    Xt = fun_map(covmats_4d, np.eye(n_channels))
+    assert Xt.shape == (n_sets, n_matrices, n_channels, n_channels)
+
+
+@pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])
+def test_tangent_space_shape(metric, get_covmats):
     """Test tangent space projection"""
     n_matrices, n_channels = 6, 3
     n_ts = (n_channels * (n_channels + 1)) // 2
     covmats = get_covmats(n_matrices, n_channels)
-    Xts = tangent_space(covmats, np.eye(n_channels))
+    Xts = tangent_space(covmats, np.eye(n_channels), metric=metric)
     assert Xts.shape == (n_matrices, n_ts)
 
     n_sets = 2
     covmats_4d = np.asarray([covmats for _ in range(n_sets)])
-    Xts = tangent_space(covmats_4d, np.eye(n_channels))
+    Xts = tangent_space(covmats_4d, np.eye(n_channels), metric=metric)
     assert Xts.shape == (n_sets, n_matrices, n_ts)
 
 
-def test_untangent_space_shape(rndstate):
+@pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])
+def test_untangent_space_shape(metric, rndstate):
     """Test untangent space projection"""
     n_matrices, n_channels = 10, 3
     n_ts = (n_channels * (n_channels + 1)) // 2
     T = rndstate.randn(n_matrices, n_ts)
-    covmats = untangent_space(T, np.eye(n_channels))
+    covmats = untangent_space(T, np.eye(n_channels), metric=metric)
     assert covmats.shape == (n_matrices, n_channels, n_channels)
 
     n_sets = 2
     T_4d = np.asarray([T for _ in range(n_sets)])
-    covmats = untangent_space(T_4d, np.eye(n_channels))
+    covmats = untangent_space(T_4d, np.eye(n_channels), metric=metric)
     assert covmats.shape == (n_sets, n_matrices, n_channels, n_channels)
 
 
-def test_tangent_and_untangent_space(get_covmats):
+@pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])
+def test_tangent_and_untangent_space(metric, get_covmats):
     """Test tangent space projection and retro-projection should be the same"""
-    def tangent_untangent_space(X, n):
-        return untangent_space(tangent_space(X, np.eye(n)), np.eye(n))
+    def tangent_untangent_space(X, n, metric):
+        return untangent_space(tangent_space(X, np.eye(n), metric=metric),
+                               np.eye(n), metric=metric)
     n_matrices, n_channels = 10, 3
     covmats = get_covmats(n_matrices, n_channels)
-    covmats_ut = tangent_untangent_space(covmats, n_channels)
+    covmats_ut = tangent_untangent_space(covmats, n_channels, metric)
     assert covmats_ut == approx(covmats)
 
     n_sets = 2
     covmats_4d = np.asarray([covmats for _ in range(n_sets)])
-    covmats_4d_ut = tangent_untangent_space(covmats_4d, n_channels)
+    covmats_4d_ut = tangent_untangent_space(covmats_4d, n_channels, metric)
     assert covmats_4d_ut == approx(covmats_4d)
 
 


### PR DESCRIPTION
This PR:
- adds exponential and logarithmic maps for the three main metrics ('euclid', 'logeuclid', and 'riemann'), with the possibility to compute the full tangent space mapping (related to #71);
- adds an argument 'metric' to `utils.tangent_space`, `utils.untangent_space`, and `TangentSpace`, with 'riemann' as default value for backward compatibility;
- updates tests.

@gabelstein, is it ok for you?