### PR TITLE
Fix kernel_euclid applied on non-symmetric matrices

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -25,6 +25,8 @@ v0.5.dev
 
 - Fix regression introduced in :func:`pyriemann.spatialfilters.Xdawn` by :pr:`214`. :pr:`242` by :user:`qbarthelemy`
 
+- Fix :func:`pyriemann.utils.kernel.kernel_euclid` applied on non-symmetric matrices. :pr:`244` by :user:`qbarthelemy`
+
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -183,7 +183,8 @@ def _apply_matrix_kernel(kernel_fct, X, Y=None, *, Cref=None, reg=1e-10):
         Y_ = kernel_fct(Y, Cref)
 
     # calculate scalar products: K[i,j] = np.trace(X_[i]^T @ Y_[j])
-    K = np.einsum('abc,dbc->ad', X_, Y_, optimize=True)
+    X_T = X_.transpose((0, 2, 1))
+    K = np.einsum('acb,dbc->ad', X_T, Y_, optimize=True)
 
     # regularization due to numerical errors
     if np.array_equal(X_, Y_):

--- a/tests/test_utils_kernel.py
+++ b/tests/test_utils_kernel.py
@@ -1,4 +1,4 @@
-from numpy import eye
+import numpy as np
 from numpy.core import tensordot, trace
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
@@ -80,19 +80,22 @@ def test_input_dimension_error(ker, rndstate, get_covmats):
         kernel(X, Y, metric=ker)
 
 
-def test_euclid(rndstate):
+@pytest.mark.parametrize("n_dim0, n_dim1", [(4, 4), (4, 5), (5, 4)])
+def test_euclid(n_dim0, n_dim1, rndstate):
     """Test the Euclidean kernel for generic matrices"""
-    n_matrices_X, n_matrices_Y, n_dim0, n_dim1 = 10, 8, 3, 4
+    n_matrices_X, n_matrices_Y = 2, 3
     X = rndstate.randn(n_matrices_X, n_dim0, n_dim1)
     Y = rndstate.randn(n_matrices_Y, n_dim0, n_dim1)
-    assert kernel_euclid(X, Y).shape == (n_matrices_X, n_matrices_Y)
+    K = kernel_euclid(X, Y)
+    assert K.shape == (n_matrices_X, n_matrices_Y)
+    assert_array_almost_equal(K[0, 0], np.trace(X[0].T @ Y[0]))
 
 
 def test_riemann_correctness(rndstate, get_covmats):
     """Test example correctness of Riemann kernel."""
     n_matrices, n_channels = 5, 3
     X = get_covmats(n_matrices, n_channels)
-    K = kernel_riemann(X, Cref=eye(n_channels), reg=0)
+    K = kernel_riemann(X, Cref=np.eye(n_channels), reg=0)
 
     log_X = logm(X)
     tensor = tensordot(log_X, log_X.T, axes=1)


### PR DESCRIPTION
A transpose was missing into kernel computation.
For symmetric matrices, no problem.
For non-symmetric matrices, result was wrong.