### PR TITLE
Add fixed point covariance estimator and add **kwds arguments in Covariances 

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,7 +35,7 @@ v0.3.1.dev
 
 - Add kernel matrices representation :class:`pyriemann.estimation.Kernels` and complete example comparing estimators. :pr:`217` by :user:`qbarthelemy`
 
-- Add a new covariance estimator, robust fixed point covariance, and add **kwds arguments for all covariance based functions and classes. :pr:`220` by :user:`qbarthelemy`
+- Add a new covariance estimator, robust fixed point covariance, and add kwds arguments for all covariance based functions and classes. :pr:`220` by :user:`qbarthelemy`
 
 v0.3 (July 2022)
 ----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,6 +35,8 @@ v0.3.1.dev
 
 - Add kernel matrices representation :class:`pyriemann.estimation.Kernels` and complete example comparing estimators. :pr:`217` by :user:`qbarthelemy`
 
+- Add a new covariance estimator, fixed point covariance, and add **kwds arguments for all covariance based functions and classes. :pr:`220` by :user:`qbarthelemy`
+
 v0.3 (July 2022)
 ----------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,7 +35,7 @@ v0.3.1.dev
 
 - Add kernel matrices representation :class:`pyriemann.estimation.Kernels` and complete example comparing estimators. :pr:`217` by :user:`qbarthelemy`
 
-- Add a new covariance estimator, fixed point covariance, and add **kwds arguments for all covariance based functions and classes. :pr:`220` by :user:`qbarthelemy`
+- Add a new covariance estimator, robust fixed point covariance, and add **kwds arguments for all covariance based functions and classes. :pr:`220` by :user:`qbarthelemy`
 
 v0.3 (July 2022)
 ----------------

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -24,9 +24,11 @@ class Covariances(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    estimator : string, default=scm'
+    estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     See Also
     --------
@@ -36,9 +38,10 @@ class Covariances(BaseEstimator, TransformerMixin):
     HankelCovariances
     """
 
-    def __init__(self, estimator='scm'):
+    def __init__(self, estimator='scm', **kwds):
         """Init."""
         self.estimator = estimator
+        self.kwds = kwds
 
     def fit(self, X, y=None):
         """Fit.
@@ -72,7 +75,7 @@ class Covariances(BaseEstimator, TransformerMixin):
         covmats : ndarray, shape (n_matrices, n_channels, n_channels)
             Covariance matrices.
         """
-        covmats = covariances(X, estimator=self.estimator)
+        covmats = covariances(X, estimator=self.estimator, **self.kwds)
         return covmats
 
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -111,6 +111,8 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
     svd : int | None, default=None
         If not None, number of components of SVD used to reduce prototype
         responses.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Attributes
     ----------
@@ -142,11 +144,12 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         GRETSI, 2013.
     """
 
-    def __init__(self, classes=None, estimator='scm', svd=None):
+    def __init__(self, classes=None, estimator='scm', svd=None, **kwds):
         """Init."""
         self.classes = classes
         self.estimator = estimator
         self.svd = svd
+        self.kwds = kwds
 
     def fit(self, X, y):
         """Fit.
@@ -204,7 +207,12 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
             is None, and to `n_channels + n_classes x min(svd, n_channels)`
             otherwise.
         """
-        covmats = covariances_EP(X, self.P_, estimator=self.estimator)
+        covmats = covariances_EP(
+            X,
+            self.P_,
+            estimator=self.estimator,
+            **self.kwds
+        )
         return covmats
 
 
@@ -244,6 +252,8 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     baseline_cov : array, shape (n_channels, n_channels) | None, default=None
         Baseline covariance for `Xdawn` spatial filtering,
         see :class:`pyriemann.spatialfilters.Xdawn`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Attributes
     ----------
@@ -270,7 +280,8 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
                  classes=None,
                  estimator='scm',
                  xdawn_estimator='scm',
-                 baseline_cov=None):
+                 baseline_cov=None,
+                 **kwds):
         """Init."""
         self.applyfilters = applyfilters
         self.estimator = estimator
@@ -278,6 +289,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         self.classes = classes
         self.nfilter = nfilter
         self.baseline_cov = baseline_cov
+        self.kwds = kwds
 
     def fit(self, X, y):
         """Fit.
@@ -325,7 +337,12 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         if self.applyfilters:
             X = self.Xd_.transform(X)
 
-        covmats = covariances_EP(X, self.P_, estimator=self.estimator)
+        covmats = covariances_EP(
+            X,
+            self.P_,
+            estimator=self.estimator,
+            **self.kwds
+        )
         return covmats
 
 
@@ -349,6 +366,8 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
     estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Notes
     -----
@@ -359,10 +378,11 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
     Covariances
     """
 
-    def __init__(self, block_size, estimator='scm'):
+    def __init__(self, block_size, estimator='scm', **kwds):
         """Init."""
         self.estimator = estimator
         self.block_size = block_size
+        self.kwds = kwds
 
     def fit(self, X, y=None):
         """Fit.
@@ -408,7 +428,7 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
         else:
             raise ValueError("Parameter block_size must be int or list.")
 
-        return block_covariances(X, blocks, self.estimator)
+        return block_covariances(X, blocks, self.estimator, **self.kwds)
 
 
 ###############################################################################
@@ -633,6 +653,8 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
     estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     See Also
     --------
@@ -650,10 +672,11 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
         Biomedical Engineering 52(9), 1541-1548, 2005.
     """
 
-    def __init__(self, delays=4, estimator='scm'):
+    def __init__(self, delays=4, estimator='scm', **kwds):
         """Init."""
         self.delays = delays
         self.estimator = estimator
+        self.kwds = kwds
 
     def fit(self, X, y=None):
         """Fit.
@@ -704,7 +727,7 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
                 tmp = np.r_[tmp, np.roll(x, d, axis=-1)]
             X2.append(tmp)
         X2 = np.array(X2)
-        covmats = covariances(X2, estimator=self.estimator)
+        covmats = covariances(X2, estimator=self.estimator, **self.kwds)
         return covmats
 
 

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -52,7 +52,7 @@ def _fpcm(X, *, init=None, tol=10e-3, n_iter_max=50, assume_centered=False):
         <https://hal.science/hal-01816367/document>`_
         F. Pascal, Y. Chitour, J.P. Ovarlez, P. Forster, P. Arzabal. IEEE
         Transactions on Signal Processing, 2008.
-    """  #noqa
+    """  # noqa
     n_channels, n_times = X.shape
     if not assume_centered:
         X -= np.mean(X, axis=1, keepdims=True)

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -84,7 +84,7 @@ def _scm(X, **kwds):
 def _sch(X):
     r"""Schaefer-Strimmer covariance estimator.
 
-    Shrinkage estimator using method from [1]_:
+    Shrinkage estimator using method:
 
     .. math::
             \hat{\Sigma} = (1 - \gamma)\Sigma_{scm} + \gamma T
@@ -216,7 +216,7 @@ def covariances(X, estimator='cov', **kwds):
     return covmats
 
 
-def covariances_EP(X, P, estimator='cov'):
+def covariances_EP(X, P, estimator='cov', **kwds):
     """Special form covariance matrix, concatenating a prototype P.
 
     Parameters
@@ -225,10 +225,11 @@ def covariances_EP(X, P, estimator='cov'):
         Multi-channel time-series.
     P : ndarray, shape (n_channels_proto, n_times)
         Multi-channel prototype.
-    estimator : {'cov', 'scm', 'lwf', 'oas', 'mcd', 'sch', 'corr'}, \
-            default='cov'
+    estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Returns
     -------
@@ -245,23 +246,24 @@ def covariances_EP(X, P, estimator='cov'):
     covmats = np.empty((n_matrices, n_channels + n_channels_proto,
                         n_channels + n_channels_proto))
     for i in range(n_matrices):
-        covmats[i] = est(np.concatenate((P, X[i]), axis=0))
+        covmats[i] = est(np.concatenate((P, X[i]), axis=0), **kwds)
     return covmats
 
 
-def covariances_X(X, estimator='scm', alpha=0.2):
+def covariances_X(X, estimator='scm', alpha=0.2, **kwds):
     """Special form covariance matrix, embedding input X.
 
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n_channels, n_times)
         Multi-channel time-series.
-    estimator : {'cov', 'scm', 'lwf', 'oas', 'mcd', 'sch', 'corr'}, \
-            default='scm'
+    estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
     alpha : float, default=0.2
         Regularization parameter (strictly positive).
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Returns
     -------
@@ -297,11 +299,11 @@ def covariances_X(X, estimator='scm', alpha=0.2):
             np.concatenate((X[i], alpha * np.eye(n_channels)), axis=1),  # top
             np.concatenate((alpha * np.eye(n_times), X[i].T), axis=1)  # bottom
         ), axis=0)  # Eq(9)
-        covmats[i] = est(Y)
+        covmats[i] = est(Y, **kwds)
     return covmats / (2 * alpha)  # Eq(10)
 
 
-def block_covariances(X, blocks, estimator='cov'):
+def block_covariances(X, blocks, estimator='cov', **kwds):
     """Compute block diagonal covariance.
 
     Calculates block diagonal matrices where each block is a covariance
@@ -315,10 +317,11 @@ def block_covariances(X, blocks, estimator='cov'):
         Multi-channel time-series.
     blocks: list of int
         List of block sizes.
-    estimator : {'cov', 'scm', 'lwf', 'oas', 'mcd', 'sch', 'corr'}, \
-        default='scm'
+    estimator : string, default='scm'
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the covariance estimator.
 
     Returns
     -------
@@ -336,7 +339,7 @@ def block_covariances(X, blocks, estimator='cov'):
     for i in range(n_matrices):
         blockcov, idx_start = [], 0
         for j in blocks:
-            blockcov.append(est(X[i, idx_start:idx_start+j, :]))
+            blockcov.append(est(X[i, idx_start:idx_start+j, :], **kwds))
             idx_start += j
         covmats[i] = block_diag(*tuple(blockcov))
 

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -10,6 +10,9 @@ from .test import is_square
 def _fpcm(X, *, init=None, tol=10e-3, n_iter_max=50, assume_centered=False):
     """Fixed point covariance estimator.
 
+    Fixed point covariance estimator with properties of existence, uniqueness,
+    unbiasedness and consistency.
+
     Parameters
     ----------
     X : ndarray, shape (n_channels, n_times)
@@ -34,6 +37,18 @@ def _fpcm(X, *, init=None, tol=10e-3, n_iter_max=50, assume_centered=False):
     Notes
     -----
     .. versionadded:: 0.3.1
+
+    References
+    ----------
+    .. [1] `Theoretical analysis of an improved covariance matrix estimator in
+        non-Gaussian noise
+        <https://hal.science/hal-02495012/document>`_
+        F. Pascal, P. Forster, J.P. Ovarlez, P. Arzabal. IEEE ICASSP, 2005.
+    .. [2] `Covariance structure maximum-likelihood estimates in compound
+        Gaussian noise: Existence and algorithm analysis
+        <https://hal.science/hal-01816367/document>`_
+        F. Pascal, Y. Chitour, J.P. Ovarlez, P. Forster, P. Arzabal. IEEE
+        Transactions on Signal Processing, 2008.
     """
     n_channels, n_times = X.shape
     if not assume_centered:
@@ -84,7 +99,7 @@ def _scm(X, **kwds):
 def _sch(X):
     r"""Schaefer-Strimmer covariance estimator.
 
-    Shrinkage estimator using method:
+    Shrinkage covariance estimator using method [1]_:
 
     .. math::
             \hat{\Sigma} = (1 - \gamma)\Sigma_{scm} + \gamma T
@@ -109,6 +124,14 @@ def _sch(X):
     Notes
     -----
     .. versionadded:: 0.3
+
+    References
+    ----------
+    .. [1] `A shrinkage approach to large-scale covariance estimation and
+        implications for functional genomics
+        <http://doi.org/10.2202/1544-6115.1175>`_
+        J. Schafer, and K. Strimmer. Statistical Applications in Genetics and
+        Molecular Biology, Volume 4, Issue 1, 2005.
     """
     n_times = X.shape[1]
     X_c = (X.T - X.T.mean(axis=0)).T
@@ -194,10 +217,10 @@ def covariances(X, estimator='cov', **kwds):
     .. [est] https://scikit-learn.org/stable/modules/covariance.html
     .. [corr] https://numpy.org/doc/stable/reference/generated/numpy.corrcoef.html
     .. [cov] https://numpy.org/doc/stable/reference/generated/numpy.cov.html
-    .. [fpcm] `Theoretical analysis of an improved covariance matrix estimator in
-        non-Gaussian noise
+    .. [fpcm] `Theoretical analysis of an improved covariance matrix estimator
+        in non-Gaussian noise
         <https://hal.science/hal-02495012/document>`_
-        F. Pascal, P. Forster, J.P. Ovarlez, P. Arzabal. ICASSP, 2005.
+        F. Pascal, P. Forster, J.P. Ovarlez, P. Arzabal. IEEE ICASSP, 2005.
     .. [lwf] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.ledoit_wolf.html
     .. [mcd] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.MinCovDet.html
     .. [oas] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.OAS.html

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -199,7 +199,7 @@ def covariances(X, estimator='cov', **kwds):
 
         * 'corr' for correlation coefficient matrix [corr]_,
         * 'cov' for numpy based covariance matrix [cov]_,
-        * 'fpcm' for fixed point covariance matrix [fpcm]_,
+        * 'fpcm' for robust fixed point covariance matrix [fpcm]_,
         * 'lwf' for shrunk Ledoit-Wolf covariance matrix [lwf]_,
         * 'mcd' for minimum covariance determinant matrix [mcd]_,
         * 'oas' for oracle approximating shrunk covariance matrix [oas]_,

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -20,7 +20,7 @@ from pyriemann.estimation import (
 from pyriemann.utils.test import (is_sym_pos_def as is_spd,
                                   is_sym_pos_semi_def as is_spsd)
 
-estim = ["cov", "scm", "lwf", "oas", "mcd", "corr", "sch"]
+estim = ["corr", "cov", "fpcm", "lwf", "mcd", "oas", "sch", "scm"]
 coh = ["ordinary", "instantaneous", "lagged", "imaginary"]
 
 
@@ -35,6 +35,26 @@ def test_covariances(estimator, rndstate):
     assert covmats.shape == (n_matrices, n_channels, n_channels)
     assert is_spd(covmats)
 
+
+@pytest.mark.parametrize(
+    "estimator, kwds",
+    [
+        ('cov', {'bias': True}),
+        ('fpcm', {'tol': 10e-1, 'n_iter_max': 10}),
+        ('lwf', {'assume_centered': True}),
+        ('mcd', {'support_fraction': 0.78}),
+        ('oas', {'assume_centered': True}),
+        ('scm', {'assume_centered': True}),
+    ],
+)
+def test_covariances_kwds(estimator, kwds, rndstate):
+    n_matrices, n_channels, n_times = 3, 6, 10
+    x = rndstate.randn(n_matrices, n_channels, n_times) + 1
+    covs_none = Covariances(estimator=estimator).fit_transform(x)
+    covs_kwds = Covariances(estimator=estimator, **kwds).fit_transform(x)
+    assert_raises(
+        AssertionError, assert_array_equal, covs_none, covs_kwds
+    )
 
 @pytest.mark.parametrize("delays", [4, [1, 2]])
 def test_hankel_covariances_delays(delays, rndstate):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -56,6 +56,7 @@ def test_covariances_kwds(estimator, kwds, rndstate):
         AssertionError, assert_array_equal, covs_none, covs_kwds
     )
 
+
 @pytest.mark.parametrize("delays", [4, [1, 2]])
 def test_hankel_covariances_delays(delays, rndstate):
     n_matrices, n_channels, n_times = 2, 3, 100

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -12,11 +12,11 @@ from pyriemann.utils.covariance import (
 from pyriemann.utils.test import is_real, is_hermitian
 
 
-estimators = ['corr', 'cov', 'fpcm', 'lwf', 'mcd', 'oas', 'sch', 'scm']
+estimators = ['corr', 'cov', 'lwf', 'mcd', 'oas', 'sch', 'scm']
 
 
 @pytest.mark.parametrize(
-    'estimator', estimators + [np.cov, 'truc', None]
+    'estimator', estimators + [np.cov, 'fpcm', 'truc', None]
 )
 def test_covariances(estimator, rndstate):
     """Test covariance for multiple estimators"""
@@ -32,6 +32,17 @@ def test_covariances(estimator, rndstate):
     else:
         cov = covariances(x, estimator=estimator)
         assert cov.shape == (n_matrices, n_channels, n_channels)
+
+        if estimator == 'corr':
+            assert_array_almost_equal(
+                np.diagonal(cov, axis1=-2, axis2=-1),
+                np.ones((n_matrices, n_channels))
+            )
+        elif estimator == 'fpcm':
+            assert_array_almost_equal(
+                np.trace(cov, axis1=-2, axis2=-1),
+                np.full(n_matrices, n_channels)
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -12,7 +12,7 @@ from pyriemann.utils.covariance import (
 from pyriemann.utils.test import is_real, is_hermitian
 
 
-estimators = ['corr', 'cov', 'lwf', 'mcd', 'oas', 'sch', 'scm']
+estimators = ['corr', 'cov', 'fpcm', 'lwf', 'mcd', 'oas', 'sch', 'scm']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR:
- adds a new covariance estimator: [fixed point covariance matrix](https://hal.science/hal-02495012/document);
- adds **kwds arguments in `Covariances`, for parameters passed directly to the covariance estimator.