### PR TITLE
Correct transform and predict_proba of MeanField

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -29,6 +29,8 @@ v0.5.dev
 
 - Add argument ``squared`` to all distances. :pr:`246` by :user:`qbarthelemy`
 
+- Correct transform and predict_proba of :class:`pyriemann.classification.MeanField`. :pr:`247` by :user:`qbarthelemy`
+
 v0.4 (Feb 2023)
 ---------------
 

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -182,7 +182,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         return self.predict(X)
 
     def predict_proba(self, X):
-        """Predict proba using softmax.
+        """Predict proba using softmax of negative squared distances.
 
         Parameters
         ----------
@@ -864,7 +864,6 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
                             x,
                             self.covmeans_[p][ll],
                             metric=self.metric,
-                            squared=True,
                         )
                     )
             pmin = min(m.items(), key=lambda x: np.sum(x[1]))[0]
@@ -893,7 +892,7 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
         return self.predict(X)
 
     def predict_proba(self, X):
-        """Predict proba using softmax.
+        """Predict proba using softmax of negative squared distances.
 
         Parameters
         ----------


### PR DESCRIPTION
Classifier `MeanField` has been added in https://github.com/pyRiemann/pyRiemann/pull/172 .

Code had been adapted from
https://github.com/plcrodrigues/means-field-classifier/blob/master/power_means.py#L42
where `transform` function used squared distances.
But `predict_proba` has been copied from MDM, using squared distances too.

Finally, in `predict_proba`, before applying softmax, distances are magnified by power 4.

I suggest to remove squared distances from transform to be homogenous to MDM.

@plcrodrigues 