### PR TITLE
MAINT correct license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2015, authors of pyRiemann
+Copyright (c) 2015-2022, authors of pyRiemann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the names of pyriemann authors nor the names of any
+    * Neither the name of the copyright holder nor the names of its
       contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
 


### PR DESCRIPTION
It seems that the license is not correctly recognized, it is listed as BSD-1 clause in https://github.com/ml-tooling/best-of-ml-python#medical-data  and the wording is not exactly the same as the [reference one](https://tldrlegal.com/license/bsd-3-clause-license-(revised)#fulltext).

I used MNE license file template to update ours. If the issue persists in best-of-ml listing, I'll open an issue on their side.