### PR TITLE
Enhance ajd module

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -338,6 +338,7 @@ Aproximate Joint Diagonalization
 .. autosummary::
     :toctree: generated/
 
+    ajd
     ajd_pham
     rjd
     uwedge

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -18,6 +18,8 @@ v0.6.dev
 - Add :func:`pyriemann.utils.test.is_real_type` to check the type of input arrays and
   add :func:`pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator. :pr:`251` by :user:`qbarthelemy`
 
+- Add a generic :func:`pyriemann.utils.ajd.ajd` function. :pr:`238` by :user:`qbarthelemy`
+
 
 v0.5 (Jun 2023)
 ---------------
@@ -49,7 +51,6 @@ v0.5 (Jun 2023)
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
 
-- Add a generic :func:`pyriemann.utils.ajd.ajd` function, enhance func:`pyriemann.utils.ajd.ajd_pham` to process HPD matrices, and complete tests. :pr:`238` by :user:`qbarthelemy`
 
 v0.4 (Feb 2023)
 ---------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -49,6 +49,8 @@ v0.5 (Jun 2023)
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
 
+- Add a generic :func:`pyriemann.utils.ajd.ajd` function, enhance func:`pyriemann.utils.ajd.ajd_pham` to process HPD matrices, and complete tests. :pr:`237` by :user:`qbarthelemy`
+
 v0.4 (Feb 2023)
 ---------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -18,7 +18,7 @@ v0.6.dev
 - Add :func:`pyriemann.utils.test.is_real_type` to check the type of input arrays and
   add :func:`pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator. :pr:`251` by :user:`qbarthelemy`
 
-- Add a generic :func:`pyriemann.utils.ajd.ajd` function. :pr:`238` by :user:`qbarthelemy`
+- Enhance ajd module and add a generic :func:`pyriemann.utils.ajd.ajd` function. :pr:`238` by :user:`qbarthelemy`
 
 
 v0.5 (Jun 2023)
@@ -50,7 +50,6 @@ v0.5 (Jun 2023)
 - Correct :func:`pyriemann.utils.distance.distance_mahalanobis`, keeping only real part. :pr:`249` by :user:`qbarthelemy`
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
-
 
 v0.4 (Feb 2023)
 ---------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -49,7 +49,7 @@ v0.5 (Jun 2023)
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
 
-- Add a generic :func:`pyriemann.utils.ajd.ajd` function, enhance func:`pyriemann.utils.ajd.ajd_pham` to process HPD matrices, and complete tests. :pr:`237` by :user:`qbarthelemy`
+- Add a generic :func:`pyriemann.utils.ajd.ajd` function, enhance func:`pyriemann.utils.ajd.ajd_pham` to process HPD matrices, and complete tests. :pr:`238` by :user:`qbarthelemy`
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -265,8 +265,8 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
     .. [2] `Fast Approximate Joint Diagonalization Incorporating Weight
         Matrices
         <https://ieeexplore.ieee.org/document/4671095>`_
-        P. Tichavsky and A. Yeredor. IEEE Transactions on Signal Processing,
-        Volume 57, Issue 3, 2009.
+        P. Tichavsky and A. Yeredor. IEEE Trans Signal Process, 57(3), pp.
+        878 - 891, 2009.
     """
     n_matrices, _, _ = X.shape
     # reshape input matrix
@@ -350,6 +350,9 @@ def _check_ajd_function(method):
 def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
     """Aproximate joint diagonalization (AJD) according to a method.
 
+    Compute the AJD of a set of matrices according to a method [1]_, estimating
+    the joint diagonalizer matrix, diagonalizing the set as much as possible.
+
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n, n)
@@ -382,6 +385,14 @@ def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
     ajd_pham
     rjd
     uwedge
+
+    References
+    ----------
+    .. [1] `Joint Matrices Decompositions and Blind Source Separation: A survey
+        of methods, identification, and applications
+        <http://library.utia.cas.cz/separaty/2014/SI/tichavsky-0427607.pdf>`_
+        G. Chabriel, M. Kleinsteuber, E. Moreau, H. Shen; P. Tichavsky and A.
+        Yeredor. IEEE Signal Process Mag, 31(3), pp. 34-43, 2014.
     """
     ajd_function = _check_ajd_function(method)
     V, D = ajd_function(

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -107,7 +107,7 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
     return V, D
 
 
-def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
+def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=100, sample_weight=None):
     """Approximate joint diagonalization based on Pham's algorithm.
 
     This is a direct implementation of the AJD algorithm [1]_, optimizing a

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -20,7 +20,7 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
     This is an implementation of the orthogonal AJD algorithm [1]_: joint
     approximate diagonalization of eigen-matrices (JADE), based on Jacobi
     angles.
-    The code is a translation of the Matlab code provided on the author's website.
+    The code is a translation of the Matlab code provided on the author's
     website.
 
     Parameters

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -20,7 +20,7 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
     This is an implementation of the orthogonal AJD algorithm [1]_: joint
     approximate diagonalization of eigen-matrices (JADE), based on Jacobi
     angles.
-    The code is a translation of the Matlab code provided in the author
+    The code is a translation of the Matlab code provided on the author's website.
     website.
 
     Parameters
@@ -221,7 +221,7 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
     This is an implementation of the AJD algorithm [1]_ [2]_: uniformly
     weighted exhaustive diagonalization using Gauss iterations (U-WEDGE).
-    This is a translation from the Matlab code provided by the authors.
+    It is a translation from the Matlab code provided by the authors.
 
     Parameters
     ----------
@@ -337,7 +337,7 @@ def _check_ajd_function(method):
             method = ajd_functions[method]
     elif not hasattr(method, '__call__'):
         raise ValueError("Ajd method must be a function or a string "
-                         f"(Got {type(method)}.")
+                         f"(Got {type(method)}).")
     return method
 
 

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -1,41 +1,45 @@
 """Aproximate joint diagonalization algorithms."""
 
 import numpy as np
+import warnings
+
 from .utils import check_weights
 
 
 def _check_init_diag(init, n):
     if init.shape != (n, n):
         raise ValueError(
-            'Initial diagonalizer shape must be %d x % d (Got %s).'
+            "Initial diagonalizer shape must be %d x % d (Got %s)."
             % (n, n, init.shape,))
     return init
 
 
-def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
-    """Approximate joint diagonalization based on Jacobi angles.
+def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
+    """Approximate joint diagonalization based on JADE.
 
-    This is a direct implementation of the AJD algorithm by Cardoso and
-    Souloumiac [1]_ used in JADE. The code is a translation of the Matlab code
-    provided in the author website.
+    This is an implementation of the orthogonal AJD algorithm [1]_: joint
+    approximate diagonalization of eigen-matrices (JADE), based on Jacobi
+    angles.
+    The code is a translation of the Matlab code provided in the author
+    website.
 
     Parameters
     ----------
-    X : ndarray, shape (n_matrices, n_channels, n_channels)
+    X : ndarray, shape (n_matrices, n, n)
         Set of symmetric matrices to diagonalize.
-    init : None | ndarray, shape (n_channels, n_channels), default=None
+    init : None | ndarray, shape (n, n), default=None
         Initialization for the diagonalizer.
     eps : float, default=1e-8
         Tolerance for stopping criterion.
-    n_iter_max : int, default=1000
+    n_iter_max : int, default=100
         The maximum number of iterations to reach convergence.
 
     Returns
     -------
-    V : ndarray, shape (n_channels, n_channels)
+    V : ndarray, shape (n, n)
         The diagonalizer, an orthogonal matrix.
-    D : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of quasi diagonal matrices.
+    D : ndarray, shape (n_matrices, n, n)
+        Set of quasi diagonal matrices, D = V^T X V.
 
     Notes
     -----
@@ -43,26 +47,25 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
 
     See Also
     --------
-    ajd_pham
-    uwedge
+    ajd
 
     References
     ----------
     .. [1] `Jacobi angles for simultaneous diagonalization
         <https://epubs.siam.org/doi/abs/10.1137/S0895479893259546>`_
         J.-F. Cardoso and A. Souloumiac, SIAM Journal on Matrix Analysis and
-        Applications, Volume 17, Issue 1, Jan. 1996.
+        Applications, 17(1), pp. 161–164, 1996.
     """
-
+    n_matrices, _, _ = X.shape
     # reshape input matrix
     A = np.concatenate(X, 0).T
+    n, n_matrices_x_n = A.shape
 
     # init variables
-    m, nm = A.shape  # n_channels, n_matrices_x_channels
     if init is None:
-        V = np.eye(m)
+        V = np.eye(n)
     else:
-        V = _check_init_diag(init, m)
+        V = _check_init_diag(init, n)
     encore = True
     k = 0
 
@@ -71,15 +74,15 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
         k += 1
         if k > n_iter_max:
             break
-        for p in range(m - 1):
-            for q in range(p + 1, m):
+        for p in range(n - 1):
+            for q in range(p + 1, n):
 
-                Ip = np.arange(p, nm, m)
-                Iq = np.arange(q, nm, m)
+                Ip = np.arange(p, n_matrices_x_n, n)
+                Iq = np.arange(q, n_matrices_x_n, n)
 
                 # computation of Givens angle
                 g = np.array([A[p, Ip] - A[q, Iq], A[p, Iq] + A[q, Ip]])
-                gg = np.dot(g, g.T)
+                gg = g @ g.T
                 ton = gg[0, 0] - gg[1, 1]
                 toff = gg[0, 1] + gg[1, 0]
                 theta = 0.5 * np.arctan2(
@@ -100,24 +103,25 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=1000):
                     V[:, p] = c * V[:, p] + s * V[:, q]
                     V[:, q] = c * V[:, q] - s * tmp
 
-    D = np.reshape(A, (m, int(nm / m), m)).transpose(1, 0, 2)
+    D = np.reshape(A, (n, n_matrices, n)).transpose(1, 0, 2)
     return V, D
 
 
-def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
+def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=100, sample_weight=None):
     """Approximate joint diagonalization based on Pham's algorithm.
 
-    This is a direct implementation of the Pham's AJD algorithm [1]_.
+    This is a direct implementation of the AJD algorithm [1]_, optimizing a
+    log-likelihood criterion based on the Kullback-Leibler divergence.
 
     Parameters
     ----------
-    X : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of SPD matrices to diagonalize.
-    init : None | ndarray, shape (n_channels, n_channels), default=None
+    X : ndarray, shape (n_matrices, n, n)
+        Set of SPD/HPD matrices to diagonalize.
+    init : None | ndarray, shape (n, n), default=None
         Initialization for the diagonalizer.
     eps : float, default=1e-6
         Tolerance for stoping criterion.
-    n_iter_max : int, default=15
+    n_iter_max : int, default=100
         The maximum number of iterations to reach convergence.
     sample_weight : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix, strictly positive.
@@ -125,10 +129,10 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
 
     Returns
     -------
-    V : ndarray, shape (n_channels, n_channels)
+    V : ndarray, shape (n, n)
         The diagonalizer, an invertible matrix.
-    D : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of quasi diagonal matrices.
+    D : ndarray, shape (n_matrices, n, n)
+        Set of quasi diagonal matrices, D = V X V^H.
 
     Notes
     -----
@@ -136,16 +140,15 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
 
     See Also
     --------
-    rjd
-    uwedge
+    ajd
 
     References
     ----------
     .. [1] `Joint approximate diagonalization of positive definite
         Hermitian matrices
         <https://epubs.siam.org/doi/10.1137/S089547980035689X>`_
-        D.-T. Pham. SIAM Journal on Matrix Analysis and Applications, Volume 22
-        Issue 4, 2000
+        D.-T. Pham. SIAM Journal on Matrix Analysis and Applications, 22(4),
+        pp. 1136-1152, 2000.
     """
     n_matrices, _, _ = X.shape
     normalized_weight = check_weights(
@@ -154,23 +157,24 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
         check_positivity=True,
     )  # sum = 1
 
-    # Reshape input matrix
+    # reshape input matrix
     A = np.concatenate(X, axis=0).T
+    n, n_matrices_x_n = A.shape
 
-    # Init variables
-    n_channels, n_matrices_x_channels = A.shape
+    # init variables
     if init is None:
-        V = np.eye(n_channels)
+        V = np.eye(n)
     else:
-        V = _check_init_diag(init, n_channels)
-    epsilon = n_channels * (n_channels - 1) * eps
+        V = _check_init_diag(init, n)
+    V = V.astype(X.dtype)
+    epsilon = n * (n - 1) * eps
 
-    for it in range(n_iter_max):
+    for _ in range(n_iter_max):
         decr = 0
-        for ii in range(1, n_channels):
+        for ii in range(1, n):
             for jj in range(ii):
-                Ii = np.arange(ii, n_matrices_x_channels, n_channels)
-                Ij = np.arange(jj, n_matrices_x_channels, n_channels)
+                Ii = np.arange(ii, n_matrices_x_n, n)
+                Ij = np.arange(jj, n_matrices_x_n, n)
 
                 c1 = A[ii, Ii]
                 c2 = A[jj, Ij]
@@ -184,45 +188,52 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=15, sample_weight=None):
 
                 tmp = np.sqrt(omega21 / omega12)
                 tmp1 = (tmp * g12 + g21) / (omega + 1)
-                tmp2 = (tmp * g12 - g21) / max(omega - 1, 1e-9)
+                if np.isrealobj(X):
+                    omega = max(omega - 1, 1e-9)
+                tmp2 = (tmp * g12 - g21) / omega
 
                 h12 = tmp1 + tmp2
                 h21 = np.conj((tmp1 - tmp2) / tmp)
 
                 decr += n_matrices * (g12 * np.conj(h12) + g21 * h21) / 2.0
 
-                tmp = 1 + 1.j * 0.5 * np.imag(h12 * h21)
-                tmp = np.real(tmp + np.sqrt(tmp ** 2 - h12 * h21))
-                tau = np.array([[1, -h12 / tmp], [-h21 / tmp, 1]])
+                tmp = 1 + 0.5j * np.imag(h12 * h21)
+                tmp = tmp + np.sqrt(tmp ** 2 - h12 * h21)
+                if np.isrealobj(X):
+                    tmp = np.real(tmp)
+                tau = np.array([[1, np.conj(-h12 / tmp)],
+                                [np.conj(-h21 / tmp), 1]])
 
-                A[[ii, jj], :] = np.dot(tau, A[[ii, jj], :])
+                A[[ii, jj], :] = tau.conj() @ A[[ii, jj], :]
                 tmp = np.c_[A[:, Ii], A[:, Ij]]
-                tmp = np.reshape(tmp, (n_channels * n_matrices, 2), order='F')
-                tmp = np.dot(tmp, tau.T)
+                tmp = np.reshape(tmp, (n * n_matrices, 2), order='F')
+                tmp = tmp @ tau.T
 
-                tmp = np.reshape(tmp, (n_channels, n_matrices * 2), order='F')
+                tmp = np.reshape(tmp, (n, n_matrices * 2), order='F')
                 A[:, Ii] = tmp[:, :n_matrices]
                 A[:, Ij] = tmp[:, n_matrices:]
-                V[[ii, jj], :] = np.dot(tau, V[[ii, jj], :])
+                V[[ii, jj], :] = tau @ V[[ii, jj], :]
         if decr < epsilon:
             break
-    D = np.reshape(A, (n_channels, -1, n_channels)).transpose(1, 0, 2)
-    return V, D
+    else:
+        warnings.warn("Convergence not reached")
+
+    D = np.reshape(A, (n, -1, n)).transpose(1, 0, 2).conj()
+    return V.astype(X.dtype), D.astype(X.dtype)
 
 
 def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
     """Approximate joint diagonalization based on UWEDGE.
 
-    Implementation of the AJD algorithm by Tichavsky and Yeredor [1]_ [2]_:
-    uniformly weighted exhaustive diagonalization using Gauss iterations
-    (U-WEDGE). This is a translation from the matlab code provided by the
-    authors.
+    This is an implementation of the AJD algorithm [1]_ [2]_: uniformly
+    weighted exhaustive diagonalization using Gauss iterations (U-WEDGE).
+    This is a translation from the Matlab code provided by the authors.
 
     Parameters
     ----------
-    X : ndarray, shape (n_matrices, n_channels, n_channels)
+    X : ndarray, shape (n_matrices, n, n)
         Set of symmetric matrices to diagonalize.
-    init : None | ndarray, shape (n_channels, n_channels), default=None
+    init : None | ndarray, shape (n, n), default=None
         Initialization for the diagonalizer.
     eps : float, default=1e-7
         Tolerance for stoping criterion.
@@ -231,10 +242,10 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
     Returns
     -------
-    V : ndarray, shape (n_channels, n_channels)
+    V : ndarray, shape (n, n)
         The diagonalizer.
-    D : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of quasi diagonal matrices.
+    D : ndarray, shape (n_matrices, n, n)
+        Set of quasi diagonal matrices, D = V X V^T.
 
     Notes
     -----
@@ -242,8 +253,7 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
     See Also
     --------
-    ajd_pham
-    rjd
+    ajd
 
     References
     ----------
@@ -251,64 +261,134 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
         Criterion with a Block Diagonal Weight Matrix
         <https://ieeexplore.ieee.org/abstract/document/4518361>`_
         P. Tichavsky, A. Yeredor and J. Nielsen. 2008 IEEE International
-        Conference on Acoustics, Speech and Signal ProcessingICASSP.
+        Conference on Acoustics, Speech and Signal Processing ICASSP.
     .. [2] `Fast Approximate Joint Diagonalization Incorporating Weight
         Matrices
         <https://ieeexplore.ieee.org/document/4671095>`_
         P. Tichavsky and A. Yeredor. IEEE Transactions on Signal Processing,
-        Volume 57, Issue 3, March 2009.
+        Volume 57, Issue 3, 2009.
     """
-    n_matrices, d, _ = X.shape
+    n_matrices, _, _ = X.shape
     # reshape input matrix
     M = np.concatenate(X, 0).T
+    n, n_matrices_x_n = M.shape
 
     # init variables
-    d, Md = M.shape  # n_channels, n_matrices_x_channels
     iteration = 0
     improve = 10
-
     if init is None:
-        E, H = np.linalg.eig(M[:, 0:d])
-        W_est = H.T / np.sqrt(np.abs(E))[:, np.newaxis]
+        E, H = np.linalg.eig(M[:, 0:n])
+        V = H.T / np.sqrt(np.abs(E))[:, np.newaxis]
     else:
-        W_est = _check_init_diag(init, d)
+        V = _check_init_diag(init, n)
 
     Ms = np.array(M)
-    Rs = np.zeros((d, n_matrices))
+    Rs = np.zeros((n, n_matrices))
 
     for k in range(n_matrices):
-        ini = k*d
-        Il = np.arange(ini, ini + d)
-        M[:, Il] = 0.5*(M[:, Il] + M[:, Il].T)
-        Ms[:, Il] = np.dot(np.dot(W_est, M[:, Il]), W_est.T)
+        ini = k * n
+        Il = np.arange(ini, ini + n)
+        M[:, Il] = 0.5 * (M[:, Il] + M[:, Il].T)
+        Ms[:, Il] = V @ M[:, Il] @ V.T
         Rs[:, k] = np.diag(Ms[:, Il])
 
-    crit = np.sum(Ms**2) - np.sum(Rs**2)
+    crit = np.sum(Ms ** 2) - np.sum(Rs ** 2)
     while (improve > eps) & (iteration < n_iter_max):
         B = Rs @ Rs.T
-        C1 = np.zeros((d, d))
-        for i in range(d):
-            C1[:, i] = np.sum(Ms[:, i:Md:d]*Rs, axis=1)
+        C1 = np.zeros((n, n))
+        for i in range(n):
+            C1[:, i] = np.sum(Ms[:, i:n_matrices_x_n:n] * Rs, axis=1)
 
         D0 = B * B.T - np.outer(np.diag(B), np.diag(B))
-        A0 = (C1 * B - np.diag(np.diag(B)) @ C1.T) / (D0 + np.eye(d))
-        A0 += np.eye(d)
-        W_est = np.linalg.solve(A0, W_est)
+        A0 = (C1 * B - np.diag(np.diag(B)) @ C1.T) / (D0 + np.eye(n))
+        A0 += np.eye(n)
+        V = np.linalg.solve(A0, V)
 
-        Raux = np.dot(np.dot(W_est, M[:, 0:d]), W_est.T)
+        Raux = V @ M[:, 0:n] @ V.T
         aux = 1. / np.sqrt(np.abs(np.diag(Raux)))
-        W_est = np.diag(aux) @ W_est
+        V = np.diag(aux) @ V
 
         for k in range(n_matrices):
-            ini = k*d
-            Il = np.arange(ini, ini + d)
-            Ms[:, Il] = np.dot(np.dot(W_est, M[:, Il]), W_est.T)
+            ini = k * n
+            Il = np.arange(ini, ini + n)
+            Ms[:, Il] = V @ M[:, Il] @ V.T
             Rs[:, k] = np.diag(Ms[:, Il])
 
-        crit_new = np.sum(Ms**2) - np.sum(Rs**2)
+        crit_new = np.sum(Ms ** 2) - np.sum(Rs ** 2)
         improve = np.abs(crit_new - crit)
         crit = crit_new
         iteration += 1
 
-    D = np.reshape(Ms, (d, n_matrices, d)).transpose(1, 0, 2)
-    return W_est, D
+    D = np.reshape(Ms, (n, n_matrices, n)).transpose(1, 0, 2)
+    return V, D
+
+
+###############################################################################
+
+
+ajd_methods = {
+    'ajd_pham': ajd_pham,
+    'rjd': rjd,
+    'uwedge': uwedge,
+}
+
+
+def _check_ajd_method(method):
+    """Check ajd methods."""
+    if isinstance(method, str):
+        if method not in ajd_methods.keys():
+            raise ValueError("Unknown ajd method")
+        else:
+            method = ajd_methods[method]
+    elif not hasattr(method, '__call__'):
+        raise ValueError("Ajd method must be a function or a string.")
+    return method
+
+
+def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=50, **kwargs):
+    """Aproximate joint diagonalization (AJD) according to a method.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_matrices, n, n)
+        Set of symmetric matrices to diagonalize.
+    method : string, default='ajd_pham'
+        The method for ajd, can be: 'ajd_pham', 'rjd', 'uwedge', or a callable
+        function.
+    init : None | ndarray, shape (n, n), default=None
+        Initialization for the diagonalizer.
+    eps : float, default=1e-6
+        Tolerance for stopping criterion.
+    n_iter_max : int, default=50
+        The maximum number of iterations to reach convergence.
+    kwargs : dict
+        The keyword arguments passed to the sub function.
+
+    Returns
+    -------
+    V : ndarray, shape (n, n)
+        The diagonalizer.
+    D : ndarray, shape (n_matrices, n, n)
+        Set of quasi diagonal matrices.
+
+    Notes
+    -----
+    .. versionadded:: 0.5
+
+    See Also
+    --------
+    ajd_pham
+    rjd
+    uwedge
+    """
+    if callable(method):
+        V, D = method(X, init=init, eps=eps, n_iter_max=n_iter_max, **kwargs)
+    else:
+        V, D = ajd_methods[method](
+            X,
+            init=init,
+            eps=eps,
+            n_iter_max=n_iter_max,
+            **kwargs,
+        )
+    return V, D

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -372,7 +372,7 @@ def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
 
     Notes
     -----
-    .. versionadded:: 0.5
+    .. versionadded:: 0.6
 
     See Also
     --------

--- a/pyriemann/utils/ajd.py
+++ b/pyriemann/utils/ajd.py
@@ -107,7 +107,7 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
     return V, D
 
 
-def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=100, sample_weight=None):
+def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=20, sample_weight=None):
     """Approximate joint diagonalization based on Pham's algorithm.
 
     This is a direct implementation of the AJD algorithm [1]_, optimizing a
@@ -121,7 +121,7 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=100, sample_weight=None):
         Initialization for the diagonalizer.
     eps : float, default=1e-6
         Tolerance for stoping criterion.
-    n_iter_max : int, default=100
+    n_iter_max : int, default=20
         The maximum number of iterations to reach convergence.
     sample_weight : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix, strictly positive.

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -12,15 +12,15 @@ from .utils import check_weights
 
 
 def mean_ale(covmats, tol=10e-7, maxiter=50, sample_weight=None):
-    """AJD-based log-Euclidean (ALE) mean of SPD matrices.
+    """AJD-based log-Euclidean (ALE) mean of SPD/HPD matrices.
 
-    Return the mean of a set of SPD matrices using the approximate joint
+    Return the mean of a set of SPD/HPD matrices using the approximate joint
     diagonalization (AJD) based log-Euclidean (ALE) mean [1]_.
 
     Parameters
     ----------
     covmats : ndarray, shape (n_matrices, n, n)
-        Set of SPD matrices.
+        Set of SPD/HPD matrices.
     tol : float, default=10e-7
         The tolerance to stop the gradient descent.
     maxiter : int, default=50

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -12,15 +12,15 @@ from .utils import check_weights
 
 
 def mean_ale(covmats, tol=10e-7, maxiter=50, sample_weight=None):
-    """AJD-based log-Euclidean (ALE) mean of SPD/HPD matrices.
+    """AJD-based log-Euclidean (ALE) mean of SPD matrices.
 
-    Return the mean of a set of SPD/HPD matrices using the approximate joint
+    Return the mean of a set of SPD matrices using the approximate joint
     diagonalization (AJD) based log-Euclidean (ALE) mean [1]_.
 
     Parameters
     ----------
     covmats : ndarray, shape (n_matrices, n, n)
-        Set of SPD/HPD matrices.
+        Set of SPD matrices.
     tol : float, default=10e-7
         The tolerance to stop the gradient descent.
     maxiter : int, default=50

--- a/tests/test_utils_ajd.py
+++ b/tests/test_utils_ajd.py
@@ -3,69 +3,104 @@ import numpy as np
 import pytest
 from pytest import approx
 
-from pyriemann.utils.ajd import rjd, ajd_pham, uwedge
+from pyriemann.utils.ajd import ajd, rjd, ajd_pham, uwedge
 
 
-@pytest.mark.parametrize("ajd", [rjd, ajd_pham, uwedge])
-@pytest.mark.parametrize("init", [True, False])
-def test_ajd(ajd, init, get_covmats_params):
+@pytest.mark.parametrize(
+    "method, algo",
+    [
+        ("rjd", rjd),
+        ("ajd_pham", ajd_pham),
+        ("uwedge", uwedge),
+        (uwedge, uwedge),
+    ]
+)
+def test_ajd(method, algo, get_covmats):
     """Test ajd algos"""
-    n_matrices, n_channels = 5, 3
-    covmats, _, evecs = get_covmats_params(n_matrices, n_channels)
-    if init:
-        V, D = ajd(covmats)
-    else:
-        V, D = ajd(covmats, init=evecs)
+    eps, n_iter_max = 1e-6, 100
+    n_matrices, n_channels = 10, 3
+    mats = get_covmats(n_matrices, n_channels)
+
+    V, D = ajd(mats, method=method, eps=eps, n_iter_max=n_iter_max)
     assert V.shape == (n_channels, n_channels)
     assert D.shape == (n_matrices, n_channels, n_channels)
 
-    if ajd is rjd:
+    if method == "rjd":
+        assert D == approx(V.T @ mats @ V)
         assert V.T @ V == approx(np.eye(n_channels))  # check orthogonality
+    else:
+        assert D == approx(V @ mats @ V.T)
+
+    V_, D_ = algo(mats, eps=eps, n_iter_max=n_iter_max)
+    assert np.all(V == V_)
+    assert np.all(D == D_)
 
 
-@pytest.mark.parametrize("ajd", [rjd, ajd_pham, uwedge])
-def test_ajd_init_error(ajd, get_covmats):
+@pytest.mark.parametrize("method", ["rjd", "ajd_pham", "uwedge"])
+@pytest.mark.parametrize("init", [True, False])
+def test_ajd_init(method, init, get_covmats_params):
     """Test init for ajd algos"""
-    n_matrices, n_channels = 5, 3
-    covmats = get_covmats(n_matrices, n_channels)
+    n_matrices, n_channels = 9, 4
+    mats, _, evecs = get_covmats_params(n_matrices, n_channels)
+    if init:
+        ajd(mats, method=method, init=evecs)
+    else:
+        ajd(mats, method=method)
+
+
+@pytest.mark.parametrize("method", ["rjd", "ajd_pham", "uwedge"])
+def test_ajd_init_error(method, get_covmats):
+    """Test init errors for ajd algos"""
+    n_matrices, n_channels = 4, 3
+    mats = get_covmats(n_matrices, n_channels)
     with pytest.raises(ValueError):  # not 2D array
-        ajd(covmats, init=np.ones((3, 2, 2)))
+        ajd(mats, method=method, init=np.ones((3, 2, 2)))
     with pytest.raises(ValueError):  # not square array
-        ajd(covmats, init=np.ones((3, 2)))
+        ajd(mats, method=method, init=np.ones((3, 2)))
     with pytest.raises(ValueError):  # shape not equal to n_channels
-        ajd(covmats, init=np.ones((2, 2)))
+        ajd(mats, method=method, init=np.ones((2, 2)))
 
 
-def test_pham_weight_none_equivalent_uniform(get_covmats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham(kind, get_mats):
+    """Test pham's ajd"""
+    n_matrices, n_channels = 7, 4
+    mats = get_mats(n_matrices, n_channels, kind)
+    V, D = ajd_pham(mats)
+    assert D == approx(V @ mats @ V.conj().T)
+
+
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham_weight_none_equivalent_uniform(kind, get_mats):
     """Test pham's ajd weights: none is equivalent to uniform values"""
-    n_matrices, n_channels, w_val = 5, 3, 2
-    covmats = get_covmats(n_matrices, n_channels)
-    V, D = ajd_pham(covmats)
-    assert V.shape == (n_channels, n_channels)
-    assert D.shape == (n_matrices, n_channels, n_channels)
-
-    Vw, Dw = ajd_pham(covmats, sample_weight=w_val * np.ones(n_matrices))
+    n_matrices, n_channels = 5, 3
+    mats = get_mats(n_matrices, n_channels, kind)
+    V, D = ajd_pham(mats)
+    Vw, Dw = ajd_pham(mats, sample_weight=np.ones(n_matrices))
     assert_array_equal(V, Vw)  # same result as ajd_pham without weight
     assert_array_equal(D, Dw)
 
+    ajd(mats, method="ajd_pham", sample_weight=np.ones(n_matrices))
 
-def test_pham_weight_positive(get_covmats):
+
+def test_ajd_pham_weight_positive(get_covmats):
     """Test pham's ajd weights: must be strictly positive"""
-    n_matrices, n_channels, w_val = 5, 3, 2
-    covmats = get_covmats(n_matrices, n_channels)
-    w = w_val * np.ones(n_matrices)
+    n_matrices, n_channels = 4, 2
+    mats = get_covmats(n_matrices, n_channels)
+    w = 1.23 * np.ones(n_matrices)
     with pytest.raises(ValueError):  # not strictly positive weight
         w[0] = 0
-        ajd_pham(covmats, sample_weight=w)
+        ajd_pham(mats, sample_weight=w)
 
 
-def test_pham_weight_zero(get_covmats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham_weight_zero(kind, get_mats):
     """Setting one weight to almost 0 it's almost like not passing the mat"""
-    n_matrices, n_channels, w_val = 5, 3, 2
-    covmats = get_covmats(n_matrices, n_channels)
-    w = w_val * np.ones(n_matrices)
-    V, D = ajd_pham(covmats[1:], sample_weight=w[1:])
+    n_matrices, n_channels = 5, 4
+    mats = get_mats(n_matrices, n_channels, kind)
+    w = 4.32 * np.ones(n_matrices)
+    V, D = ajd_pham(mats[1:], sample_weight=w[1:])
     w[0] = 1e-12
-    Vw, Dw = ajd_pham(covmats, sample_weight=w)
+    Vw, Dw = ajd_pham(mats, sample_weight=w)
     assert V == approx(Vw, rel=1e-4, abs=1e-8)
     assert D == approx(Dw[1:], rel=1e-4, abs=1e-8)

--- a/tests/test_utils_ajd.py
+++ b/tests/test_utils_ajd.py
@@ -61,6 +61,12 @@ def test_ajd_init_error(method, get_covmats):
         ajd(mats, method=method, init=np.ones((2, 2)))
 
 
+@pytest.mark.parametrize("method", ["abc", 42])
+def test_ajd_method_error(method):
+    with pytest.raises(ValueError):
+        ajd(np.ones((3, 2, 2)), method=method)
+
+
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 def test_ajd_pham(kind, get_mats):
     """Test pham's ajd"""


### PR DESCRIPTION
This PR aims to:

- add a generic `ajd` function, solving partially #49;
- enhance functions `rjd` and `uwedge`, removing np.dot and np.diag(np.diag()), and using uniform notations;
- enhance `ajd_pham`, adding a warning when convergence is not reached; 
- ~~enhance `ajd_pham` to process HPD matrices, 
(following code https://github.com/Marco-Congedo/Diagonalizations.jl/blob/master/src/optim/LogLike.jl#L46). 
A consequence is that mean ALE supports HPD matrices (related to #204);~~
- complete tests.