### PR TITLE
Add tests for matrix operators and distances for HPD matrices

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -321,11 +321,11 @@ Base
 .. autosummary::
     :toctree: generated/
 
-    sqrtm
-    invsqrtm
     expm
+    invsqrtm
     logm
     powm
+    sqrtm
     nearest_sym_pos_def
 
 Aproximate Joint Diagonalization

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -19,6 +19,8 @@ v0.5.dev
 - Add function :func:`pyriemann.datasets.simulated.make_matrices` to generate SPD, SPSD, HPD and HPSD matrices.
   Deprecate function :func:`pyriemann.datasets.simulated.make_covariances`. :pr:`232` by :user:`qbarthelemy`
 
+- Add tests for matrix operators and distances for HPD matrices, complete doc and add references. :pr:`234` by :user:`qbarthelemy`
+
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -1,4 +1,4 @@
-"""Base functions for SPD matrices."""
+"""Base functions for SPD/HPD matrices."""
 
 import numpy as np
 from numpy.core.numerictypes import typecodes
@@ -8,7 +8,7 @@ from .test import is_pos_def
 def _matrix_operator(C, operator):
     """Matrix function."""
     if not isinstance(C, np.ndarray) or C.ndim < 2:
-        raise ValueError('Input must be at least a 2D ndarray')
+        raise ValueError("Input must be at least a 2D ndarray")
     if C.dtype.char in typecodes['AllFloat'] and (
             np.isinf(C).any() or np.isnan(C).any()):
         raise ValueError(
@@ -22,62 +22,13 @@ def _matrix_operator(C, operator):
     return D
 
 
-def sqrtm(C):
-    r"""Square root of SPD matrices.
-
-    The matrix square root of a SPD matrix C is defined by:
-
-    .. math::
-        \mathbf{D} =
-        \mathbf{V} \left( \mathbf{\Lambda} \right)^{1/2} \mathbf{V}^\top
-
-    where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
-    and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
-
-    Parameters
-    ----------
-    C : ndarray, shape (..., n, n)
-        SPD matrices, at least 2D ndarray.
-
-    Returns
-    -------
-    D : ndarray, shape (..., n, n)
-        Matrix square root of C.
-    """
-    return _matrix_operator(C, np.sqrt)
-
-
-def logm(C):
-    r"""Logarithm of SPD matrices.
-
-    The matrix logarithm of a SPD matrix C is defined by:
-
-    .. math::
-        \mathbf{D} = \mathbf{V} \log{(\mathbf{\Lambda})} \mathbf{V}^\top
-
-    where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
-    and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
-
-    Parameters
-    ----------
-    C : ndarray, shape (..., n, n)
-        SPD matrices, at least 2D ndarray.
-
-    Returns
-    -------
-    D : ndarray, shape (..., n, n)
-        Matrix logarithm of C.
-    """
-    return _matrix_operator(C, np.log)
-
-
 def expm(C):
-    r"""Exponential of SPD matrices.
+    r"""Exponential of SPD/HPD matrices.
 
-    The matrix exponential of a SPD matrix C is defined by:
+    The symmetric matrix exponential of a SPD/HPD matrix C is defined by:
 
     .. math::
-        \mathbf{D} = \mathbf{V} \exp{(\mathbf{\Lambda})} \mathbf{V}^\top
+        \mathbf{D} = \mathbf{V} \exp{(\mathbf{\Lambda})} \mathbf{V}^H
 
     where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
     and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
@@ -85,7 +36,7 @@ def expm(C):
     Parameters
     ----------
     C : ndarray, shape (..., n, n)
-        SPD matrices, at least 2D ndarray.
+        SPD/HPD matrices, at least 2D ndarray.
 
     Returns
     -------
@@ -96,13 +47,14 @@ def expm(C):
 
 
 def invsqrtm(C):
-    r"""Inverse square root of SPD matrices.
+    r"""Inverse square root of SPD/HPD matrices.
 
-    The matrix inverse square root of a SPD matrix C is defined by:
+    The symmetric matrix inverse square root of a SPD/HPD matrix C is
+    defined by:
 
     .. math::
         \mathbf{D} =
-        \mathbf{V} \left( \mathbf{\Lambda} \right)^{-1/2} \mathbf{V}^\top
+        \mathbf{V} \left( \mathbf{\Lambda} \right)^{-1/2} \mathbf{V}^H
 
     where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
     and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
@@ -110,7 +62,7 @@ def invsqrtm(C):
     Parameters
     ----------
     C : ndarray, shape (..., n, n)
-        SPD matrices, at least 2D ndarray.
+        SPD/HPD matrices, at least 2D ndarray.
 
     Returns
     -------
@@ -121,14 +73,13 @@ def invsqrtm(C):
     return _matrix_operator(C, isqrt)
 
 
-def powm(C, alpha):
-    r"""Power of SPD matrices.
+def logm(C):
+    r"""Logarithm of SPD/HPD matrices.
 
-    The matrix power :math:`\alpha` of a SPD matrix C is defined by:
+    The symmetric matrix logarithm of a SPD/HPD matrix C is defined by:
 
     .. math::
-        \mathbf{D} =
-        \mathbf{V} \left( \mathbf{\Lambda} \right)^{\alpha} \mathbf{V}^\top
+        \mathbf{D} = \mathbf{V} \log{(\mathbf{\Lambda})} \mathbf{V}^H
 
     where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
     and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
@@ -136,7 +87,33 @@ def powm(C, alpha):
     Parameters
     ----------
     C : ndarray, shape (..., n, n)
-        SPD matrices, at least 2D ndarray.
+        SPD/HPD matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    D : ndarray, shape (..., n, n)
+        Matrix logarithm of C.
+    """
+    return _matrix_operator(C, np.log)
+
+
+def powm(C, alpha):
+    r"""Power of SPD/HPD matrices.
+
+    The symmetric matrix power :math:`\alpha` of a SPD/HPD matrix C is defined
+    by:
+
+    .. math::
+        \mathbf{D} =
+        \mathbf{V} \left( \mathbf{\Lambda} \right)^{\alpha} \mathbf{V}^H
+
+    where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
+    and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
+
+    Parameters
+    ----------
+    C : ndarray, shape (..., n, n)
+        SPD/HPD matrices, at least 2D ndarray.
     alpha : float
         The power to apply.
 
@@ -147,6 +124,35 @@ def powm(C, alpha):
     """
     def power(x): return x**alpha
     return _matrix_operator(C, power)
+
+
+def sqrtm(C):
+    r"""Square root of SPD/HPD matrices.
+
+    The symmetric matrix square root of a SPD/HPD matrix C is defined
+    by:
+
+    .. math::
+        \mathbf{D} =
+        \mathbf{V} \left( \mathbf{\Lambda} \right)^{1/2} \mathbf{V}^H
+
+    where :math:`\mathbf{\Lambda}` is the diagonal matrix of eigenvalues
+    and :math:`\mathbf{V}` the eigenvectors of :math:`\mathbf{C}`.
+
+    Parameters
+    ----------
+    C : ndarray, shape (..., n, n)
+        SPD/HPD matrices, at least 2D ndarray.
+
+    Returns
+    -------
+    D : ndarray, shape (..., n, n)
+        Matrix square root of C.
+    """
+    return _matrix_operator(C, np.sqrt)
+
+
+###############################################################################
 
 
 def _nearest_sym_pos_def(S, reg=1e-6):

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -1,4 +1,4 @@
-"""Distances between SPD matrices."""
+"""Distances between SPD/HPD matrices."""
 
 import numpy as np
 from scipy.linalg import eigvalsh, solve
@@ -8,11 +8,11 @@ from .base import logm, sqrtm, invsqrtm
 
 def _check_inputs(A, B):
     if not isinstance(A, np.ndarray) or not isinstance(B, np.ndarray):
-        raise ValueError('Inputs must be ndarrays')
+        raise ValueError("Inputs must be ndarrays")
     if not A.shape == B.shape:
-        raise ValueError('Inputs must have equal dimensions')
+        raise ValueError("Inputs must have equal dimensions")
     if A.ndim < 2:
-        raise ValueError('Inputs must be at least a 2D ndarray')
+        raise ValueError("Inputs must be at least a 2D ndarray")
 
 
 def _recursive(fun, A, B, *args, **kwargs):
@@ -30,9 +30,9 @@ def _recursive(fun, A, B, *args, **kwargs):
 
 
 def distance_euclid(A, B):
-    r"""Euclidean distance between SPD matrices.
+    r"""Euclidean distance between matrices.
 
-    The Euclidean distance between two SPD matrices A and B is defined
+    The Euclidean distance between two matrices A and B is defined
     as the Frobenius norm of the difference of the two matrices:
 
     .. math::
@@ -40,10 +40,10 @@ def distance_euclid(A, B):
 
     Parameters
     ----------
-    A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
-    B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+    A : ndarray, shape (..., n, m)
+        First matrices, at least 2D ndarray.
+    B : ndarray, shape (..., n, m)
+        Second matrices, same dimensions as A.
 
     Returns
     -------
@@ -55,9 +55,9 @@ def distance_euclid(A, B):
 
 
 def distance_harmonic(A, B):
-    r"""Harmonic distance between SPD matrices.
+    r"""Harmonic distance between invertible matrices.
 
-    The harmonic distance between two SPD matrices A and B is:
+    The harmonic distance between two invertible matrices A and B is:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -66,9 +66,9 @@ def distance_harmonic(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First invertible matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second invertible matrices, same dimensions as A.
 
     Returns
     -------
@@ -79,9 +79,10 @@ def distance_harmonic(A, B):
 
 
 def distance_kullback(A, B):
-    r"""Kullback-Leibler divergence between SPD matrices.
+    r"""Kullback-Leibler divergence between SPD/HPD matrices.
 
-    The left Kullback-Leibler divergence between two SPD matrices A and B is:
+    The left Kullback-Leibler divergence between two SPD/HPD matrices A and B
+    is [1]_:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -91,14 +92,21 @@ def distance_kullback(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First SPD/HPD matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second SPD/HPD matrices, same dimensions as A.
 
     Returns
     -------
     d : ndarray, shape (...,) or float
         Left Kullback-Leibler divergence between A and B.
+
+    References
+    ----------
+    .. [1] `On information and sufficiency
+        <https://www.jstor.org/stable/2236703>`_
+        S. Kullback S, R. Leibler.
+        The Annals of Mathematical Statistics, 1951, 22 (1), pp. 79-86
     """
     _check_inputs(A, B)
     n = A.shape[-1]
@@ -113,18 +121,39 @@ def distance_kullback_right(A, B):
 
 
 def distance_kullback_sym(A, B):
-    """Symmetrized Kullback-Leibler divergence between SPD matrices.
+    """Symmetrized Kullback-Leibler divergence between SPD/HPD matrices.
 
-    The symmetrized Kullback-Leibler divergence between two SPD matrices A and
-    B is the sum of left and right Kullback-Leibler divergences.
+    The symmetrized Kullback-Leibler divergence between two SPD/HPD matrices A
+    and B is the sum of left and right Kullback-Leibler divergences. It is also
+    called Jeffreys divergence [1]_.
+
+    Parameters
+    ----------
+    A : ndarray, shape (..., n, n)
+        First SPD/HPD matrices, at least 2D ndarray.
+    B : ndarray, shape (..., n, n)
+        Second SPD/HPD matrices, same dimensions as A.
+
+    Returns
+    -------
+    d : ndarray, shape (...,) or float
+        Symmetrized Kullback-Leibler divergence between A and B.
+
+    References
+    ----------
+    .. [1] `An invariant form for the prior probability in estimation problems
+        <https://www.jstor.org/stable/97883>`_
+        H. Jeffreys.
+        Proceedings of the Royal Society of London A: mathematical, physical
+        and engineering sciences, 1946, 186 (1007), pp. 453-461
     """
     return distance_kullback(A, B) + distance_kullback_right(A, B)
 
 
 def distance_logdet(A, B):
-    r"""Log-det distance between SPD matrices.
+    r"""Log-det distance between SPD/HPD matrices.
 
-    The log-det distance between two SPD matrices A and B is:
+    The log-det distance between two SPD/HPD matrices A and B is [1]_:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -134,14 +163,21 @@ def distance_logdet(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First SPD/HPD matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second SPD/HPD matrices, same dimensions as A.
 
     Returns
     -------
     d : ndarray, shape (...,) or float
         Log-det distance between A and B.
+
+    References
+    ----------
+    .. [1] `Matrix nearness problems with Bregman divergences
+        <https://epubs.siam.org/doi/abs/10.1137/060649021>`_
+        I.S. Dhillon, J.A. Tropp.
+        SIAM J Matrix Anal Appl, 2007, 29 (4), pp. 1120-1146
     """
     _check_inputs(A, B)
     logdet_ApB = np.linalg.slogdet((A + B) / 2.0)[1]
@@ -152,9 +188,9 @@ def distance_logdet(A, B):
 
 
 def distance_logeuclid(A, B):
-    r"""Log-Euclidean distance between SPD matrices.
+    r"""Log-Euclidean distance between SPD/HPD matrices.
 
-    The Log-Euclidean distance between two SPD matrices A and B is:
+    The Log-Euclidean distance between two SPD/HPD matrices A and B is [1]_:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -163,23 +199,31 @@ def distance_logeuclid(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First SPD/HPD matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second SPD/HPD matrices, same dimensions as A.
 
     Returns
     -------
     d : ndarray, shape (...,) or float
         Log-Euclidean distance between A and B.
+
+    References
+    ----------
+    .. [1] `Geometric means in a novel vector space structure on symmetric
+        positive-definite matrices
+        <https://epubs.siam.org/doi/abs/10.1137/050637996>`_
+        V. Arsigny, P. Fillard, X. Pennec, N. Ayache.
+        SIAM J Matrix Anal Appl, 2007, 29 (1), pp. 328-347
     """
     return distance_euclid(logm(A), logm(B))
 
 
 def distance_riemann(A, B):
-    r"""Affine-invariant Riemannian distance between SPD matrices.
+    r"""Affine-invariant Riemannian distance between SPD/HPD matrices.
 
-    The affine-invariant Riemannian distance between two SPD matrices A and B
-    is:
+    The affine-invariant Riemannian distance between two SPD/HPD matrices A and
+    B is [1]_:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -191,23 +235,31 @@ def distance_riemann(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First SPD/HPD matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second SPD/HPD matrices, same dimensions as A.
 
     Returns
     -------
     d : ndarray, shape (...,) or float
         Affine-invariant Riemannian distance between A and B.
+
+    References
+    ----------
+    .. [1] `A differential geometric approach to the geometric mean of
+        symmetric positive-definite matrices
+        <https://epubs.siam.org/doi/10.1137/S0895479803436937>`_
+        M. Moakher. SIAM J Matrix Anal Appl, 2005, 26 (3), pp. 735-747
     """
     _check_inputs(A, B)
     return np.sqrt((np.log(_recursive(eigvalsh, A, B))**2).sum(axis=-1))
 
 
 def distance_wasserstein(A, B):
-    r"""Wasserstein distance between SPD matrices.
+    r"""Wasserstein distance between SPSD/HPSD matrices.
 
-    The Wasserstein distance between two SPD matrices A and B is:
+    The Wasserstein distance between two SPSD/HPSD matrices A and B is [1]_
+    [2]_:
 
     .. math::
         d(\mathbf{A},\mathbf{B}) =
@@ -216,15 +268,25 @@ def distance_wasserstein(A, B):
     Parameters
     ----------
     A : ndarray, shape (..., n, n)
-        First SPD matrices, at least 2D ndarray.
+        First SPSD/HPSD matrices, at least 2D ndarray.
     B : ndarray, shape (..., n, n)
-        Second SPD matrices, same dimensions as A.
+        Second SPSD/HPSD matrices, same dimensions as A.
 
     Returns
     -------
     d : ndarray, shape (...,) or float
         Wasserstein distance between A and B.
-    """
+
+    References
+    ----------
+    .. [1] `Optimal transport: old and new
+        <https://link.springer.com/book/10.1007/978-3-540-71050-9>`_
+        C. Villani. Springer Science & Business Media, 2008, vol. 338
+    .. [2] `An extension of Kakutani's theorem on infinite product measures to
+        the tensor product of semifinite w*-algebras
+        <https://www.ams.org/journals/tran/1969-135-00/S0002-9947-1969-0236719-2/S0002-9947-1969-0236719-2.pdf>`_
+        D. Bures. Trans Am Math Soc, 1969, 135, pp. 199-212
+    """  # noqa
     _check_inputs(A, B)
     B12 = sqrtm(B)
     dist2 = np.trace(A + B - 2 * sqrtm(B12 @ A @ B12), axis1=-2, axis2=-1)
@@ -252,26 +314,26 @@ def _check_distance_method(method):
     """Check distance methods."""
     if isinstance(method, str):
         if method not in distance_methods.keys():
-            raise ValueError('Unknown distance method')
+            raise ValueError("Unknown distance method")
         else:
             method = distance_methods[method]
     elif not hasattr(method, '__call__'):
-        raise ValueError('Distance method must be a function or a string.')
+        raise ValueError("Distance method must be a function or a string.")
     return method
 
 
 def distance(A, B, metric='riemann'):
-    """Distance between SPD matrices according to a metric.
+    """Distance between matrices according to a metric.
 
-    Compute the distance between two SPD matrices A and B according to a
-    metric, or between a set of SPD matrices A and a SPD matrix B.
+    Compute the distance between two matrices A and B according to a metric
+    [1]_, or between a set of matrices A and another matrix B.
 
     Parameters
     ----------
     A : ndarray, shape (n, n) or shape (n_matrices, n, n)
-        First SPD matrix.
+        First matrix, or set of matrices.
     B : ndarray, shape (n, n)
-        Second SPD matrix.
+        Second matrix.
     metric : string, default='riemann'
         The metric for distance, can be: 'euclid', 'harmonic', 'kullback',
         'kullback_right', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',
@@ -281,6 +343,14 @@ def distance(A, B, metric='riemann'):
     -------
     d : float or ndarray, shape (n_matrices, 1)
         The distance(s) between A and B.
+
+    References
+    ----------
+    .. [1] `Review of Riemannian distances and divergences, applied to
+        SSVEP-based BCI
+        <https://hal.archives-ouvertes.fr/LISV/hal-03015762v1>`_
+        S. Chevallier, E. K. Kalunga, Q. Barthélemy, E. Monacelli.
+        Neuroinformatics, Springer, 2021, 19 (1), pp.93-106
     """
     if callable(metric):
         distance_function = metric
@@ -308,9 +378,9 @@ def pairwise_distance(X, Y=None, metric='riemann'):
     Parameters
     ----------
     X : ndarray, shape (n_matrices_X, n, n)
-        First set of SPD matrices.
+        First set of matrices.
     Y : None | ndarray, shape (n_matrices_Y, n, n), default=None
-        Second set of SPD matrices. If None, Y is set to X.
+        Second set of matrices. If None, Y is set to X.
     metric : string, default='riemann'
         The metric for distance, can be: 'euclid', 'harmonic', 'kullback',
         'kullback_right', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 
 from pyriemann.datasets.sampling import generate_random_spd_matrix
 from pyriemann.datasets.simulated import (
@@ -53,12 +54,14 @@ def test_make_matrices(rndstate, kind):
     elif kind == "spd":
         assert is_spd(X)
         assert is_spsd(X)
+        assert_array_almost_equal(X, np.swapaxes(X, -2, -1))
     elif kind == "spsd":
         assert is_spsd(X)
         assert not is_spd(X, tol=1e-9)
     elif kind == "hpd":
         assert is_hpd(X)
         assert is_hpsd(X)
+        assert_array_almost_equal(X, np.swapaxes(X.conj(), -2, -1))
     else:  # hpsd
         assert is_hpsd(X)
         assert not is_hpd(X, tol=1e-9)

--- a/tests/test_utils_base.py
+++ b/tests/test_utils_base.py
@@ -3,11 +3,11 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from pyriemann.utils.base import (
-    sqrtm,
+    expm,
     invsqrtm,
     logm,
-    expm,
     powm,
+    sqrtm,
     nearest_sym_pos_def,
 )
 from pyriemann.utils.mean import mean_riemann
@@ -17,53 +17,55 @@ from pyriemann.utils.test import is_pos_def, is_sym_pos_def
 n_channels = 3
 
 
-def test_sqrtm():
-    """Test matrix square root"""
+def test_expm():
+    """Test matrix exponential"""
     C = 2 * np.eye(n_channels)
-    Ctrue = np.sqrt(2) * np.eye(n_channels)
-    assert_array_almost_equal(sqrtm(C), Ctrue)
-
-    C = np.array([[1, -1j], [1j, 1]])
-    Ctrue = np.sqrt(2) / 2 * C
-    assert_array_almost_equal(sqrtm(C), Ctrue)
+    Ctrue = np.exp(2) * np.eye(n_channels)
+    assert_array_almost_equal(expm(C), Ctrue, decimal=10)
 
 
 def test_invsqrtm():
     """Test matrix inverse square root"""
     C = 2 * np.eye(n_channels)
     Ctrue = (1.0 / np.sqrt(2)) * np.eye(n_channels)
-    assert_array_almost_equal(invsqrtm(C), Ctrue)
+    assert_array_almost_equal(invsqrtm(C), Ctrue, decimal=10)
 
 
 def test_logm():
     """Test matrix logarithm"""
     C = 2 * np.eye(n_channels)
     Ctrue = np.log(2) * np.eye(n_channels)
-    assert_array_almost_equal(logm(C), Ctrue)
-
-
-def test_expm():
-    """Test matrix exponential"""
-    C = 2 * np.eye(n_channels)
-    Ctrue = np.exp(2) * np.eye(n_channels)
-    assert_array_almost_equal(expm(C), Ctrue)
+    assert_array_almost_equal(logm(C), Ctrue, decimal=10)
 
 
 def test_powm():
     """Test matrix power"""
     C = 2 * np.eye(n_channels)
-    Ctrue = (2 ** 0.5) * np.eye(n_channels)
-    assert_array_almost_equal(powm(C, 0.5), Ctrue)
+    Ctrue = (2 ** 0.3) * np.eye(n_channels)
+    assert_array_almost_equal(powm(C, 0.3), Ctrue, decimal=10)
 
 
-def test_check_raise():
-    """Test check SPD matrices"""
-    C = 2 * np.ones((10, n_channels, n_channels))
-    # This is an indirect check, the riemannian mean must crash when the
-    # matrices are not SPD.
-    with pytest.warns(RuntimeWarning):
-        with pytest.raises(ValueError):
-            mean_riemann(C)
+def test_sqrtm():
+    """Test matrix square root"""
+    C = 2 * np.eye(n_channels)
+    Ctrue = np.sqrt(2) * np.eye(n_channels)
+    assert_array_almost_equal(sqrtm(C), Ctrue, decimal=10)
+
+    C = np.array([[1, -1j], [1j, 1]])
+    Ctrue = np.sqrt(2) / 2 * C
+    assert_array_almost_equal(sqrtm(C), Ctrue, decimal=10)
+
+
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+@pytest.mark.parametrize("funm", [expm, invsqrtm, logm, powm, sqrtm])
+def test_funm_all(kind, funm, get_mats):
+    n_matrices, n_dim = 10, 3
+    C = get_mats(n_matrices, n_dim, kind)
+    if funm is powm:
+        D = funm(C, 0.42)
+    else:
+        D = funm(C)
+    assert D.shape == (n_matrices, n_dim, n_dim)
 
 
 def test_funm_error():
@@ -75,7 +77,7 @@ def test_funm_error():
         logm([5.2])
 
 
-@pytest.mark.parametrize("funm", [sqrtm, invsqrtm, logm, expm, powm])
+@pytest.mark.parametrize("funm", [expm, invsqrtm, logm, powm, sqrtm])
 def test_funm_ndarray(funm):
     def test(funm, C):
         if funm == powm:
@@ -93,12 +95,66 @@ def test_funm_ndarray(funm):
     test(funm, C_4d)
 
 
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_funm_properties(get_mats, kind):
+    n_matrices, n_dim = 10, 3
+    C = get_mats(n_matrices, n_dim, kind)
+    invC = np.linalg.inv(C)
+
+    # expm and logm
+    eC, lC = expm(C), logm(C)
+    assert_array_almost_equal(eC.conj(), expm(C.conj()), decimal=10)
+    assert_array_almost_equal(
+        np.linalg.det(eC),
+        np.exp(np.trace(C, axis1=-2, axis2=-1)),
+        decimal=10,
+    )
+    assert_array_almost_equal(logm(eC), C, decimal=10)
+    assert_array_almost_equal(expm(lC), C, decimal=10)
+    assert_array_almost_equal(expm(-lC), invC, decimal=10)
+
+    # invsqrtm
+    isC = invsqrtm(C)
+    Eye = np.repeat(np.eye(n_dim)[np.newaxis, :, :], n_matrices, axis=0)
+    assert_array_almost_equal(isC @ C @ isC, Eye, decimal=10)
+    assert_array_almost_equal(isC @ isC, invC, decimal=10)
+
+    # sqrtm
+    sC = sqrtm(C)
+    assert_array_almost_equal(
+        np.swapaxes(sC.conj(), -2, -1) @ sC,
+        C,
+        decimal=10,
+    )
+    assert_array_almost_equal(isC @ C @ isC, Eye, decimal=10)
+
+    # powm
+    assert_array_almost_equal(powm(C, 0.5), sC, decimal=10)
+    assert_array_almost_equal(powm(C, -0.5), isC, decimal=10)
+    alpha = 0.3
+    assert_array_almost_equal(
+        powm(C, alpha=alpha),
+        expm(alpha * logm(C)),
+        decimal=10,
+    )
+
+
+def test_check_raise():
+    """Test check SPD matrices"""
+    C = 2 * np.ones((10, n_channels, n_channels))
+    # This is an indirect check, the riemannian mean must crash when the
+    # matrices are not SPD.
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError):
+            mean_riemann(C)
+
+
 def test_nearest_sym_pos_def(get_covmats):
     n_matrices = 3
-    covmats = get_covmats(n_matrices, n_channels)
-    D = covmats.diagonal(axis1=1, axis2=2)
-    psd = np.array([cov - np.diag(d) for cov, d in zip(covmats, D)])
+    mats = get_covmats(n_matrices, n_channels)
+    D = mats.diagonal(axis1=1, axis2=2)
+    psd = np.array([mat - np.diag(d) for mat, d in zip(mats, D)])
 
     assert not is_pos_def(psd)
-    assert is_sym_pos_def(nearest_sym_pos_def(covmats))
+    assert is_sym_pos_def(nearest_sym_pos_def(mats))
     assert is_sym_pos_def(nearest_sym_pos_def(psd))

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -129,12 +129,22 @@ def test_distances_all_triangle_inequality(kind, dist, get_mats):
 
 @pytest.mark.parametrize("complex_valued", [True, False])
 def test_distance_euclid(rndstate, complex_valued):
+    """Test Euclidean distance for generic matrices"""
     n_matrices, n_dim0, n_dim1 = 2, 3, 4
     mats = rndstate.randn(n_matrices, n_dim0, n_dim1)
     if complex_valued:
         mats = mats + 1j * rndstate.randn(n_matrices, n_dim0, n_dim1)
     A, B = mats[0], mats[1]
     distance_euclid(A, B)
+
+
+@pytest.mark.parametrize("kind", ["real", "comp"])
+def test_distance_harmonic(kind, get_mats):
+    """Test harmonic distance for invertible matrices"""
+    n_matrices, n_channels = 2, 5
+    mats = get_mats(n_matrices, n_channels, kind)
+    A, B = mats[0], mats[1]
+    distance_harmonic(A, B)
 
 
 def test_distance_kullback_implementation(get_covmats):


### PR DESCRIPTION
This PR:
- sorts matrix operators in alphabetic order in code, test and API;
- completes doc and add references for matrix operators and distances;
- completes tests with HPD matrices for matrix operators and distances.

Related to #204.