### PR TITLE
Add warm restart to AJDC

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,6 +16,9 @@ v0.3.1.dev
   The different metrics for tangent space mapping can now be defined into :class:`pyriemann.tangentspace.TangentSpace`,
   then used for ``transform()`` as well as for ``inverse_transform()``. :pr:`195` by :user:`qbarthelemy`
 
+- Enhance AJD: add ``init`` to :func:`pyriemann.utils.ajd.ajd_pham` and :func:`pyriemann.utils.ajd.rjd`,
+  add ``warm_restart`` to :class:`pyriemann.spatialfilters.AJDC`. :pr:`196` by :user:`qbarthelemy`
+
 v0.3 (July 2022)
 ----------------
 

--- a/pyriemann/preprocessing.py
+++ b/pyriemann/preprocessing.py
@@ -19,8 +19,8 @@ class Whitening(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     metric : str, default='euclid'
-        The metric for the estimation of mean covariance matrix used for
-        whitening and dimension reduction.
+        The metric for the estimation of mean matrix used for whitening and
+        dimension reduction.
     dim_red : None | dict, default=None
         If ``None`` :
             no dimension reduction during whitening.
@@ -34,8 +34,7 @@ class Whitening(BaseEstimator, TransformerMixin):
             ``val`` must be a float in (0,1], typically ``0.99``.
         If ``{'max_cond': val}`` :
             dimension reduction selecting the number of components such that
-            the condition number of the mean covariance matrix is lower than
-            ``val``.
+            the condition number of the mean matrix is lower than ``val``.
             This threshold has a physiological interpretation, because it can
             be viewed as the ratio between the power of the strongest component
             (usually, eye-blink source) and the power of the lowest component
@@ -49,9 +48,9 @@ class Whitening(BaseEstimator, TransformerMixin):
     n_components_ : int
         If fit, the number of components after dimension reduction.
     filters_ : ndarray, shape ``(n_channels_, n_components_)``
-        If fit, the spatial filters to whiten covariance matrices.
+        If fit, the spatial filters to whiten SPD matrices.
     inv_filters_ : ndarray, shape ``(n_components_, n_channels_)``
-        If fit, the spatial filters to unwhiten covariance matrices.
+        If fit, the spatial filters to unwhiten SPD matrices.
 
     Notes
     -----
@@ -75,16 +74,15 @@ class Whitening(BaseEstimator, TransformerMixin):
         y : None
             Ignored as unsupervised.
         sample_weight : None | ndarray, shape (n_matrices,), default=None
-            Weight of each matrix, to compute the weighted mean covariance
-            matrix used for whitening and dimension reduction. If None, it uses
-            equal weights.
+            Weight of each matrix, to compute the weighted mean matrix used for
+            whitening and dimension reduction. If None, it uses equal weights.
 
         Returns
         -------
         self : Whitening instance
             The Whitening instance.
         """
-        # weighted mean of input covariance matrices
+        # weighted mean of input SPD matrices
         Xm = mean_covariance(
             X,
             metric=self.metric,

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -344,12 +344,12 @@ class CSP(BilinearFilter):
             ix = np.argsort(np.abs(evals - 0.5))[::-1]
         elif len(classes) > 2:
             evecs, D = ajd_pham(C)
-            Ctot = np.array(mean_covariance(C, self.metric))
+            Ctot = mean_covariance(C, self.metric)
             evecs = evecs.T
 
             # normalize
             for i in range(evecs.shape[1]):
-                tmp = np.dot(np.dot(evecs[:, i].T, Ctot), evecs[:, i])
+                tmp = evecs[:, i].T @ Ctot @ evecs[:, i]
                 evecs[:, i] /= np.sqrt(tmp)
 
             mutual_info = []
@@ -359,7 +359,7 @@ class CSP(BilinearFilter):
                 a = 0
                 b = 0
                 for i, c in enumerate(classes):
-                    tmp = np.dot(np.dot(evecs[:, j].T, C[i]), evecs[:, j])
+                    tmp = evecs[:, j].T @ C[i] @ evecs[:, j]
                     a += Pc[i] * np.log(np.sqrt(tmp))
                     b += Pc[i] * (tmp ** 2 - 1)
                 mi = - (a + (3.0 / 16) * (b ** 2))

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -20,6 +20,14 @@ def _get_normalized_weight(sample_weight, data):
     return normalized_weight
 
 
+def _check_init_diag(init, n):
+    if init.shape != (n, n):
+        raise ValueError(
+            'Initial diagonalizer shape must be %d x % d (Got %s).'
+            % (n, n, init.shape,))
+    return init
+
+
 def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
     """Approximate joint diagonalization based on Jacobi angles.
 
@@ -68,7 +76,7 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
     if init is None:
         V = np.eye(m)
     else:
-        V = init
+        V = _check_init_diag(init, m)
     encore = True
     k = 0
 
@@ -161,7 +169,7 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
     if init is None:
         V = np.eye(n_channels)
     else:
-        V = init
+        V = _check_init_diag(init, n_channels)
     epsilon = n_channels * (n_channels - 1) * eps
 
     for it in range(n_iter_max):
@@ -263,9 +271,9 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
     if init is None:
         E, H = np.linalg.eig(M[:, 0:d])
-        W_est = np.diag(1. / np.sqrt(np.abs(E))) @ H.T
+        W_est = H.T / np.sqrt(np.abs(E))[:, np.newaxis]
     else:
-        W_est = init
+        W_est = _check_init_diag(init, d)
 
     Ms = np.array(M)
     Rs = np.zeros((d, n_matrices))

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -53,11 +53,11 @@ def test_ajd_init_error(ajd, get_covmats):
     """Test init for ajd algos"""
     n_matrices, n_channels = 5, 3
     covmats = get_covmats(n_matrices, n_channels)
-    with pytest.raises(ValueError):  #  not 2D array
+    with pytest.raises(ValueError):  # not 2D array
         ajd(covmats, init=np.ones((3, 2, 2)))
-    with pytest.raises(ValueError):  #  not square array
+    with pytest.raises(ValueError):  # not square array
         ajd(covmats, init=np.ones((3, 2)))
-    with pytest.raises(ValueError):  #  shape not equal to n_channels
+    with pytest.raises(ValueError):  # shape not equal to n_channels
         ajd(covmats, init=np.ones((2, 2)))
 
 

--- a/tests/test_ajd.py
+++ b/tests/test_ajd.py
@@ -48,6 +48,19 @@ def test_ajd(ajd, init, get_covmats_params):
         assert V.T @ V == approx(np.eye(n_channels))  # check orthogonality
 
 
+@pytest.mark.parametrize("ajd", [rjd, ajd_pham, uwedge])
+def test_ajd_init_error(ajd, get_covmats):
+    """Test init for ajd algos"""
+    n_matrices, n_channels = 5, 3
+    covmats = get_covmats(n_matrices, n_channels)
+    with pytest.raises(ValueError):  #  not 2D array
+        ajd(covmats, init=np.ones((3, 2, 2)))
+    with pytest.raises(ValueError):  #  not square array
+        ajd(covmats, init=np.ones((3, 2)))
+    with pytest.raises(ValueError):  #  shape not equal to n_channels
+        ajd(covmats, init=np.ones((2, 2)))
+
+
 def test_pham_weight_none_equivalent_uniform(get_covmats):
     """Test pham's ajd weights: none is equivalent to uniform values"""
     n_matrices, n_channels, w_val = 5, 3, 2

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -241,6 +241,7 @@ def test_ajdc_fit_error(rndstate):
     with pytest.raises(ValueError):  # initial diag not square
         ajdc.fit(X)
 
+
 def test_ajdc_transform_error(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 2, 2, 4, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -55,6 +55,8 @@ class TestSpatialFilters(SpatialFiltersTestCase):
         if spfilt is BilinearFilter:
             filters = np.eye(n_channels)
             sf = spfilt(filters)
+        elif spfilt is AJDC:
+            sf = spfilt(dim_red={"n_components": n_channels - 1})
         else:
             sf = spfilt()
         sf.fit(X, labels)
@@ -87,8 +89,9 @@ class TestSpatialFilters(SpatialFiltersTestCase):
                       n_matrices, n_channels, n_times):
         n_classes = len(np.unique(labels))
         if spfilt is BilinearFilter:
-            filters = np.eye(n_channels)
-            sf = spfilt(filters)
+            sf = spfilt(np.eye(n_channels))
+        elif spfilt is AJDC:
+            sf = spfilt(dim_red={"expl_var": 0.9})
         else:
             sf = spfilt()
         if spfilt is AJDC:
@@ -110,8 +113,9 @@ class TestSpatialFilters(SpatialFiltersTestCase):
 
     def clf_transform_error(self, spfilt, X, labels, n_channels):
         if spfilt is BilinearFilter:
-            filters = np.eye(n_channels)
-            sf = spfilt(filters)
+            sf = spfilt(np.eye(n_channels))
+        elif spfilt is AJDC:
+            sf = spfilt(dim_red={"max_cond": 10})
         else:
             sf = spfilt()
         with pytest.raises(ValueError):
@@ -119,8 +123,9 @@ class TestSpatialFilters(SpatialFiltersTestCase):
 
     def clf_fit_independence(self, spfilt, X, labels, n_channels, n_times):
         if spfilt is BilinearFilter:
-            filters = np.eye(n_channels)
-            sf = spfilt(filters)
+            sf = spfilt(np.eye(n_channels))
+        elif spfilt is AJDC:
+            sf = spfilt(dim_red={"max_cond": 10})
         else:
             sf = spfilt()
         sf.fit(X, labels)
@@ -206,14 +211,16 @@ def test_ajdc_init():
 def test_ajdc_fit(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 5, 3, 8, 512
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
-    ajdc = AJDC().fit(X)
+    ajdc = AJDC(dim_red={"n_components": n_channels - 1}).fit(X)
     assert ajdc.forward_filters_.shape == (ajdc.n_sources_, n_channels)
     assert ajdc.backward_filters_.shape == (n_channels, ajdc.n_sources_)
+    with pytest.warns(UserWarning):  # dim_red is None
+        AJDC().fit(X)
 
 
 def test_ajdc_fit_error(rndstate):
-    n_conditions, n_channels, n_times = 3, 8, 512
-    ajdc = AJDC()
+    n_subjects, n_conditions, n_channels, n_times = 2, 3, 8, 512
+    ajdc = AJDC(dim_red={"expl_var": 0.9})
     with pytest.raises(ValueError):  # unequal # of conditions
         ajdc.fit(
             [
@@ -228,12 +235,16 @@ def test_ajdc_fit_error(rndstate):
                 rndstate.randn(n_conditions, n_channels + 1, n_times),
             ]
         )
-
+    X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
+    V = rndstate.randn(n_channels, n_channels - 1)
+    ajdc = AJDC(dim_red={'warm_restart': V})
+    with pytest.raises(ValueError):  # initial diag not square
+        ajdc.fit(X)
 
 def test_ajdc_transform_error(rndstate):
-    n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
+    n_subjects, n_conditions, n_channels, n_times = 2, 2, 4, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
-    ajdc = AJDC().fit(X)
+    ajdc = AJDC(dim_red={"warm_restart": np.eye(n_channels - 1)}).fit(X)
     n_matrices = 4
     X_new = rndstate.randn(n_matrices, n_channels, n_times)
     with pytest.raises(ValueError):  # not 3 dims
@@ -245,7 +256,7 @@ def test_ajdc_transform_error(rndstate):
 def test_ajdc_fit_variable_input(rndstate):
     n_subjects, n_cond, n_chan, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_cond, n_chan, n_times)
-    ajdc = AJDC()
+    ajdc = AJDC(dim_red={"expl_var": 0.9})
     # 3 subjects, same # conditions and channels, different # of times
     X = [
         rndstate.randn(n_cond, n_chan, n_times + rndstate.randint(500))
@@ -264,9 +275,9 @@ def test_ajdc_fit_variable_input(rndstate):
 
 
 def test_ajdc_inverse_transform(rndstate):
-    n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
+    n_subjects, n_conditions, n_channels, n_times = 2, 2, 5, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
-    ajdc = AJDC().fit(X)
+    ajdc = AJDC(dim_red={"warm_restart": np.eye(n_channels - 1)}).fit(X)
     n_matrices = 4
     X_new = rndstate.randn(n_matrices, n_channels, n_times)
     Xt = ajdc.transform(X_new)
@@ -284,11 +295,10 @@ def test_ajdc_inverse_transform(rndstate):
         ajdc.inverse_transform(Xt, supp=1)
 
 
-def test_ajdc_expl_var(rndstate):
-    # Test get_src_expl_var
+def test_ajdc_get_src_expl_var(rndstate):
     n_subjects, n_conditions, n_channels, n_times = 2, 2, 3, 256
     X = rndstate.randn(n_subjects, n_conditions, n_channels, n_times)
-    ajdc = AJDC().fit(X)
+    ajdc = AJDC(dim_red={"expl_var": 0.9}).fit(X)
     n_matrices = 4
     X_new = rndstate.randn(n_matrices, n_channels, n_times)
     v = ajdc.get_src_expl_var(X_new)


### PR DESCRIPTION
This PR enhances AJDC when used for group BBS (gBSS): it allows to refine group sources for a specific subject, using an initial diagonalizer.

- Add parameter 'init' to `ajd_pham` and `rjd` to allow warm restart, and complete tests;
- Add a warning if 'dim_red' is let to None in `AJDC`, and add key 'warm_restart' for dimension reduction, and update tests.