### PR TITLE
Correct KL and Wasserstein distances, keeping only real part

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,8 @@ v0.6.dev
 
 - Update to Read the Docs v2. :pr:`260` by :user:`qbarthelemy`
 
+- Correct :func:`pyriemann.utils.distance.distance_wasserstein` and :func:`pyriemann.utils.distance.distance_kullback`, keeping only real part. :pr:`267` by :user:`qbarthelemy`
+
 
 v0.5 (Jun 2023)
 ---------------

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -140,7 +140,7 @@ def distance_kullback(A, B, squared=False):
     n = A.shape[-1]
     tr = np.trace(_recursive(solve, B, A, assume_a='pos'), axis1=-2, axis2=-1)
     logdet = np.linalg.slogdet(B)[1] - np.linalg.slogdet(A)[1]
-    d = 0.5 * (tr - n + logdet)
+    d = 0.5 * (tr - n + logdet).real
     return d ** 2 if squared else d
 
 
@@ -365,7 +365,7 @@ def distance_wasserstein(A, B, squared=False):
     _check_inputs(A, B)
     B12 = sqrtm(B)
     d2 = np.trace(A + B - 2 * sqrtm(B12 @ A @ B12), axis1=-2, axis2=-1)
-    d2 = np.maximum(0, d2)
+    d2 = np.maximum(0, d2.real)
     return d2 if squared else np.sqrt(d2)
 
 

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -66,8 +66,8 @@ def test_distances_metric(kind, metric, dist, get_mats):
     mats = get_mats(n_matrices, n_channels, kind)
     A, B = mats[0], mats[1]
     d = distance(A, B, metric=metric)
-    dtrue = dist(A, B)
-    assert d == approx(dtrue)
+    assert d == approx(dist(A, B))
+    assert np.isreal(d)
 
 
 def test_distances_metric_error(get_covmats):
@@ -181,18 +181,18 @@ def test_distance_kullback_implementation(get_covmats):
     n_matrices, n_channels = 2, 6
     mats = get_covmats(n_matrices, n_channels)
     A, B = mats[0], mats[1]
-    dist = 0.5*(np.trace(np.linalg.inv(B) @ A) - n_channels
-                + np.log(np.linalg.det(B) / np.linalg.det(A)))
-    assert distance_kullback(A, B) == approx(dist)
+    d = 0.5*(np.trace(np.linalg.inv(B) @ A) - n_channels
+             + np.log(np.linalg.det(B) / np.linalg.det(A)))
+    assert distance_kullback(A, B) == approx(d)
 
 
 def test_distance_logdet_implementation(get_covmats):
     n_matrices, n_channels = 2, 6
     mats = get_covmats(n_matrices, n_channels)
     A, B = mats[0], mats[1]
-    dist = np.sqrt(np.log(np.linalg.det((A + B) / 2.0))
-                   - 0.5 * np.log(np.linalg.det(A)*np.linalg.det(B)))
-    assert distance_logdet(A, B) == approx(dist)
+    d = np.sqrt(np.log(np.linalg.det((A + B) / 2.0))
+                - 0.5 * np.log(np.linalg.det(A)*np.linalg.det(B)))
+    assert distance_logdet(A, B) == approx(d)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
@@ -280,9 +280,9 @@ def test_distance_mahalanobis(rndstate, complex_valued):
     X = rndstate.randn(n_channels, n_times)
     if complex_valued:
         X = X + 1j * rndstate.randn(n_channels, n_times)
-    dist = distance_mahalanobis(X, np.cov(X))
-    assert dist.shape == (n_times,)
-    assert np.all(np.isreal(dist))
+    d = distance_mahalanobis(X, np.cov(X))
+    assert d.shape == (n_times,)
+    assert np.all(np.isreal(d))
 
 
 @pytest.mark.parametrize("mean", [True, None])


### PR DESCRIPTION
Used with HPD matrices, KL and Wasserstein distances returned complex values.
This PR takes the real part of the distances, and complete tests.

Related to #204