### PR TITLE
Faster sampling 2D Riemannian Gaussian

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -19,6 +19,8 @@ v0.3.1.dev
 - Enhance AJD: add ``init`` to :func:`pyriemann.utils.ajd.ajd_pham` and :func:`pyriemann.utils.ajd.rjd`,
   add ``warm_restart`` to :class:`pyriemann.spatialfilters.AJDC`. :pr:`196` by :user:`qbarthelemy`
 
+- Add parameter ``sampling_method`` to :func:`pyriemann.dataset.sample_gaussian_spd`, with ``rejection`` accelerating 2x2 matrices generation. :pr:`198` by :user:`Artim436`
+
 v0.3 (July 2022)
 ----------------
 

--- a/examples/simulated/plot_riemannian_gaussian.py
+++ b/examples/simulated/plot_riemannian_gaussian.py
@@ -34,18 +34,15 @@ mean = generate_random_spd_matrix(n_dim)  # random reference point
 samples_1 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=mean,
                                 sigma=sigma,
-                                random_state=random_state,
-                                sampling_method='rejection')
+                                random_state=random_state)
 samples_2 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=mean,
                                 sigma=sigma/2,
-                                random_state=random_state,
-                                sampling_method='rejection')
+                                random_state=random_state)
 samples_3 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=epsilon*mean,
                                 sigma=sigma,
-                                random_state=random_state,
-                                sampling_method='rejection')
+                                random_state=random_state)
 
 # Stack all of the samples into one data array for the embedding
 samples = np.concatenate([samples_1, samples_2, samples_3])

--- a/examples/simulated/plot_riemannian_gaussian.py
+++ b/examples/simulated/plot_riemannian_gaussian.py
@@ -23,7 +23,7 @@ print(__doc__)
 ###############################################################################
 # Set parameters for sampling from the Riemannian Gaussian distribution
 n_matrices = 100  # how many SPD matrices to generate
-n_dim = 4  # number of dimensions of the SPD matrices
+n_dim = 2  # number of dimensions of the SPD matrices
 sigma = 1.0  # dispersion of the Gaussian distribution
 epsilon = 4.0  # parameter for controlling the distance between centers
 random_state = 42  # ensure reproducibility
@@ -34,15 +34,18 @@ mean = generate_random_spd_matrix(n_dim)  # random reference point
 samples_1 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=mean,
                                 sigma=sigma,
-                                random_state=random_state)
+                                random_state=random_state,
+                                sampling_method='rejection')
 samples_2 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=mean,
                                 sigma=sigma/2,
-                                random_state=random_state)
+                                random_state=random_state,
+                                sampling_method='rejection')
 samples_3 = sample_gaussian_spd(n_matrices=n_matrices,
                                 mean=epsilon*mean,
                                 sigma=sigma,
-                                random_state=random_state)
+                                random_state=random_state,
+                                sampling_method='rejection')
 
 # Stack all of the samples into one data array for the embedding
 samples = np.concatenate([samples_1, samples_2, samples_3])

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -103,7 +103,7 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
     Parameters
     ----------
     n_samples : int
-        Number of samples to get from the ptarget distribution.
+        Number of samples to get from the target distribution.
     sigma : float
         Dispersion of the Riemannian Gaussian distribution.
     random_state : int, RandomState instance or None, default=None

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -274,7 +274,7 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
     Sample the logarithm of the eigenvalues of a SPD matrix following a
     Riemannian Gaussian distribution.
 
-    See https://arxiv.org/pdf/1507.01760.pdf for the mathematical details.
+    See [1]_ for the mathematical details.
 
     Parameters
     ----------
@@ -294,11 +294,19 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+        .. versionadded:: 0.3.1
 
     Returns
     -------
     r_samples : ndarray, shape (n_samples, n_dim)
         Samples of the r parameters of the Riemannian Gaussian distribution.
+
+    References
+    ----------
+    .. [1] S. Said, L. Bombrun, Y. Berthoumieu, and J. Manton, “Riemannian
+        Gaussian distributions on the space of symmetric positive definite
+        matrices”, IEEE Trans Inf Theory, vol. 63, pp. 2153–2170, 2017.
+        https://arxiv.org/pdf/1507.01760.pdf
     """
     if sampling_method not in ['slice', 'rejection', 'auto']:
         raise ValueError(f'Unknown sampling method {sampling_method},'
@@ -382,6 +390,7 @@ def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+        .. versionadded:: 0.3.1
 
     Returns
     -------
@@ -449,6 +458,7 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+        .. versionadded:: 0.3.1
 
     Returns
     -------

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -45,6 +45,7 @@ def _pdf_r(r, sigma):
 
 def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     """Auxiliary function for the 2D rejection sampling algorithm.
+
     It is used in the case where r is sampled with the function g+.
 
     Parameters
@@ -71,6 +72,7 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
 
 def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
     """Auxiliary function for the 2D rejection sampling algorithm.
+
     It is used in the case where r is sampled with the function g-.
 
     Parameters
@@ -97,6 +99,7 @@ def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
 
 def _rejection_sampling_2D(n_samples, sigma, random_state=None):
     """Rejection sampling algorithm for the 2D case.
+
     Implementation of a rejection sampling algorithm. The implementation
     follows the description given in page 528 of Christopher Bishop's book
     "Pattern recognition and Machine Learning" (2006).

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -65,12 +65,15 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     .. versionadded:: 0.3.1
 
     """
-    mu_a = np.array([sigma**2/2, -sigma**2/2])
-    cov_matrix = (sigma**2)*np.eye(2)
-    m = np.pi*(sigma**2)*np.exp(sigma**2/4)
+    mu_a = np.array([sigma**2 / 2, -(sigma**2) / 2])
+    cov_matrix = (sigma**2) * np.eye(2)
+    m = np.pi * (sigma**2) * np.exp(sigma**2 / 4)
     if r_sample[0] >= r_sample[1]:
-        num = np.exp(-1/(2*sigma**2) * np.sum(r_sample**2))\
-            * np.sinh((r_sample[0] - r_sample[1])/2) * 1/m
+        num = (
+            np.exp(-1 / (2 * sigma**2) * np.sum(r_sample**2))
+            * np.sinh((r_sample[0] - r_sample[1]) / 2)
+            / m
+        )
         den = multivariate_normal.pdf(r_sample, mean=mu_a, cov=cov_matrix)
         return num / den
     return 0
@@ -98,14 +101,16 @@ def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
     .. versionadded:: 0.3.1
 
     """
-    mu_b = np.array([-sigma**2/2, sigma**2/2])
-    cov_matrix = (sigma**2)*np.eye(2)
-    m = np.pi*(sigma**2)*np.exp(sigma**2/4)
+    mu_b = np.array([-(sigma**2) / 2, sigma**2 / 2])
+    cov_matrix = (sigma**2) * np.eye(2)
+    m = np.pi * (sigma**2) * np.exp(sigma**2 / 4)
     if r_sample[0] < r_sample[1]:
-        num = np.exp(-1/(2*sigma**2) * np.sum(r_sample**2))\
-            * np.sinh((r_sample[1] - r_sample[0])/2)
-        den = multivariate_normal.pdf(r_sample, mean=mu_b, cov=cov_matrix)*m
-        return num/den
+        num = (
+            np.exp(-1 / (2 * sigma**2) * np.sum(r_sample**2))
+            * np.sinh((r_sample[1] - r_sample[0]) / 2)
+        )
+        den = multivariate_normal.pdf(r_sample, mean=mu_b, cov=cov_matrix) * m
+        return num / den
     return 0
 
 
@@ -135,9 +140,9 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
     .. versionadded:: 0.3.1
 
     """
-    mu_a = np.array([sigma**2/2, -sigma**2/2])
-    mu_b = np.array([-sigma**2/2, sigma**2/2])
-    cov_matrix = (sigma**2)*np.eye(2)
+    mu_a = np.array([sigma**2 / 2, -(sigma**2) / 2])
+    mu_b = np.array([-(sigma**2) / 2, sigma**2 / 2])
+    cov_matrix = (sigma**2) * np.eye(2)
     r_samples = []
     cpt = 0
     rs = check_random_state(random_state)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -294,8 +294,8 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
         Samples of the r parameters of the Riemannian Gaussian distribution.
     """
     if sampling_method not in ['slice', 'rejection', None]:
-        raise ValueError(f'Unknown sampling method {sampling_method},\
-                         try slice or rejection')
+        raise ValueError(f'Unknown sampling method {sampling_method},'
+                         'try slice or rejection')
     if n_dim == 2 and sampling_method != "slice":
         return _rejection_sampling_2D(n_samples, sigma,
                                       random_state=random_state)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -44,15 +44,17 @@ def _pdf_r(r, sigma):
 
 
 def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
-    """ auxiliary function used for the 2D rejection sampling
-    algorithm in the case where r is sampled with
-    the function g+.
+    """Auxiliary function for the 2D rejection sampling algorithm.
+    
+    It is used in the case where r is sampled with the function g+.
+
     Parameters
     ----------
     sigma : float
         Dispersion of the Riemannian Gaussian distribution.
     r_samples : ndarray, shape (1, n_dim)
         Sample of the r parameters of the Riemannian Gaussian distribution.
+
     Returns
     -------
     probability_of_acceptation : float

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -85,7 +85,8 @@ def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
 
     Returns
     -------
-    probability_of_acceptation : float
+    p : float
+        Probability of acceptation.
     """
     mu_b = np.array([-sigma**2/2, sigma**2/2])
     cov_matrix = (sigma**2)*np.eye(2)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -607,5 +607,3 @@ def generate_random_spd_matrix(n_dim, random_state=None, *, mat_mean=.0,
         warnings.warn(msg)
 
     return C
-
-print(_sample_parameter_r(n_samples=5, n_dim=2, sigma=1, random_state=1))

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -59,6 +59,11 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     -------
     p : float
         Probability of acceptation.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
+
     """
     mu_a = np.array([sigma**2/2, -sigma**2/2])
     cov_matrix = (sigma**2)*np.eye(2)
@@ -87,6 +92,11 @@ def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
     -------
     p : float
         Probability of acceptation.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
+
     """
     mu_b = np.array([-sigma**2/2, sigma**2/2])
     cov_matrix = (sigma**2)*np.eye(2)
@@ -119,6 +129,11 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
     -------
     r_samples : ndarray, shape (n_samples, n_dim)
         Samples of the r parameters of the Riemannian Gaussian distribution.
+
+    Notes
+    -----
+    .. versionadded:: 0.3.1
+
     """
     mu_a = np.array([sigma**2/2, -sigma**2/2])
     mu_b = np.array([-sigma**2/2, sigma**2/2])
@@ -294,6 +309,7 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+
         .. versionadded:: 0.3.1
 
     Returns

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -390,6 +390,7 @@ def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+
         .. versionadded:: 0.3.1
 
     Returns
@@ -458,6 +459,7 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+
         .. versionadded:: 0.3.1
 
     Returns

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -60,45 +60,49 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     probability_of_acceptation : float
     """
     mu_a = np.array([sigma**2/2, -sigma**2/2])
-    COV_MATRIX = (sigma**2)*np.eye(2)
-    M = np.pi*(sigma**2)*np.exp(sigma**2/4)
+    cov_matrix = (sigma**2)*np.eye(2)
+    m = np.pi*(sigma**2)*np.exp(sigma**2/4)
     if r_sample[0] >= r_sample[1]:
         num = np.exp(-1/(2*sigma**2) * np.sum(r_sample**2))\
-            * np.sinh((r_sample[0] - r_sample[1])/2) * 1/M
-        den = multivariate_normal.pdf(r_sample, mean=MU_A, cov=COV_MATRIX)
+            * np.sinh((r_sample[0] - r_sample[1])/2) * 1/m
+        den = multivariate_normal.pdf(r_sample, mean=mu_a, cov=cov_matrix)
         return num / den
     return 0
 
 
 def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
-    """ auxiliary function used for the 2D rejection sampling
-    algorithm in the case where r is sampled with
-    the function g-.
+    """Auxiliary function for the 2D rejection sampling algorithm.
+    
+    It is used in the case where r is sampled with the function g-.
+
     Parameters
     ----------
     sigma : float
         Dispersion of the Riemannian Gaussian distribution.
-    r_samples : ndarray, shape (n_samples, n_dim)
-        Samples of the r parameters of the Riemannian Gaussian distribution.
+    r_samples : ndarray, shape (1, n_dim)
+        Sample of the r parameters of the Riemannian Gaussian distribution.
+
     Returns
     -------
     probability_of_acceptation : float
     """
-    MU_B = np.array([-sigma**2/2, sigma**2/2])
-    COV_MATRIX = (sigma**2)*np.eye(2)
-    M = np.pi*(sigma**2)*np.exp(sigma**2/4)
+    mu_b = np.array([-sigma**2/2, sigma**2/2])
+    cov_matrix = (sigma**2)*np.eye(2)
+    m = np.pi*(sigma**2)*np.exp(sigma**2/4)
     if r_sample[0] < r_sample[1]:
         num = np.exp(-1/(2*sigma**2) * np.sum(r_sample**2))\
             * np.sinh((r_sample[1] - r_sample[0])/2)
-        den = multivariate_normal.pdf(r_sample, mean=MU_B, cov=COV_MATRIX)*M
+        den = multivariate_normal.pdf(r_sample, mean=mu_b, cov=cov_matrix)*m
         return num/den
     return 0
 
 
 def _rejection_sampling_2D(n_samples, sigma, random_state=None):
-    """ Rejection sampling algorithm for the 2D case. The algorithm is
-    optimized for spatial complexity but not for time complexity.
-    Works very well for low sigma values
+    """Rejection sampling algorithm for the 2D case. 
+    
+    Implementation of a rejection sampling algorithm. The implementation 
+    follows the description given in page 528 of Christopher Bishop's book
+    "Pattern recognition and Machine Learning" (2006).
 
     Parameters
     ----------
@@ -108,26 +112,27 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
         Dispersion of the Riemannian Gaussian distribution.
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
+
     Returns
     -------
     r_samples : ndarray, shape (n_samples, n_dim)
         Samples of the r parameters of the Riemannian Gaussian distribution.
     """
-    MU_A = np.array([sigma**2/2, -sigma**2/2])
-    MU_B = np.array([-sigma**2/2, sigma**2/2])
-    COV_MATRIX = (sigma**2)*np.eye(2)
+    mu_a = np.array([sigma**2/2, -sigma**2/2])
+    mu_b = np.array([-sigma**2/2, sigma**2/2])
+    cov_matrix = (sigma**2)*np.eye(2)
     RES = []
     cpt = 0
     rs = check_random_state(random_state)
     while cpt != n_samples:
         if rs.binomial(1, 0.5, 1) == 1:
-            r_sample = multivariate_normal.rvs(MU_A, COV_MATRIX, 1, rs)
+            r_sample = multivariate_normal.rvs(mu_a, cov_matrix, 1, rs)
             res = _rejection_sampling_2D_gfunction_plus(sigma, r_sample)
             if rs.rand(1) < res:
                 RES.append(r_sample)
                 cpt += 1
         else:
-            r_sample = multivariate_normal.rvs(MU_B, COV_MATRIX, 1, rs)
+            r_sample = multivariate_normal.rvs(mu_b, cov_matrix, 1, rs)
             res = _rejection_sampling_2D_gfunction_minus(sigma, r_sample)
             if rs.rand(1) < res:
                 RES.append(r_sample)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -268,7 +268,7 @@ def _slice_sampling(ptarget, n_samples, x0, n_burnin=20, thin=10,
 
 
 def _sample_parameter_r(n_samples, n_dim, sigma,
-                        random_state=None, n_jobs=1, sampling_method=None):
+                        random_state=None, n_jobs=1, sampling_method='auto'):
     """Sample the r parameters of a Riemannian Gaussian distribution.
 
     Sample the logarithm of the eigenvalues of a SPD matrix following a
@@ -289,9 +289,9 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
-    sampling_method : str, default=None
+    sampling_method : str, default='auto'
         Name of the sampling method used to sample samples_r. It can be
-        'slice' or 'rejection'. If it is None, the sampling_method
+        'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
 
@@ -300,7 +300,7 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
     r_samples : ndarray, shape (n_samples, n_dim)
         Samples of the r parameters of the Riemannian Gaussian distribution.
     """
-    if sampling_method not in ['slice', 'rejection', None]:
+    if sampling_method not in ['slice', 'rejection', 'auto']:
         raise ValueError(f'Unknown sampling method {sampling_method},'
                          'try slice or rejection')
     if n_dim == 2 and sampling_method != "slice":
@@ -357,7 +357,7 @@ def _sample_parameter_U(n_samples, n_dim, random_state=None):
 
 
 def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
-                                  n_jobs=1, sampling_method=None):
+                                  n_jobs=1, sampling_method='auto'):
     """Sample a Riemannian Gaussian distribution centered at the Identity.
 
     Sample SPD matrices from a Riemannian Gaussian distribution centered at the
@@ -377,9 +377,9 @@ def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
-    sampling_method : str, default=None
+    sampling_method : str, default='auto'
         Name of the sampling method used to sample samples_r. It can be
-        'slice' or 'rejection'. If it is None, the sampling_method
+        'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
 
@@ -421,7 +421,7 @@ def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
 
 
 def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None,
-                        n_jobs=1, sampling_method=None):
+                        n_jobs=1, sampling_method='auto'):
     """Sample a Riemannian Gaussian distribution.
 
     Sample SPD matrices from a Riemannian Gaussian distribution centered at
@@ -444,9 +444,9 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None,
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
-    sampling_method : str, default=None
+    sampling_method : str, default='auto'
         Name of the sampling method used to sample samples_r. It can be
-        'slice' or 'rejection'. If it is None, the sampling_method
+        'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
 

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -45,7 +45,6 @@ def _pdf_r(r, sigma):
 
 def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     """Auxiliary function for the 2D rejection sampling algorithm.
-    
     It is used in the case where r is sampled with the function g+.
 
     Parameters
@@ -72,7 +71,6 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
 
 def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
     """Auxiliary function for the 2D rejection sampling algorithm.
-    
     It is used in the case where r is sampled with the function g-.
 
     Parameters
@@ -98,9 +96,8 @@ def _rejection_sampling_2D_gfunction_minus(sigma, r_sample):
 
 
 def _rejection_sampling_2D(n_samples, sigma, random_state=None):
-    """Rejection sampling algorithm for the 2D case. 
-    
-    Implementation of a rejection sampling algorithm. The implementation 
+    """Rejection sampling algorithm for the 2D case.
+    Implementation of a rejection sampling algorithm. The implementation
     follows the description given in page 528 of Christopher Bishop's book
     "Pattern recognition and Machine Learning" (2006).
 

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -57,7 +57,8 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
 
     Returns
     -------
-    probability_of_acceptation : float
+    p : float
+        Probability of acceptation.
     """
     mu_a = np.array([sigma**2/2, -sigma**2/2])
     cov_matrix = (sigma**2)*np.eye(2)

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -43,10 +43,10 @@ def _pdf_r(r, sigma):
     return np.exp(partial_1 + partial_2)
 
 
-def rejection_sampling_a(sigma, r_sample):
+def _rejection_sampling_gfunction_plus(sigma, r_sample):
     """ side function used for the rejection sampling
-    algorithm in the case where we generate r with
-        the first multivariate normal pdf
+    algorithm in the case where r is sampled with
+    the function g+.
     Parameters
     ----------
     sigma : float
@@ -68,10 +68,10 @@ def rejection_sampling_a(sigma, r_sample):
     return 0
 
 
-def rejection_sampling_b(sigma, r_sample):
+def _rejection_sampling_gfunction_minus(sigma, r_sample):
     """ side function used for the rejection sampling
-    algorithm in the case where we generate r with
-        the second multivariate normal pdf
+    algorithm in the case where r is sampled with
+    the function g-.
     Parameters
     ----------
     sigma : float
@@ -119,13 +119,13 @@ def rejection_sampling(n_samples, sigma, random_state=None):
     while cpt != n_samples:
         if rs.binomial(1, 0.5, 1) == 1:
             r_sample = multivariate_normal.rvs(MU_A, COV_MATRIX, 1, rs)
-            res = rejection_sampling_a(sigma, r_sample)
+            res = _rejection_sampling_gfunction_plus(sigma, r_sample)
             if rs.rand(1) < res:
                 RES.append(r_sample)
                 cpt += 1
         else:
             r_sample = multivariate_normal.rvs(MU_B, COV_MATRIX, 1, rs)
-            res = rejection_sampling_b(sigma, r_sample)
+            res = _rejection_sampling_gfunction_minus(sigma, r_sample)
             if rs.rand(1) < res:
                 RES.append(r_sample)
                 cpt += 1
@@ -278,17 +278,21 @@ def _sample_parameter_r(
     random_state : int, RandomState instance or None, default=None
         Pass an int for reproducible output across multiple function calls.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        The numbfer of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : str, default=None
         Name of the sampling method used to sample samples_r. It can be
-        'slice' or 'rejection'.
-
+        'slice' or 'rejection'. If it is None, the sampling_method
+        will be equal to 'slice' for n_dim != 2 and equal to 
+        'rejection' for n_dim = 2.
     Returns
     -------
     r_samples : ndarray, shape (n_samples, n_dim)
         Samples of the r parameters of the Riemannian Gaussian distribution.
     """
+    if sampling_method not in ['slice', 'rejection', None]:
+        raise ValueError(f'Unknown sampling method {sampling_method},\
+                         try slice or rejection')
     if n_dim == 2 and sampling_method != "slice":
         return rejection_sampling(n_samples, sigma,
                                   random_state=random_state)
@@ -365,8 +369,10 @@ def _sample_gaussian_spd_centered(
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : str, default=None
-        Name of the sampling method used to sample samples_r. It can be 
-        'slice' or 'rejection'.
+        Name of the sampling method used to sample samples_r. It can be
+        'slice' or 'rejection'. If it is None, the sampling_method
+        will be equal to 'slice' for n_dim != 2 and equal to 
+        'rejection' for n_dim = 2.
 
     Returns
     -------
@@ -431,8 +437,10 @@ def sample_gaussian_spd(
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : str, default=None
-        Name of the sampling method used to sample samples_r. It can be 
-        'slice' or 'rejection'.
+        Name of the sampling method used to sample samples_r. It can be
+        'slice' or 'rejection'. If it is None, the sampling_method
+        will be equal to 'slice' for n_dim != 2 and equal to 
+        'rejection' for n_dim = 2.
 
     Returns
     -------

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -476,7 +476,7 @@ def sample_gaussian_spd(n_matrices, mean, sigma, random_state=None,
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : str, default='auto'
-        Name of the sampling method used to sample samples_r. It can be
+        Sampling method to sample eigenvalues. It can be
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -59,7 +59,7 @@ def _rejection_sampling_2D_gfunction_plus(sigma, r_sample):
     -------
     probability_of_acceptation : float
     """
-    MU_A = np.array([sigma**2/2, -sigma**2/2])
+    mu_a = np.array([sigma**2/2, -sigma**2/2])
     COV_MATRIX = (sigma**2)*np.eye(2)
     M = np.pi*(sigma**2)*np.exp(sigma**2/4)
     if r_sample[0] >= r_sample[1]:

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -123,7 +123,7 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
     mu_a = np.array([sigma**2/2, -sigma**2/2])
     mu_b = np.array([-sigma**2/2, sigma**2/2])
     cov_matrix = (sigma**2)*np.eye(2)
-    RES = []
+    r_samples = []
     cpt = 0
     rs = check_random_state(random_state)
     while cpt != n_samples:
@@ -131,15 +131,15 @@ def _rejection_sampling_2D(n_samples, sigma, random_state=None):
             r_sample = multivariate_normal.rvs(mu_a, cov_matrix, 1, rs)
             res = _rejection_sampling_2D_gfunction_plus(sigma, r_sample)
             if rs.rand(1) < res:
-                RES.append(r_sample)
+                r_samples.append(r_sample)
                 cpt += 1
         else:
             r_sample = multivariate_normal.rvs(mu_b, cov_matrix, 1, rs)
             res = _rejection_sampling_2D_gfunction_minus(sigma, r_sample)
             if rs.rand(1) < res:
-                RES.append(r_sample)
+                r_samples.append(r_sample)
                 cpt += 1
-    return np.array(RES)
+    return np.array(r_samples)
 
 
 def _slice_one_sample(ptarget, x0, w, rs):

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -109,8 +109,10 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : str, default=None
-        Name of the sampling method used to sample samples_r. It can be 
-        'slice' or 'rejection'.
+        Name of the sampling method used to sample samples_r. It can be
+        'slice' or 'rejection'. If it is None, the sampling_method
+        will be equal to 'slice' for n_dim != 2 and equal to 
+        'rejection' for n_dim = 2.
 
     Returns
     -------

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -114,6 +114,7 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+        .. versionadded:: 0.3.1
 
     Returns
     -------

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -80,7 +80,7 @@ def make_masks(n_masks, n_dim0, n_dim1_min, rs):
 def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
                         return_centers=False, random_state=None, *,
                         mat_mean=.0, mat_std=1., n_jobs=1,
-                        sampling_method=None):
+                        sampling_method='auto'):
     """Generate SPD dataset with two classes sampled from Riemannian Gaussian.
 
     Generate a dataset with SPD matrices drawn from two Riemannian Gaussian
@@ -109,9 +109,9 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
-    sampling_method : str, default=None
+    sampling_method : str, default='auto'
         Name of the sampling method used to sample samples_r. It can be
-        'slice' or 'rejection'. If it is None, the sampling_method
+        'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
 

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -79,7 +79,8 @@ def make_masks(n_masks, n_dim0, n_dim1_min, rs):
 
 def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
                         return_centers=False, random_state=None, *,
-                        mat_mean=.0, mat_std=1., n_jobs=1, sampling_method=None):
+                        mat_mean=.0, mat_std=1., n_jobs=1,
+                        sampling_method=None):
     """Generate SPD dataset with two classes sampled from Riemannian Gaussian.
 
     Generate a dataset with SPD matrices drawn from two Riemannian Gaussian
@@ -111,7 +112,7 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
     sampling_method : str, default=None
         Name of the sampling method used to sample samples_r. It can be
         'slice' or 'rejection'. If it is None, the sampling_method
-        will be equal to 'slice' for n_dim != 2 and equal to 
+        will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
 
     Returns

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -114,6 +114,7 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         'auto', 'slice' or 'rejection'. If it is 'auto', the sampling_method
         will be equal to 'slice' for n_dim != 2 and equal to
         'rejection' for n_dim = 2.
+
         .. versionadded:: 0.3.1
 
     Returns

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -79,7 +79,7 @@ def make_masks(n_masks, n_dim0, n_dim1_min, rs):
 
 def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
                         return_centers=False, random_state=None, *,
-                        mat_mean=.0, mat_std=1., n_jobs=1):
+                        mat_mean=.0, mat_std=1., n_jobs=1, sampling_method=None):
     """Generate SPD dataset with two classes sampled from Riemannian Gaussian.
 
     Generate a dataset with SPD matrices drawn from two Riemannian Gaussian
@@ -108,6 +108,9 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
+    sampling_method : str, default=None
+        Name of the sampling method used to sample samples_r. It can be 
+        'slice' or 'rejection'.
 
     Returns
     -------
@@ -140,7 +143,9 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         mean=C0,
         sigma=class_disp,
         random_state=random_state,
-        n_jobs=n_jobs)
+        n_jobs=n_jobs,
+        sampling_method=sampling_method
+    )
     y0 = np.zeros(n_matrices)
 
     # generate dataset for class 1
@@ -151,7 +156,9 @@ def make_gaussian_blobs(n_matrices=100, n_dim=2, class_sep=1.0, class_disp=1.0,
         mean=C1,
         sigma=class_disp,
         random_state=random_state,
-        n_jobs=n_jobs)
+        n_jobs=n_jobs,
+        sampling_method=sampling_method
+    )
     y1 = np.ones(n_matrices)
 
     X = np.concatenate([X0, X1])

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -23,7 +23,7 @@ def test_sample_gaussian_spd_dim2(n_jobs, sampling_method):
 @pytest.mark.parametrize("n_jobs", [1, -1])
 @pytest.mark.parametrize("sampling_method", [None, 'slice'])
 def test_sample_gaussian_spd_dimsup(n_dim, n_jobs, sampling_method):
-    """Test Riemannian Gaussian sampling for dim > 2."""
+    """Test Riemannian Gaussian sampling for dim>2."""
     n_matrices, sigma = 5, 1.
     mean = np.eye(n_dim)
     X = sample_gaussian_spd(n_matrices, mean, sigma, random_state=42,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -13,7 +13,7 @@ def test_sample_gaussian_spd(n_jobs):
     n_matrices, n_dim, sigma = 10, 8, 1.
     mean = np.eye(n_dim)
     X = sample_gaussian_spd(
-        n_matrices, mean, sigma, random_state=42, n_jobs=n_jobs
+        n_matrices, mean, sigma, random_state=42, n_jobs=n_jobs, sampling_method=None
         )
     assert X.shape == (n_matrices, n_dim, n_dim)  # X shape mismatch
     assert is_spd(X)  # X is an array of SPD matrices

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -8,7 +8,7 @@ from pyriemann.utils.test import is_sym_pos_def as is_spd
 
 
 @pytest.mark.parametrize("n_jobs", [1, -1])
-@pytest.mark.parametrize("sampling_method", [None, 'slice', 'rejection'])
+@pytest.mark.parametrize("sampling_method", ['auto', 'slice', 'rejection'])
 def test_sample_gaussian_spd_dim2(n_jobs, sampling_method):
     """Test Riemannian Gaussian sampling for dim=2."""
     n_matrices, n_dim, sigma = 5, 2, 1.
@@ -21,7 +21,7 @@ def test_sample_gaussian_spd_dim2(n_jobs, sampling_method):
 
 @pytest.mark.parametrize("n_dim", [3, 4])
 @pytest.mark.parametrize("n_jobs", [1, -1])
-@pytest.mark.parametrize("sampling_method", [None, 'slice'])
+@pytest.mark.parametrize("sampling_method", ['auto', 'slice'])
 def test_sample_gaussian_spd_dimsup(n_dim, n_jobs, sampling_method):
     """Test Riemannian Gaussian sampling for dim>2."""
     n_matrices, sigma = 5, 1.

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -2,9 +2,36 @@ import pytest
 import numpy as np
 
 from pyriemann.datasets.sampling import generate_random_spd_matrix
-from pyriemann.datasets.simulated import (make_gaussian_blobs,
-                                          make_outliers)
+from pyriemann.datasets.simulated import (
+    make_covariances,
+    make_masks,
+    make_gaussian_blobs,
+    make_outliers,
+)
 from pyriemann.utils.test import is_sym_pos_def as is_spd
+
+
+def test_make_covariances(rndstate):
+    """Test function for make covariances."""
+    n_matrices, n_channels = 5, 4
+    X, evals, evecs = make_covariances(n_matrices=n_matrices,
+                                       n_channels=n_channels,
+                                       return_params=True,
+                                       rs=rndstate)
+    assert X.shape == (n_matrices, n_channels, n_channels)  # X shape mismatch
+    assert evals.shape == (n_matrices, n_channels)  # evals shape mismatch
+    assert evecs.shape == (n_channels, n_channels)  # evecs shape mismatch
+
+
+def test_make_masks(rndstate):
+    """Test function for make masks."""
+    n_masks, n_dim0, n_dim1_min, = 5, 10, 3
+    M = make_masks(n_masks, n_dim0, n_dim1_min, rndstate)
+
+    for m in M:
+        dim0, dim1 = m.shape
+        assert dim0 == n_dim0  # 1st dim mismatch
+        assert n_dim1_min <= dim1 <= n_dim0  # 2nd dim mismatch
 
 
 def test_gaussian_blobs():

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -9,7 +9,7 @@ from pyriemann.utils.test import is_sym_pos_def as is_spd
 
 def test_gaussian_blobs():
     """Test function for sampling Gaussian blobs."""
-    n_matrices, n_dim = 50, 8
+    n_matrices, n_dim = 5, 4
     X, y = make_gaussian_blobs(n_matrices=n_matrices,
                                n_dim=n_dim,
                                class_sep=2.0,
@@ -33,7 +33,7 @@ def test_gaussian_blobs():
 
 def test_generate_random_spd_matrix():
     """Test function for sampling outliers"""
-    n_matrices, n_dim, sigma = 100, 8, 1.
+    n_matrices, n_dim, sigma = 5, 4, 1.
     mean = generate_random_spd_matrix(n_dim)
     X = make_outliers(n_matrices=n_matrices,
                       mean=mean,
@@ -45,7 +45,7 @@ def test_generate_random_spd_matrix():
 
 
 def test_functions_error():
-    n_matrices, n_dim, class_sep, class_disp = 10, 16, 2., 1.
+    n_matrices, n_dim, class_sep, class_disp = 5, 4, 2., 1.
     with pytest.raises(ValueError):  # n_matrices is not an integer
         make_gaussian_blobs(n_matrices=float(n_matrices),
                             n_dim=n_dim,


### PR DESCRIPTION
## Introduction

Hi, everyone.

In this issue, I would like to share an improvement that @plcrodrigues and myself made for `_sample_parameter_r`, which is the main bottleneck for sampling SPD matrices from a Riemannian Gaussian distribution via`sample_gaussian_spd`.

**Disclaimer**: This improvement is only for `n_dim=2` but we think it will be useful for the community, since many toy models can be reduced to the 2D case.

In summary, our idea is to use rejection sampling in `_sample_parameter_r` instead of the current implementation with slice sampling. To have a first look, here is a graph of the speedup with a fixed choice of `sigma` (i.e. the dispersion of the Gaussian distribution).

![comparaison](https://user-images.githubusercontent.com/4588557/184829337-51159b1b-3a5f-4ff1-802c-43cbab638d3c.png)

## Theory

**Breaking the problem in two**. We want to sample the vector $r = (r_1, \dots, r_m)$ from the probability distribution

$$
p(r) = \dfrac{1}{Z(m, \sigma)} \exp\left(-\frac{1}{2\sigma^2}\sum_{i = 1}^m r^2_i\right) \times \prod_{i < j}\sinh\left(|r_i - r_j|/2\right)
$$

which has to be done via some computational method. At the moment, `pyriemann` uses a slice sampling approach [[1]](https://projecteuclid.org/journals/annals-of-statistics/volume-31/issue-3/Slice-sampling/10.1214/aos/1056562461.full) to obtain samples from $p(r)$ but this is rather slow. We suggest changing the implementation to a rejection sampling approach [[2]](https://en.wikipedia.org/wiki/Rejection_sampling), exploring certain properties of $p$ and therefore obtaining better performance.

We consider at first the simplest case for our sampling procedure, that of $m = 2$. The pdf for $r = (r_1, r_2)$ simplifies to:

$$
\begin{array}{rcl}
p(r_1, r_2) &=& \dfrac{1}{Z(2, \sigma)}\exp\left(-\dfrac{1}{2\sigma^2}(r_1^2 + r_2^2)\right) \times \sinh\left(|r_1 - r_2|/2\right) 
\end{array}
$$

we can see this pdf as a mixture of two components depending on a binary variable $b$

$$
p(r) = p(r \mid b = 0) \times \mathbb{P}(b = 0) + p(r \mid b = 1) \times \mathbb{P}(b = 1)
$$

with $\mathbb{P}(b = 0) = \mathbb{P}(b = 1) = 1/2$ and

$$
p(r \mid b = 0) = \dfrac{2}{Z(2, \sigma)}\exp\left(-\dfrac{1}{2\sigma^2}(r_1^2 + r_2^2)\right)\sinh\Big((r_1 - r_2)/2\Big) \times \mathbb{I}({\{r_1 - r_2 \geq 0\}})
$$

and

$$
p(r \mid b = 1) = \dfrac{2}{Z(2, \sigma)}\exp\left(-\dfrac{1}{2\sigma^2}(r_1^2 + r_2^2)\right) \sinh\Big((r_2 - r_1)/2\Big) \times \mathbb{I}({\{r_1 - r_2 < 0\}})
$$

where $\mathbb{I}$ is the indicator function.

Great, we see that to generate a sample from $p(r_1, r_2)$ we can first generate a Bernoulli variable $b \sim \mathcal{B}(1/2)$ and then sample from one of the conditional distributions. Now the question is: how do we sample from the conditional distributions?

**Sampling from the conditional distributions.** We can use rejection sampling to sample from $p(r \mid b = 0)$ and first we need to find a nice upper bound to it. Considering the inequality valid for all $x > 0$: 

$$
\sinh(x) = \dfrac{1}{2}\exp(x) - \dfrac{1}{2}\exp(-x) \leq \dfrac{1}{2}\exp(x)
$$

we can write

$$
p(r \mid b = 0) \leq \dfrac{1}{Z(2, \sigma)} \exp\left(-\dfrac{1}{2\sigma^2}(r_1^2 + r_2^2)\right) \exp\Big((r_1 - r_2)/2\Big) \times \mathbb{I}(\{r_1 - r_2 \geq 0\})
$$

and through some rearrangements,

$$
p(r \mid b = 0) \leq \dfrac{2\pi\sigma^2 \exp(\sigma^2/4)}{Z(2, \sigma)} \times \dfrac{1}{2\pi \sigma^2}\exp\left(-\dfrac{1}{2\sigma^2}\Big(\big(r_1-\sigma^2/2\big)^2 + \big(r_2+\sigma^2/2\big)^2\Big)\right)
$$

The expression above indicates that if we want to sample from $p(r \mid b = 0)$ we can do it via rejection sampling using as auxiliary distribution 

$$
g_+(r) = \dfrac{1}{2\pi \sigma^2}\exp\left(-\dfrac{1}{2\sigma^2}\Big(\big(r_1-\sigma^2/2\big)^2 + \big(r_2+\sigma^2/2\big)^2\Big)\right)
$$

the algorithm goes as follows:
1. Sample $u \sim \mathcal{U}(0, 1)$ and $r \sim g_+(r)$

2. Check whether 

$$
u < \exp\left(-\dfrac{1}{2\sigma^2}(r_1^2+r_2^2)\right)\sinh((r_1 - r_2)/2)\times \mathbb{I}({r_1 - r_2 \geq 0})\times\dfrac{1}{M g_+(r)}
$$

- If this holds, then accept $r$ as a sample from $p(r \mid b = 0)$
- If not, reject the sample

Where $M = \pi\sigma^2 \exp(\sigma^2/4)$.

As you can imagine, sampling from $p(r \mid b = 1)$ follows the same logic but with a different auxiliary pdf $g_-(r)$

## The algorithm

Summing up, the new implementation that we propose for `_sample_parameter_r` is based on the following algorithm:

- Sample $b \sim \mathcal{B}(1/2)$
- If $b = 0$, then sample $r \sim p(r \mid b = 0)$
- If $b = 1$, then sample $r \sim p(r \mid b = 1)$

the sampling from the conditional distributions is done following the rejection sampling procedure described above.

## Why not consider more dimensions ?

A natural question to ask is why we have not considered cases with more dimensions than just two dimensions? Well, things can get quite complicated when $m$ increases...

For instance, suppose we have $r = (r_1, r_2, r_3)$ then the pdf of interest can be written as

$$
p(r_1, r_2, r_3) = \dfrac{1}{Z(3,\sigma)}\exp\Big(-\dfrac{1}{2}(r_1^2 + r_2^2 + r_3^2)\Big) \times \sinh\Big(\dfrac{|r_1 - r_2|}{2}\Big) \times \sinh\Big(\dfrac{|r_1 - r_3|}{2}\Big) \times \sinh\Big(\dfrac{|r_2 - r_3|}{2}\Big)
$$

To use the same strategy from our 2D example, we would have to sample three Bernoulli random variables (one for each factor in the product) and consider the $2^3 = 8$ possible combinations of signs inside each of the $\sinh$. We have tried to implement this case, but our first results indicate a the probability of acceptance that is too small and makes the rejection sampling algorithm impractical.

Moreover, we see that the number of conditional distributions increases as $2^m$ where $m$ is the dimensionality of the SPD matrices being considered. Therefore, our algorithm does not look scalable for larger matrix dimensions.

## Final remarks

This is it, we have obtained a much faster implementation for sampling 2D Gaussian SPDs than what was available in `pyriemann` so far. We should mention that our implementation is based on a `while` loop that stops once we have obtained the desired number of samples. However, we can use certain properties of the rejection sampling algorithm to calculate the probability of acceptance of a sample and write code that generates several candidates in the upper hand. Such an algorithm can be even faster than the one we have implemented, but it requires approximating the normalizing constant of $p(r_1, r_2)$, which can be cumbersome. We will leave this extension for a future PR.