### PR TITLE
Correct mean_covariance when used with keyword arguments

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,6 +12,8 @@ v0.5.dev
 
 - Correct :func:`pyriemann.utils.distance.pairwise_distance` for non-symmetric metrics. :pr:`229` by :user:`qbarthelemy`
 
+- Correct :func:`pyriemann.utils.mean.mean_covariances` used with keyword arguments. :pr:`230` by :user:`qbarthelemy`
+
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -577,7 +577,7 @@ def mean_covariance(covmats, metric='riemann', sample_weight=None, **kwargs):
         'wasserstein', or a callable function.
     sample_weight : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. If None, it uses equal weights.
-    kwargs : list of params
+    **kwargs : dict
         The keyword arguments passed to the sub function.
 
     Returns

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -564,7 +564,7 @@ def _check_mean_method(method):
     return method
 
 
-def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
+def mean_covariance(covmats, metric='riemann', sample_weight=None, **kwargs):
     """Mean of SPD matrices according to a metric.
 
     Parameters
@@ -577,8 +577,8 @@ def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
         'wasserstein', or a callable function.
     sample_weight : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. If None, it uses equal weights.
-    args : list of params
-        The arguments passed to the sub function.
+    kwargs : list of params
+        The keyword arguments passed to the sub function.
 
     Returns
     -------
@@ -586,9 +586,13 @@ def mean_covariance(covmats, metric='riemann', sample_weight=None, *args):
         Mean of SPD matrices.
     """
     if callable(metric):
-        C = metric(covmats, sample_weight=sample_weight, *args)
+        C = metric(covmats, sample_weight=sample_weight, **kwargs)
     else:
-        C = mean_methods[metric](covmats, sample_weight=sample_weight, *args)
+        C = mean_methods[metric](
+            covmats,
+            sample_weight=sample_weight,
+            **kwargs,
+        )
     return C
 
 

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -231,6 +231,8 @@ def test_riemann_mean(init, get_covmats_params):
     Ctrue = evecs @ np.diag(Ctrue) @ evecs.T
     assert C == approx(Ctrue)
 
+    mean_covariance(covmats, metric='riemann', maxiter=10)
+
 
 def test_riemann_mean_properties(get_covmats):
     n_matrices, n_channels = 5, 3


### PR DESCRIPTION
`mean_covariance(covmats, metric='riemann', maxiter=10)`
raises the following error
`TypeError: mean_covariance() got an unexpected keyword argument 'maxiter'`