### PR TITLE
Add function make_matrices to generate SPD, SPSD, HPD and HPSD matrices

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -183,6 +183,7 @@ Datasets
     make_gaussian_blobs
     make_outliers
     make_covariances
+    make_matrices
     make_masks
     sample_gaussian_spd
     generate_random_spd_matrix

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,6 +16,9 @@ v0.5.dev
 
 - Add functions to test HPD and HPSD matrices, :func:`pyriemann.utils.test.is_herm_pos_def` and :func:`pyriemann.utils.test.is_herm_pos_semi_def`. :pr:`231` by :user:`qbarthelemy`
 
+- Add function :func:`pyriemann.datasets.simulated.make_matrices` to generate SPD, SPSD, HPD and HPSD matrices.
+  Deprecate function :func:`pyriemann.datasets.simulated.make_covariances`. :pr:`232` by :user:`qbarthelemy`
+
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/datasets/__init__.py
+++ b/pyriemann/datasets/__init__.py
@@ -1,12 +1,21 @@
 from .sampling import sample_gaussian_spd, generate_random_spd_matrix
-from .simulated import (make_covariances, make_masks, make_gaussian_blobs,
-                        make_outliers, make_classification_transfer)
+from .simulated import (
+    make_covariances,
+    make_matrices,
+    make_masks,
+    make_gaussian_blobs,
+    make_outliers,
+    make_classification_transfer,
+)
 
 
-__all__ = ["sample_gaussian_spd",
-           "generate_random_spd_matrix",
-           "make_covariances",
-           "make_masks",
-           "make_gaussian_blobs",
-           "make_outliers",
-           "make_classification_transfer"]
+__all__ = [
+    "sample_gaussian_spd",
+    "generate_random_spd_matrix",
+    "make_covariances",
+    "make_matrices",
+    "make_masks",
+    "make_gaussian_blobs",
+    "make_outliers",
+    "make_classification_transfer",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from functools import partial
 
-from pyriemann.datasets import make_covariances, make_masks
+from pyriemann.datasets import make_matrices, make_masks
 
 
 def requires_module(function, name, call=None):
@@ -32,8 +32,8 @@ def rndstate():
 @pytest.fixture
 def get_covmats(rndstate):
     def _gen_cov(n_matrices, n_channels):
-        return make_covariances(n_matrices, n_channels, rndstate,
-                                return_params=False)
+        return make_matrices(n_matrices, n_channels, "spd", rndstate,
+                             return_params=False, eigvecs_same=False)
 
     return _gen_cov
 
@@ -41,10 +41,19 @@ def get_covmats(rndstate):
 @pytest.fixture
 def get_covmats_params(rndstate):
     def _gen_cov_params(n_matrices, n_channels):
-        return make_covariances(n_matrices, n_channels, rndstate,
-                                return_params=True)
+        return make_matrices(n_matrices, n_channels, "spd", rndstate,
+                             return_params=True, eigvecs_same=True)
 
     return _gen_cov_params
+
+
+@pytest.fixture
+def get_mats(rndstate):
+    def _gen_mat(n_matrices, n_dim, mtype):
+        return make_matrices(n_matrices, n_dim, mtype, rndstate,
+                             return_params=False)
+
+    return _gen_mat
 
 
 @pytest.fixture

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -8,7 +8,7 @@ from sklearn.pipeline import make_pipeline, Pipeline
 
 from pyriemann.datasets.simulated import (
     make_classification_transfer,
-    make_covariances,
+    make_matrices,
 )
 from pyriemann.classification import (
     MDM,
@@ -38,7 +38,8 @@ rndstate = 1234
 
 def test_encode_decode_domains(rndstate):
     """Test encoding and decoding of domains for data points"""
-    X = make_covariances(n_matrices=4, n_channels=2, rs=rndstate)
+    n_matrices, n_channels = 4, 2
+    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
     y = np.array(['left_hand', 'right_hand', 'left_hand', 'right_hand'])
     domain = np.array(2*['source_domain'] + 2*['target_domain'])
 
@@ -262,8 +263,8 @@ def test_tlregressors(rndstate, reg, source_domain, target_domain):
     """Test wrapper for regressors in transfer learning"""
 
     def make_regression_transfer(n_matrices, n_channels, rs):
-        X = make_covariances(
-            n_matrices=n_matrices, n_channels=n_channels, rs=rndstate
+        X = make_matrices(
+            n_matrices, n_channels, "spd", rs=rndstate
         )
         y = np.random.uniform(low=1.0, high=10.0, size=n_matrices)
         domain = np.array(20*['source_domain'] + 20*['target_domain'])


### PR DESCRIPTION
This PR:
- adds function `make_matrices` to generate SPD, SPSD, HPD and HPSD matrices;
- deprecates function `make_covariances`, limited to SPD matrices;
- updates tests.

Related to #204