### PR TITLE
Correct pairwise_distance for non symmetric metrics

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,8 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.5.dev
 --------
 
-- ...
+- Correct :func:`pyriemann.utils.distance.pairwise_distance` for non-symmetric metrics. :pr:`229` by :user:`qbarthelemy`
+
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -325,6 +325,10 @@ def pairwise_distance(X, Y=None, metric='riemann'):
     """
     n_matrices_X, _, _ = X.shape
 
+    # compute full pairwise matrix for non-symmetric metrics
+    if Y is None and metric in ["kullback", "kullback_right"]:
+        Y = X
+
     if Y is None:
         dist = np.zeros((n_matrices_X, n_matrices_X))
         for i in range(n_matrices_X):
@@ -337,6 +341,7 @@ def pairwise_distance(X, Y=None, metric='riemann'):
         for i in range(n_matrices_X):
             for j in range(n_matrices_Y):
                 dist[i, j] = distance(X[i], Y[j], metric)
+
     return dist
 
 


### PR DESCRIPTION
As noted in https://github.com/pyRiemann/pyRiemann/issues/224#issuecomment-1433562379, `pairwise_distance` is currently false for non-symmetric metrics.