### PR TITLE
Add squared argument to distances

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -27,6 +27,7 @@ v0.5.dev
 
 - Fix :func:`pyriemann.utils.kernel.kernel_euclid` applied on non-symmetric matrices. :pr:`245` by :user:`qbarthelemy`
 
+- Add argument ``squared`` to all distances. :pr:`246` by :user:`qbarthelemy`
 
 v0.4 (Feb 2023)
 ---------------

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -818,7 +818,7 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
         for ip, p in enumerate(self.power_list):
             for ill, ll in enumerate(labs_unique):
                 m[ip, ill] = distance(
-                    x, self.covmeans_[p][ll], metric=self.metric) ** 2
+                    x, self.covmeans_[p][ll], metric=self.metric, squared=True)
 
         if self.method_label == 'sum_means':
             ipmin = np.argmin(np.sum(m, axis=1))
@@ -861,8 +861,11 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
                 for ll in self.classes_:
                     m[p].append(
                         distance(
-                            x, self.covmeans_[p][ll], metric=self.metric
-                        ) ** 2
+                            x,
+                            self.covmeans_[p][ll],
+                            metric=self.metric,
+                            squared=True,
+                        )
                     )
             pmin = min(m.items(), key=lambda x: np.sum(x[1]))[0]
             dist.append(np.array(m[pmin]))

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -354,7 +354,7 @@ def make_outliers(n_matrices, mean, sigma, outlier_coeff=10,
     for i in range(n_matrices):
         Oi = generate_random_spd_matrix(n_dim=n_dim, random_state=random_state)
         epsilon_num = outlier_coeff * sigma * n_dim
-        epsilon_den = distance_riemann(Oi, np.eye(n_dim))**2
+        epsilon_den = distance_riemann(Oi, np.eye(n_dim), squared=True)
         epsilon = np.sqrt(epsilon_num / epsilon_den)
         outliers[i] = mean_sqrt @ powm(Oi, epsilon) @ mean_sqrt
 

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -388,7 +388,7 @@ class PermutationDistance(BasePermutation):
                 covmeans[ix],
                 metric=mdm.metric_dist,
                 squared=True,
-                ).sum()
+            ).sum()
         within /= (len(y) - n_classes)
 
         score = between / within

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -359,7 +359,7 @@ class PermutationDistance(BasePermutation):
         if self.mode == 'ftest':
             self.global_mean = mean_covariance(X, metric=self.mdm.metric_mean)
         elif self.mode == 'pairwise':
-            X = pairwise_distance(X, metric=self.mdm.metric_dist)**2
+            X = pairwise_distance(X, metric=self.mdm.metric_dist, squared=True)
         return X
 
     def _score_ftest(self, X, y):
@@ -372,16 +372,23 @@ class PermutationDistance(BasePermutation):
         between = 0
         for ix, classe in enumerate(mdm.classes_):
             di = distance(
-                covmeans[ix], self.global_mean, metric=mdm.metric_dist)**2
+                covmeans[ix],
+                self.global_mean,
+                metric=mdm.metric_dist,
+                squared=True,
+            )
             between += np.sum(y == classe) * di
         between /= (n_classes - 1)
 
         # estimates within class variability
         within = 0
         for ix, classe in enumerate(mdm.classes_):
-            within += (distance(
-                X[y == classe], covmeans[ix], metric=mdm.metric_dist)
-                ** 2).sum()
+            within += distance(
+                X[y == classe],
+                covmeans[ix],
+                metric=mdm.metric_dist,
+                squared=True,
+                ).sum()
         within /= (len(y) - n_classes)
 
         score = between / within
@@ -400,9 +407,12 @@ class PermutationDistance(BasePermutation):
 
         dist = 0
         for ix, classe in enumerate(mdm.classes_):
-            di = (distance(
-                X[y == classe], covmeans[ix], metric=mdm.metric_dist)
-                ** 2).mean()
+            di = distance(
+                X[y == classe],
+                covmeans[ix],
+                metric=mdm.metric_dist,
+                squared=True,
+            ).mean()
             dist += (di / np.sum(y == classe))
         score = mean_dist / np.sqrt(dist)
         return score

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -286,9 +286,12 @@ class TLStretch(BaseEstimator, TransformerMixin):
                 self._means[d] = np.eye(n_dim)
             else:
                 self._means[d] = mean_riemann(X[domains == d])
-            disp_domain = np.sum(distance(
-                X[domains == d], self._means[d], metric=self.metric
-            )**2)
+            disp_domain = distance(
+                X[domains == d],
+                self._means[d],
+                metric=self.metric,
+                squared=True,
+            ).sum()
             self.dispersions_[d] = disp_domain
 
         return self

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -149,7 +149,7 @@ def distance_kullback_right(A, B, squared=False):
 
 
 def distance_kullback_sym(A, B, squared=False):
-    """Symmetrized Kullback-Leibler divergence between SPD/HPD matrices.
+    r"""Symmetrized Kullback-Leibler divergence between SPD/HPD matrices.
 
     The symmetrized Kullback-Leibler divergence between two SPD/HPD matrices
     :math:`\mathbf{A}` and :math:`\mathbf{B}` is the sum of left and right


### PR DESCRIPTION
Many distances need to compute a square root to output final value,
but many algorithms require the squared distances. 

Adding a squared argument to all distances allows to avoid these useless computations.