### PR TITLE
Enhance 'scm' covariance estimator to process complex inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ through the Riemannian geometry of symmetric (*resp*. Hermitian)
 pyRiemann aims at being a generic package for multivariate data analysis
 but has been designed around [biosignals](https://en.wikipedia.org/wiki/Biosignal) (like EEG, MEG or EMG)
 manipulation applied to [brain-computer interface](https://en.wikipedia.org/wiki/Brain%E2%80%93computer_interface) (BCI),
-estimating covariance matrices from multichannel time series, and classifying them using the Riemannian geometry of SPD matrices [[1]](#1).
+estimating [covariance matrices](https://en.wikipedia.org/wiki/Covariance_matrix) from multichannel time series,
+and classifying them using the Riemannian geometry of SPD matrices [[1]](#1).
 
 For BCI applications, studied paradigms are motor imagery [[2]](#2) [[3]](#3), event-related potentials (ERP) [[4]](#4) and steady-state visually evoked potentials (SSVEP) [[5]](#5).
 Using extended labels, API allows transfer learning between sessions or subjects [[6]](#6).

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 [![Downloads](https://pepy.tech/badge/pot)](https://pepy.tech/project/pyriemann)
 
 pyRiemann is a Python machine learning package based on [scikit-learn](http://scikit-learn.org/stable/modules/classes.html) API.
-It provides a high-level interface for processing and classification of multivariate time series
-through the Riemannian geometry of symmetric positive definite (SPD) matrices.
+It provides a high-level interface for processing and classification of real (*resp*. complex)-valued multivariate data
+through the Riemannian geometry of symmetric (*resp*. Hermitian) 
+[positive definite](https://en.wikipedia.org/wiki/Definite_matrix) (SPD) (*resp*. HPD) matrices.
 
-pyRiemann aims at being a generic package for multivariate time series classification
-but has been designed around multichannel biosignals (like EEG, MEG or EMG) manipulation applied to brain-computer interface (BCI),
-transforming multichannel time series into covariance matrices, and classifying them using the Riemannian geometry of SPD matrices [[1]](#1).
+pyRiemann aims at being a generic package for multivariate data analysis
+but has been designed around [biosignals](https://en.wikipedia.org/wiki/Biosignal) (like EEG, MEG or EMG)
+manipulation applied to [brain-computer interface](https://en.wikipedia.org/wiki/Brain%E2%80%93computer_interface) (BCI),
+estimating covariance matrices from multichannel time series, and classifying them using the Riemannian geometry of SPD matrices [[1]](#1).
 
 For BCI applications, studied paradigms are motor imagery [[2]](#2) [[3]](#3), event-related potentials (ERP) [[4]](#4) and steady-state visually evoked potentials (SSVEP) [[5]](#5).
 Using extended labels, API allows transfer learning between sessions or subjects [[6]](#6).
@@ -25,14 +27,14 @@ This code is BSD-licenced (3 clause).
 
 The documentation is available on http://pyriemann.readthedocs.io/en/latest/
 
-## Install
+# Installation
 
 #### Using PyPI
 
 ```
 pip install pyriemann
 ```
-or using pip+git for the latest version of the code :
+or using pip+git for the latest version of the code:
 
 ```
 pip install git+https://github.com/pyRiemann/pyRiemann
@@ -61,7 +63,7 @@ or in editable mode to be able to modify the sources:
 pip install -e .
 ```
 
-## How to use it
+# How to use
 
 Most of the functions mimic the scikit-learn API, and therefore can be directly used with sklearn.
 For example, for cross-validation classification of EEG signal using the MDM algorithm described in [[2]](#2), it is easy as:
@@ -114,7 +116,7 @@ print(accuracy.mean())
 
 ```
 
-**Check out the example folder for more examples !**
+**Check out the example folder for more examples.**
 
 # Contribution Guidelines
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -205,6 +205,7 @@ Covariance preprocessing
     covariances
     covariance_mest
     covariance_sch
+    covariance_scm
     covariances_EP
     covariances_X
     block_covariances
@@ -353,6 +354,7 @@ Matrix Tests
     is_sym
     is_skew_sym
     is_real
+    is_real_type
     is_hermitian
     is_pos_def
     is_pos_semi_def

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -57,12 +57,12 @@ pyRiemann: Biosignals classification with Riemannian geometry
        <div class="col-md-9">
 
 pyRiemann is a Python machine learning package based on scikit-learn API.
-It provides a high-level interface for processing and classification of multivariate time series
-through the Riemannian geometry of symmetric positive definite (SPD) matrices.
+It provides a high-level interface for processing and classification of real (resp. complex)-valued multivariate data
+through the Riemannian geometry of symmetric (resp. Hermitian) positive definite (SPD) (resp. HPD) matrices.
 
-pyRiemann aims at being a generic package for multivariate time series classification
-but has been designed around multichannel biosignals (like EEG, MEG or EMG) manipulation applied to brain-computer interface (BCI),
-transforming multichannel time series into covariance matrices, and classifying them using the Riemannian geometry of SPD matrices.
+pyRiemann aims at being a generic package for multivariate data analysis
+but has been designed around biosignals (like EEG, MEG or EMG) manipulation applied to brain-computer interface (BCI),
+estimating covariance matrices from multichannel time series, and classifying them using the Riemannian geometry of SPD matrices.
 
 For a brief introduction to the ideas behind the package, you can read the
 :ref:`introductory notes <introduction>`. More practical information is on the

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,7 +12,11 @@ v0.6.dev
 
 - Update pyRiemann from Python 3.7 to 3.8. pr`254` by :user:`qbarthelemy`
 
-- Speedup pairwise distance function :func:`pyriemann.utils.distance.pairwise_distance` by adding individual functions for 'euclid', 'harmonic', 'logeuclid' and 'riemann' metrics. :pr:`256` by :user:`gabelstein`
+- Speedup pairwise distance function :func:`pyriemann.utils.distance.pairwise_distance`
+  by adding individual functions for 'euclid', 'harmonic', 'logeuclid' and 'riemann' metrics. :pr:`256` by :user:`gabelstein`
+
+- Add :func:`pyriemann.utils.test.is_real_type` to check the type of input arrays and
+  add :func:`pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator. :pr:`251` by :user:`qbarthelemy`
 
 
 v0.5 (Jun 2023)
@@ -44,9 +48,6 @@ v0.5 (Jun 2023)
 - Correct :func:`pyriemann.utils.distance.distance_mahalanobis`, keeping only real part. :pr:`249` by :user:`qbarthelemy`
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
-
-- Add :func:`pyriemann.utils.test.is_real_type` to check the type of input arrays and
-  add :func:`pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator. :pr:`251` by :user:`qbarthelemy`
 
 v0.4 (Feb 2023)
 ---------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -45,6 +45,9 @@ v0.5 (Jun 2023)
 
 - Fix :func:`pyriemann.datasets.sample_gaussian_spd` used with ``sampling_method=rejection`` on 2D matrices. :pr:`250` by :user:`mhurte`
 
+- Add :func:`pyriemann.utils.test.is_real_type` to check the type of input arrays and
+  add :func:`pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator. :pr:`251` by :user:`qbarthelemy`
+
 v0.4 (Feb 2023)
 ---------------
 

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -5,7 +5,8 @@ import numpy as np
 from scipy.linalg import eigh, inv
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from .utils.covariance import _check_est, normalize, get_nondiag_weight
+from .utils.covariance import (_check_cov_est_function, normalize,
+                               get_nondiag_weight)
 from .utils.mean import mean_covariance
 from .utils.ajd import ajd_pham
 from . import estimation as est
@@ -79,7 +80,7 @@ class Xdawn(BaseEstimator, TransformerMixin):
 
     @property
     def estimator_fn(self):
-        return _check_est(self.estimator)
+        return _check_cov_est_function(self.estimator)
 
     def fit(self, X, y):
         """Train Xdawn spatial filters.

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -263,7 +263,7 @@ def covariance_scm(X, *, assume_centered=False):
 
     Notes
     -----
-    .. versionadded:: 0.5
+    .. versionadded:: 0.6
 
     References
     ----------

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -3,33 +3,34 @@ import warnings
 import numpy as np
 from scipy.linalg import block_diag
 from scipy.stats import chi2
-from sklearn.covariance import oas, ledoit_wolf, fast_mcd, empirical_covariance
+from sklearn.covariance import oas, ledoit_wolf, fast_mcd
 
 from .distance import distance_mahalanobis
-from .test import is_square
+from .test import is_square, is_real_type
 
 
 def _lwf(X, **kwds):
     """Wrapper for sklearn ledoit wolf covariance estimator"""
+    if not is_real_type(X):
+        raise ValueError("Input must be real-valued.")
     C, _ = ledoit_wolf(X.T, **kwds)
     return C
 
 
 def _mcd(X, **kwds):
     """Wrapper for sklearn mcd covariance estimator"""
+    if not is_real_type(X):
+        raise ValueError("Input must be real-valued.")
     _, C, _, _ = fast_mcd(X.T, **kwds)
     return C
 
 
 def _oas(X, **kwds):
     """Wrapper for sklearn oas covariance estimator"""
+    if not is_real_type(X):
+        raise ValueError("Input must be real-valued.")
     C, _ = oas(X.T, **kwds)
     return C
-
-
-def _scm(X, **kwds):
-    """Wrapper for sklearn sample covariance estimator"""
-    return empirical_covariance(X.T, **kwds)
 
 
 def _hub(X, **kwds):
@@ -160,7 +161,7 @@ def covariance_mest(X, m_estimator, *, init=None, tol=10e-3, n_iter_max=50,
 
     for _ in range(n_iter_max):
 
-        dist2 = distance_mahalanobis(X, cov) ** 2
+        dist2 = distance_mahalanobis(X, cov, squared=True)
         Xw = np.sqrt(weight_func(dist2)) * X
         cov_new = Xw @ Xw.conj().T / n_times
 
@@ -198,7 +199,7 @@ def covariance_sch(X):
     Parameters
     ----------
     X : ndarray, shape (n_channels, n_times)
-        Multi-channel time-series.
+        Multi-channel time-series, real-valued.
 
     Returns
     -------
@@ -217,9 +218,11 @@ def covariance_sch(X):
         J. Schafer, and K. Strimmer. Statistical Applications in Genetics and
         Molecular Biology, Volume 4, Issue 1, 2005.
     """
+    if not is_real_type(X):
+        raise ValueError("Input must be real-valued.")
     _, n_times = X.shape
     X_c = X - X.mean(axis=1, keepdims=True)
-    C_scm = 1. / n_times * X_c @ X_c.T
+    C_scm = X_c @ X_c.T / n_times
 
     # Compute optimal gamma, the weigthing between SCM and shrinkage estimator
     R = (n_times / ((n_times - 1.) * np.outer(X.std(axis=1), X.std(axis=1))))
@@ -237,34 +240,72 @@ def covariance_sch(X):
     return sigma + shrinkage
 
 
-def _check_est(est):
-    """Check if a given estimator is valid."""
+def covariance_scm(X, *, assume_centered=False):
+    """Sample covariance estimator.
 
-    # Check estimator exist and return the correct function
-    estimators = {
-        'corr': np.corrcoef,
-        'cov': np.cov,
-        'hub': _hub,
-        'lwf': _lwf,
-        'mcd': _mcd,
-        'oas': _oas,
-        'scm': _scm,
-        'sch': covariance_sch,
-        'stu': _stu,
-        'tyl': _tyl,
-    }
+    Sample covariance estimator, re-implementing `empirical_covariance` of
+    scikit-learn [1]_, but supporting real and complex-valued data.
 
-    if callable(est):
-        # All good (cross your fingers)
-        pass
-    elif est in estimators.keys():
-        # Map the corresponding estimator
-        est = estimators[est]
+    Parameters
+    ----------
+    X : ndarray, shape (n_channels, n_times)
+        Multi-channel time-series, real or complex-valued.
+    assume_centered : bool, default=False
+        If `True`, data will not be centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If `False`, data will be centered before computation.
+
+    Returns
+    -------
+    cov : ndarray, shape (n_channels, n_channels)
+        Sample covariance matrix.
+
+    Notes
+    -----
+    .. versionadded:: 0.5
+
+    References
+    ----------
+    .. [1] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.empirical_covariance.html
+    """  # noqa
+    _, n_times = X.shape
+
+    if assume_centered:
+        cov = X @ X.conj().T / n_times
     else:
-        # raise an error
-        raise ValueError(
-            """%s is not an valid estimator ! Valid estimators are : %s or a
-             callable function""" % (est, (' , ').join(estimators.keys())))
+        cov = np.cov(X, bias=1)
+
+    return cov
+
+
+###############################################################################
+
+
+cov_est_functions = {
+    'corr': np.corrcoef,
+    'cov': np.cov,
+    'hub': _hub,
+    'lwf': _lwf,
+    'mcd': _mcd,
+    'oas': _oas,
+    'sch': covariance_sch,
+    'scm': covariance_scm,
+    'stu': _stu,
+    'tyl': _tyl,
+}
+
+
+def _check_cov_est_function(est):
+    """Check covariance estimator function."""
+    if isinstance(est, str):
+        if est not in cov_est_functions.keys():
+            raise ValueError(f"Unknown covariance estimator '{est}'")
+        else:
+            est = cov_est_functions[est]
+    elif not hasattr(est, '__call__'):
+        raise ValueError("Covariance estimator must be a function or a string "
+                         f"(Got {type(est)}.")
     return est
 
 
@@ -274,31 +315,30 @@ def covariances(X, estimator='cov', **kwds):
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n_channels, n_times)
-        Multi-channel time-series.
+        Multi-channel time-series, real or complex-valued.
     estimator : {'corr', 'cov', 'hub', 'lwf', 'mcd', 'oas', 'sch', 'scm', \
             'stu', 'tyl'}, default='scm'
         Covariance matrix estimator [est]_:
 
-        * 'corr' for correlation coefficient matrix [corr]_ supporting complex
-          inputs,
-        * 'cov' for numpy based covariance matrix [cov]_ supporting complex
-          inputs,
-        * 'hub' for Huber's M-estimator based covariance matrix [mest]_
-          supporting complex inputs,
-        * 'lwf' for Ledoit-Wolf shrunk covariance matrix [lwf]_,
-        * 'mcd' for minimum covariance determinant matrix [mcd]_,
-        * 'oas' for oracle approximating shrunk covariance matrix [oas]_,
-        * 'sch' for Schaefer-Strimmer shrunk covariance matrix [sch]_,
+        * 'corr' for correlation coefficient matrix [corr]_,
+        * 'cov' for NumPy based covariance matrix [cov]_,
+        * 'hub' for Huber's M-estimator based covariance matrix [mest]_,
+        * 'lwf' for Ledoit-Wolf shrunk covariance matrix [lwf]_
+          only for real-valued inputs,
+        * 'mcd' for minimum covariance determinant matrix [mcd]_
+          only for real-valued inputs,
+        * 'oas' for oracle approximating shrunk covariance matrix [oas]_
+          only for real-valued inputs,
+        * 'sch' for Schaefer-Strimmer shrunk covariance matrix [sch]_
+          only for real-valued inputs,
         * 'scm' for sample covariance matrix [scm]_,
-        * 'stu' for Student-t's M-estimator based covariance matrix [mest]_
-          supporting complex inputs,
-        * 'tyl' for Tyler's M-estimator based covariance matrix [mest]_
-          supporting complex inputs,
+        * 'stu' for Student-t's M-estimator based covariance matrix [mest]_,
+        * 'tyl' for Tyler's M-estimator based covariance matrix [mest]_,
         * or a callable function.
 
         For regularization, consider 'lwf' or 'oas'.
         For robustness, consider 'hub', 'mcd', 'stu' or 'tyl'.
-    **kwds : optional keyword parameters
+    **kwds : dict
         Any further parameters are passed directly to the covariance estimator.
 
     Returns
@@ -314,11 +354,11 @@ def covariances(X, estimator='cov', **kwds):
     .. [lwf] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.ledoit_wolf.html
     .. [mcd] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.MinCovDet.html
     .. [mest] :func:`pyriemann.utils.covariance.covariance_mest`
-    .. [oas] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.OAS.html
+    .. [oas] https://scikit-learn.org/stable/modules/generated/oas-function.html
     .. [sch] :func:`pyriemann.utils.covariance.covariance_sch`
-    .. [scm] https://scikit-learn.org/stable/modules/generated/sklearn.covariance.empirical_covariance.html
+    .. [scm] :func:`pyriemann.utils.covariance.covariance_scm`
     """  # noqa
-    est = _check_est(estimator)
+    est = _check_cov_est_function(estimator)
     n_matrices, n_channels, n_times = X.shape
     covmats = np.empty((n_matrices, n_channels, n_channels), dtype=X.dtype)
     for i in range(n_matrices):
@@ -347,7 +387,7 @@ def covariances_EP(X, P, estimator='cov', **kwds):
             n_channels + n_channels_proto)
         Covariance matrices.
     """
-    est = _check_est(estimator)
+    est = _check_cov_est_function(estimator)
     n_matrices, n_channels, n_times = X.shape
     n_channels_proto, n_times_p = P.shape
     if n_times_p != n_times:
@@ -393,7 +433,7 @@ def covariances_X(X, estimator='scm', alpha=0.2, **kwds):
     if alpha <= 0:
         raise ValueError(
             f"Parameter alpha must be strictly positive (Got {alpha})")
-    est = _check_est(estimator)
+    est = _check_cov_est_function(estimator)
     n_matrices, n_channels, n_times = X.shape
 
     Hchannels = np.eye(n_channels) \
@@ -435,10 +475,10 @@ def block_covariances(X, blocks, estimator='cov', **kwds):
 
     Returns
     -------
-    C : ndarray, shape (n_matrices, n_channels, n_channels)
+    covmats : ndarray, shape (n_matrices, n_channels, n_channels)
         Block diagonal covariance matrices.
     """
-    est = _check_est(estimator)
+    est = _check_cov_est_function(estimator)
     n_matrices, n_channels, n_times = X.shape
 
     if np.sum(blocks) != n_channels:
@@ -461,7 +501,7 @@ def block_covariances(X, blocks, estimator='cov', **kwds):
 
 def eegtocov(sig, window=128, overlapp=0.5, padding=True, estimator='cov'):
     """Convert EEG signal to covariance using sliding window."""
-    est = _check_est(estimator)
+    est = _check_cov_est_function(estimator)
     X = []
     if padding:
         padd = np.zeros((int(window / 2), sig.shape[1]))
@@ -486,7 +526,7 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     Parameters
     ----------
     X : ndarray, shape (n_channels, n_times)
-        Multi-channel time-series.
+        Multi-channel time-series, real-valued.
     window : int, default=128
         The length of the FFT window used for spectral estimation.
     overlap : float, default=0.75
@@ -509,6 +549,8 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Cross-spectrum
     """
+    if not is_real_type(X):
+        raise ValueError("Input must be real-valued.")
     window = int(window)
     if window < 1:
         raise ValueError("Value window must be a positive integer")
@@ -571,7 +613,7 @@ def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     Parameters
     ----------
     X : ndarray, shape (n_channels, n_times)
-        Multi-channel time-series.
+        Multi-channel time-series, real-valued.
     window : int, default=128
         The length of the FFT window used for spectral estimation.
     overlap : float, default=0.75
@@ -608,7 +650,7 @@ def coherence(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None,
     Parameters
     ----------
     X : ndarray, shape (n_channels, n_times)
-        Multi-channel time-series.
+        Multi-channel time-series, real-valued.
     window : int, default=128
         The length of the FFT window used for spectral estimation.
     overlap : float, default=0.75

--- a/pyriemann/utils/test.py
+++ b/pyriemann/utils/test.py
@@ -85,6 +85,10 @@ def is_real_type(X):
     -------
     ret : boolean
         True if matrices are real type.
+
+    Notes
+    -----
+    .. versionadded:: 0.6
     """
     return np.isrealobj(X)
 

--- a/pyriemann/utils/test.py
+++ b/pyriemann/utils/test.py
@@ -73,6 +73,22 @@ def is_real(X):
     return np.allclose(X.imag, np.zeros_like(X.imag))
 
 
+def is_real_type(X):
+    """Check if matrices are real type.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, m)
+        The set of matrices.
+
+    Returns
+    -------
+    ret : boolean
+        True if matrices are real type.
+    """
+    return np.isrealobj(X)
+
+
 def is_hermitian(X):
     """Check if all matrices are Hermitian.
 

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -2,6 +2,7 @@ from numpy.testing import assert_array_almost_equal
 import numpy as np
 from scipy.linalg import block_diag
 from scipy.signal import welch, csd, coherence as coherence_sp
+from sklearn.covariance import empirical_covariance
 import pytest
 
 from pyriemann.utils.covariance import (
@@ -52,10 +53,21 @@ def test_covariances(estimator, rndstate):
             )
 
 
-@pytest.mark.parametrize('estimator', ['corr', 'cov'] + m_estimators)
+@pytest.mark.parametrize('estimator', ['scm'])
+def test_covariances_real_vs_sklearn(estimator, rndstate):
+    """Test equivalence with scikit-learn for real inputs"""
+    n_matrices, n_channels, n_times = 1, 3, 100
+    x = rndstate.randn(n_matrices, n_channels, n_times)
+    cov = covariances(x, estimator=estimator)
+
+    if estimator == 'scm':
+        assert_array_almost_equal(cov[0], empirical_covariance(x[0].T), 10)
+
+
+@pytest.mark.parametrize('estimator', ['corr', 'cov', 'scm'] + m_estimators)
 def test_covariances_complex(estimator, rndstate):
     """Test covariance for complex inputs"""
-    n_matrices, n_channels, n_times = 2, 3, 100
+    n_matrices, n_channels, n_times = 3, 4, 100
     x = rndstate.randn(n_matrices, n_channels, n_times) \
         + 1j * rndstate.randn(n_matrices, n_channels, n_times)
 

--- a/tests/test_utils_test.py
+++ b/tests/test_utils_test.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pyriemann.utils.test import (
-    is_square, is_sym, is_skew_sym, is_real, is_hermitian,
+    is_square, is_sym, is_skew_sym, is_real, is_real_type, is_hermitian,
     is_pos_def, is_pos_semi_def,
     is_sym_pos_def, is_sym_pos_semi_def,
     is_herm_pos_def, is_herm_pos_semi_def,
@@ -45,12 +45,20 @@ def test_is_real(rndstate):
     assert not is_real(B)
 
 
+def test_is_real_type(rndstate):
+    A = np.zeros((n, n + 1))
+    assert is_real_type(A)
+
+    B = np.zeros((n, n + 2), dtype=complex)
+    assert not is_real_type(B)
+
+
 def test_is_hermitian(rndstate):
     A = rndstate.randn(n, n)
     B = np.zeros((n, n), dtype=complex)
     B.real, B.imag = A + A.T, A - A.T
     assert is_hermitian(B)
-    assert not is_hermitian(np.ones((n, n + 1)))
+    assert not is_hermitian(np.ones((n, n)) + 1j * np.ones((n, n)))
 
 
 @pytest.mark.parametrize("fast_mode", [True, False])


### PR DESCRIPTION
This PR aims to:
- add `pyriemann.utils.test.is_real_type` to check the type of input arrays;
- add `pyriemann.utils.covariance.covariance_scm` allowing to process complex-valued inputs for 'scm' covariance estimator (related to https://github.com/scikit-learn/scikit-learn/issues/25519);
- complete tests;
- update readme.

Related to #204.