### PR TITLE
Deprecate input covtest for predict function of KNN

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,8 @@ v0.6.dev
 
 - Update to Read the Docs v2. :pr:`260` by :user:`qbarthelemy`
 
+- Deprecate input ``covtest`` for predict of :class:`pyriemann.classification.KNearestNeighbor`, renamed into ``X``. :pr:`259` by :user:`qbarthelemy`
+
 
 v0.5 (Jun 2023)
 ---------------

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -536,6 +536,7 @@ class KNearestNeighbor(MDM):
         if covtest is not None:
             warnings.warn("Input covtest has been renamed into X and will be "
                           "removed in 0.8.0.", category=DeprecationWarning)
+            assert (X is None)
             X = covtest
 
         dist = self._predict_distances(X)

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -8,6 +8,7 @@ from sklearn.utils.extmath import softmax
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
 from joblib import Parallel, delayed
+import warnings
 
 from .utils.kernel import kernel
 from .utils.mean import mean_covariance, mean_power
@@ -533,8 +534,8 @@ class KNearestNeighbor(MDM):
             Predictions for each matrix according to the closest centroid.
         """
         if covtest is not None:
-            print("DeprecationWarning: input covtest has been renamed into X "
-                  "and will be removed in 0.8.0.")
+            warnings.warn("Input covtest has been renamed into X and will be "
+                          "removed in 0.8.0.", category=DeprecationWarning)
             X = covtest
 
         dist = self._predict_distances(X)

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -519,7 +519,7 @@ class KNearestNeighbor(MDM):
 
         return self
 
-    def predict(self, covtest):
+    def predict(self, X=None, covtest=None):
         """Get the predictions.
 
         Parameters
@@ -532,7 +532,12 @@ class KNearestNeighbor(MDM):
         pred : ndarray of int, shape (n_matrices,)
             Predictions for each matrix according to the closest centroid.
         """
-        dist = self._predict_distances(covtest)
+        if covtest is not None:
+            print("DeprecationWarning: input covtest has been renamed into X "
+                  "and will be removed in 0.8.0.")
+            X = covtest
+
+        dist = self._predict_distances(X)
         neighbors_classes = self.classmeans_[np.argsort(dist)]
         pred = _mode_2d(neighbors_classes[:, 0:self.n_neighbors], axis=1)
         return pred


### PR DESCRIPTION
This PR deprecates inputs `covtest` into `X` for predict function of KNN,