### PR TITLE
Update to Python-3.8

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ pytest
                   Maria Sayu Yamamoto and
                   Pierre Clisson and
                   Marie-Constance Corsi},
-  title        = {pyRiemann/pyRiemann: v0.3},
-  month        = jul,
-  year         = 2022,
+  title        = {pyRiemann/pyRiemann: v0.5},
+  month        = june,
+  year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.3},
-  doi          = {10.5281/zenodo.7547583},
-  url          = {https://doi.org/10.5281/zenodo.7547583}
+  version      = {v0.5},
+  doi          = {10.5281/zenodo.8059038},
+  url          = {https://doi.org/10.5281/zenodo.8059038}
 }
 ```
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,8 @@
 numpydoc
+sphinx<=7.0.1
 sphinx-gallery
 sphinx-bootstrap_theme
 mne[data]>=0.24
-scikit-learn
 seaborn
 pandas
-joblib
 ipython

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 numpydoc
-sphinx<=7.0.1
+sphinx>=6.0.0,<=7.0.1
 sphinx-gallery
 sphinx-bootstrap_theme
 mne[data]>=0.24

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,8 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.6.dev
 --------
 
+- Update pyRiemann from Python 3.7 to 3.8. pr`254` by :user:`qbarthelemy`
+
 
 v0.5 (Jun 2023)
 ---------------

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -35,6 +35,17 @@ def _check_metric(metric):
     return metric_mean, metric_dist
 
 
+def _mode_1d(X):
+    vals, counts = np.unique(X, return_counts=True)
+    mode = vals[counts.argmax()]
+    return mode
+
+
+def _mode_2d(X, axis=1):
+    mode = np.apply_along_axis(_mode_1d, axis, X)
+    return mode
+
+
 class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
     """Classification by Minimum Distance to Mean.
 
@@ -523,8 +534,8 @@ class KNearestNeighbor(MDM):
         """
         dist = self._predict_distances(covtest)
         neighbors_classes = self.classmeans_[np.argsort(dist)]
-        out = np.unique(neighbors_classes[:, 0:self.n_neighbors], axis=1)[:, 0]
-        return out
+        pred = _mode_2d(neighbors_classes[:, 0:self.n_neighbors], axis=1)
+        return pred
 
     def predict_proba(self, X):
         """Predict proba using softmax.

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -2,7 +2,6 @@
 import functools
 
 import numpy as np
-from scipy import stats
 from sklearn.base import BaseEstimator, ClassifierMixin, TransformerMixin
 from sklearn.svm import SVC as sklearnSVC
 from sklearn.utils.extmath import softmax
@@ -524,7 +523,7 @@ class KNearestNeighbor(MDM):
         """
         dist = self._predict_distances(covtest)
         neighbors_classes = self.classmeans_[np.argsort(dist)]
-        out, _ = stats.mode(neighbors_classes[:, 0:self.n_neighbors], axis=1)
+        out = np.unique(neighbors_classes[:, 0:self.n_neighbors], axis=1)[:, 0]
         return out.ravel()
 
     def predict_proba(self, X):

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -524,7 +524,7 @@ class KNearestNeighbor(MDM):
         dist = self._predict_distances(covtest)
         neighbors_classes = self.classmeans_[np.argsort(dist)]
         out = np.unique(neighbors_classes[:, 0:self.n_neighbors], axis=1)[:, 0]
-        return out.ravel()
+        return out
 
     def predict_proba(self, X):
         """Predict proba using softmax.

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -6,6 +6,11 @@ from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin, clone)
 from sklearn.cluster import KMeans as _KMeans
 
+from .classification import MDM, _check_metric
+from .utils.mean import mean_covariance
+from .utils.geodesic import geodesic
+
+
 def _init_centroids(X, n_clusters, init, random_state, x_squared_norms):
     if random_state is not None:
         random_state = np.random.RandomState(random_state)
@@ -26,10 +31,6 @@ def _init_centroids(X, n_clusters, init, random_state, x_squared_norms):
             sample_weight=np.ones(n_samples) / n_samples,
         )
 
-
-from .classification import MDM, _check_metric
-from .utils.mean import mean_covariance
-from .utils.geodesic import geodesic
 
 #######################################################################
 

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -2,6 +2,7 @@
 import numpy as np
 from joblib import Parallel, delayed
 from scipy.stats import norm, chi2
+import sklearn
 from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin, clone)
 from sklearn.cluster import KMeans as _KMeans
@@ -14,14 +15,14 @@ from .utils.geodesic import geodesic
 def _init_centroids(X, n_clusters, init, random_state, x_squared_norms):
     if random_state is not None:
         random_state = np.random.RandomState(random_state)
-    try:
+    if sklearn.__version__ < '1.3.0':
         return _KMeans(n_clusters=n_clusters, init=init)._init_centroids(
             X,
             x_squared_norms,
             init,
             random_state,
         )
-    except AttributeError:  # from sklearn 1.3.0
+    else:
         n_samples = X.shape[0]
         return _KMeans(n_clusters=n_clusters, init=init)._init_centroids(
             X,

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -384,7 +384,7 @@ def locally_linear_embedding(X,
     M.flat[:: M.shape[0] + 1] += 1
 
     eigen_values, eigen_vectors = eigh(
-        M, eigvals=(1, n_components), overwrite_a=True
+        M, subset_by_index=(1, n_components), overwrite_a=True
     )
     index = np.argsort(np.abs(eigen_values))
     embd, error = eigen_vectors[:, index], np.sum(eigen_values)

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -601,8 +601,7 @@ class TLEstimator(BaseEstimator):
         self : TLEstimator instance
             The TLEstimator instance.
         """
-        if not is_regressor(self.estimator) \
-                and not is_classifier(self.estimator):
+        if not (is_regressor(self.estimator) or is_classifier(self.estimator)):
             raise TypeError(
                 'Estimator has to be either a classifier or a regressor.')
 
@@ -610,6 +609,8 @@ class TLEstimator(BaseEstimator):
 
         if is_regressor(self.estimator):
             y_dec = y_dec.astype(float)
+        if is_classifier(self.estimator):
+            y_dec = y_dec.astype(int)
 
         if self.domain_weight is not None:
             w = np.zeros(len(X_dec))

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -609,8 +609,6 @@ class TLEstimator(BaseEstimator):
 
         if is_regressor(self.estimator):
             y_dec = y_dec.astype(float)
-        if is_classifier(self.estimator):
-            y_dec = y_dec.astype(int)
 
         if self.domain_weight is not None:
             w = np.zeros(len(X_dec))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy!=1.24.0
 scipy
-scikit-learn>=0.22
+scikit-learn>=0.24
 joblib<=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy!=1.24.0
 scipy
 scikit-learn>=0.22
-joblib
+joblib<=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy!=1.24.0
 scipy
 scikit-learn>=0.24
-joblib<=1.2.0
+joblib

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os.path as op
 from setuptools import setup, find_packages
 
 
-# get the version (don't import mne here, so dependencies are not needed)
 version = None
 with open(op.join("pyriemann", "_version.py"), "r") as fid:
     for line in (line.strip() for line in fid):
@@ -41,7 +40,7 @@ setup(
         "numpy!=1.24.0",
         "scipy",
         "scikit-learn",
-        "joblib",
+        "joblib<=1.2.0",
     ],
     extras_require={
         "docs": [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import sys
 import os.path as op
-
 from setuptools import setup, find_packages
 
 
@@ -39,7 +38,7 @@ setup(
     install_requires=[
         "numpy!=1.24.0",
         "scipy",
-        "scikit-learn",
+        "scikit-learn>=0.24",
         "joblib<=1.2.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,12 @@ setup(
         "Tracker": "https://github.com/pyRiemann/pyRiemann/issues/",
     },
     platforms="any",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "numpy!=1.24.0",
         "scipy",
         "scikit-learn>=0.24",
-        "joblib<=1.2.0",
+        "joblib",
     ],
     extras_require={
         "docs": [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     extras_require={
         "docs": [
-            "sphinx<=7.0.1",
+            "sphinx>=6.0.0,<=7.0.1",
             "sphinx-gallery",
             "sphinx-bootstrap_theme",
             "numpydoc",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ],
     extras_require={
         "docs": [
+            "sphinx<=7.0.1",
             "sphinx-gallery",
             "sphinx-bootstrap_theme",
             "numpydoc",

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 from pytest import approx
+from scipy.stats import mode
 from sklearn.dummy import DummyClassifier
 
 from conftest import get_distances, get_means, get_metrics
@@ -11,6 +12,7 @@ from pyriemann.estimation import Covariances
 from pyriemann.utils.kernel import kernel
 from pyriemann.utils.mean import mean_covariance
 from pyriemann.classification import (
+    _mode_2d,
     MDM,
     FgMDM,
     KNearestNeighbor,
@@ -21,6 +23,35 @@ from pyriemann.classification import (
 )
 
 rclf = [MDM, FgMDM, KNearestNeighbor, TSclassifier, SVC, MeanField]
+
+
+@pytest.mark.parametrize(
+    "X, axis, expected",
+    [
+        (
+            np.array([[0, 5], [1, 7], [0, 6], [2, 7]]),
+            0,
+            np.array([0, 7]),
+        ),
+        (
+            np.array([[0, 1, 2, 1, 1, 0], [7, 5, 7, 6, 7, 6]]),
+            1,
+            np.array([1, 7]),
+        ),
+        (
+            np.array([['a', 'b', 'a', 'c', 'a'], ['d', 'e', 'f', 'e', 'e']]),
+            1,
+            np.array(['a', 'e']),
+        ),
+    ],
+)
+def test_mode(X, axis, expected):
+    actual = _mode_2d(X, axis=axis)
+    assert_array_equal(actual, expected)
+
+    if np.issubdtype(X.dtype, np.number):
+        sp, _ = mode(X, axis=axis)
+        assert_array_equal(actual, sp.ravel())
 
 
 @pytest.mark.parametrize("n_classes", [2, 3])

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -170,9 +170,6 @@ def test_tlclassifier_mdm(rndstate, clf, source_domain, target_domain):
     }
     tlclf.fit(X, y_enc)
 
-    # test fit
-    assert_array_equal(tlclf.estimator.classes_, [1, 2])
-
     X, y, domain = decode_domains(X, y_enc)
     X_source = X[domain == 'source_domain']
     y_source = y[domain == 'source_domain']
@@ -235,7 +232,7 @@ def test_tlclassifiers(rndstate, clf, source_domain, target_domain):
     tlclf.fit(X, y_enc)
 
     # test fit
-    assert_array_equal(tlclf.estimator.classes_, [1, 2])
+    assert_array_equal(tlclf.estimator.classes_, ['1', '2'])
 
     # test predict
     predicted = tlclf.predict(X)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -170,6 +170,9 @@ def test_tlclassifier_mdm(rndstate, clf, source_domain, target_domain):
     }
     tlclf.fit(X, y_enc)
 
+    # test fit
+    assert_array_equal(tlclf.estimator.classes_, [1, 2])
+
     X, y, domain = decode_domains(X, y_enc)
     X_source = X[domain == 'source_domain']
     y_source = y[domain == 'source_domain']
@@ -232,7 +235,7 @@ def test_tlclassifiers(rndstate, clf, source_domain, target_domain):
     tlclf.fit(X, y_enc)
 
     # test fit
-    assert_array_equal(tlclf.estimator.classes_, ['1', '2'])
+    assert_array_equal(tlclf.estimator.classes_, [1, 2])
 
     # test predict
     predicted = tlclf.predict(X)

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -150,7 +150,7 @@ def test_mean_of_means(kind, mean, get_mats):
     n_matrices, n_channels = 10, 3
     mats = get_mats(n_matrices, n_channels, kind)
     if mean is mean_ale and kind == "hpd":
-        return True
+        pytest.skip()
     if mean == mean_power:
         p = -0.42
         C = mean(mats, p)

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -43,6 +43,8 @@ def test_mean_shape(kind, mean, get_mats):
     """Test the shape of mean"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
+    if mean is mean_ale and kind == "hpd":
+        pytest.skip()
     if mean == mean_power:
         C = mean(mats, 0.42)
     else:


### PR DESCRIPTION
Update to Python-3.8

Update code to support SciPy 1.11.0 and scikit-learn 1.3.0.

Update readme for version 0.5, see #253.