### PR TITLE
Rename HankelCovariances into TimeDelayCovariances

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,7 +19,7 @@ SPD Matrices Estimation
     BlockCovariances
     CospCovariances
     Coherences
-    HankelCovariances
+    TimeDelayCovariances
     Kernels
     Shrinkage
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -32,6 +32,8 @@ v0.6.dev
 
 - Correct check for `kernel_fct` param of :class:`pyriemann.classification.SVC`. :pr:`272` by :user:`qbarthelemy`
 
+- Deprecate ``HankelCovariances``, renamed into :class:`pyriemann.estimation.TimeDelayCovariances`. :pr:`275` by :user:`qbarthelemy`
+
 v0.5 (Jun 2023)
 ---------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -22,8 +22,6 @@ v0.6.dev
 
 - Correct :func:`pyriemann.utils.distance.distance_wasserstein` and :func:`pyriemann.utils.distance.distance_kullback`, keeping only real part. :pr:`267` by :user:`qbarthelemy`
 
-- Add ``sample_weight`` parameter in TLCenter, TLStretch and TLRotate. :pr:`273` by :user:`apmellot`
-
 - Deprecate input ``covmats`` for mean functions, renamed into ``X``. :pr:`252` by :user:`qbarthelemy`
 
 - Add support for complex covariance estimation for 'lwf', 'mcd', 'oas' and 'sch' estimators. :pr:`274` by :user:`gabelstein`
@@ -31,6 +29,8 @@ v0.6.dev
 - Deprecate input ``covtest`` for predict of :class:`pyriemann.classification.KNearestNeighbor`, renamed into ``X``. :pr:`259` by :user:`qbarthelemy`
 
 - Correct check for `kernel_fct` param of :class:`pyriemann.classification.SVC`. :pr:`272` by :user:`qbarthelemy`
+
+- Add ``sample_weight`` parameter in TLCenter, TLStretch and TLRotate. :pr:`273` by :user:`apmellot`
 
 - Deprecate ``HankelCovariances``, renamed into :class:`pyriemann.estimation.TimeDelayCovariances`. :pr:`275` by :user:`qbarthelemy`
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -640,14 +640,6 @@ class Coherences(CospCovariances):
         return np.array(out)
 
 
-@deprecated(
-    "HankelCovariances is deprecated and will be removed in 0.8.0; "
-    "please use TimeDelayCovariances."
-)
-class HankelCovariances(BaseEstimator, TransformerMixin):
-    pass
-
-
 class TimeDelayCovariances(BaseEstimator, TransformerMixin):
     """Estimation of covariance matrix with time delay matrices.
 
@@ -738,6 +730,14 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
         X2 = np.array(X2)
         covmats = covariances(X2, estimator=self.estimator, **self.kwds)
         return covmats
+
+
+@deprecated(
+    "HankelCovariances is deprecated and will be removed in 0.8.0; "
+    "please use TimeDelayCovariances."
+)
+class HankelCovariances(TimeDelayCovariances):
+    pass
 
 
 ###############################################################################

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -658,6 +658,12 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
     **kwds : dict
         Any further parameters are passed directly to the covariance estimator.
 
+    Attributes
+    ----------
+    Xtd_ : ndarray, shape (n_matrices, n_channels x n_delays, n_times)
+        Time delay multi-channel time-series, where `n_delays` is equal to:
+        `delays` when it is a int, and `1 + len(delays)` when it is a list.
+
     See Also
     --------
     Covariances
@@ -708,10 +714,10 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_delays x n_channels, \
-                n_delays x n_channels)
-            Time delay covariance matrices, where n_delays is equal to `delays`
-            when it is a int, and to `1 + len(delays)` when it is a list.
+        covmats : ndarray, shape (n_matrices, n_channels x n_delays, \
+                n_channels x n_delays)
+            Time delay covariance matrices, where `n_delays` is equal to:
+            `delays` when it is a int, and `1 + len(delays)` when it is a list.
         """
 
         if isinstance(self.delays, int):
@@ -721,14 +727,15 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
         else:
             raise ValueError('delays must be an integer or a list')
 
-        X2 = []
+        Xtd = []
         for x in X:
             tmp = x
             for d in delays:
                 tmp = np.r_[tmp, np.roll(x, d, axis=-1)]
-            X2.append(tmp)
-        X2 = np.array(X2)
-        covmats = covariances(X2, estimator=self.estimator, **self.kwds)
+            Xtd.append(tmp)
+        self.Xtd_ = np.array(Xtd)
+
+        covmats = covariances(self.Xtd_, estimator=self.estimator, **self.kwds)
         return covmats
 
 

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -7,6 +7,7 @@ from sklearn.metrics.pairwise import pairwise_kernels
 from .spatialfilters import Xdawn
 from .utils.covariance import (covariances, covariances_EP, cospectrum,
                                coherence, block_covariances)
+from .utils import deprecated
 
 
 def _nextpow2(i):
@@ -82,7 +83,8 @@ class Covariances(BaseEstimator, TransformerMixin):
 class ERPCovariances(BaseEstimator, TransformerMixin):
     r"""Estimate special form covariance matrix for ERP.
 
-    Estimation of special form covariance matrix dedicated to ERP processing.
+    Estimation of special form covariance matrix dedicated to event-related
+    potentials (ERP) processing.
     For each class, a prototyped response is obtained by average across trials:
 
     .. math::
@@ -638,11 +640,19 @@ class Coherences(CospCovariances):
         return np.array(out)
 
 
+@deprecated(
+    "HankelCovariances is deprecated and will be removed in 0.8.0; "
+    "please use TimeDelayCovariances."
+)
 class HankelCovariances(BaseEstimator, TransformerMixin):
-    """Estimation of covariance matrix with time delayed Hankel matrices.
+    pass
 
-    Hankel covariance matrices [1]_ are useful to catch spectral dynamics of
-    the signal, similarly to the CSSP method [2]_. It is done by concatenating
+
+class TimeDelayCovariances(BaseEstimator, TransformerMixin):
+    """Estimation of covariance matrix with time delay matrices.
+
+    Time delay covariance matrices are useful to catch spectral dynamics of
+    the signal, similarly to the CSSP method [1]_. It is done by concatenating
     time delayed version of the signal before covariance estimation.
 
     Parameters
@@ -664,8 +674,7 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Hankel_matrix
-    .. [2] `Spatio-spectral filters for improving the classification of single
+    .. [1] `Spatio-spectral filters for improving the classification of single
         trial EEG
         <http://doc.ml.tu-berlin.de/bbci/publications/LemBlaCurMue05.pdf>`_
         S. Lemm, B. Blankertz, B. Curio, K-R. Muller. IEEE Transactions on
@@ -692,13 +701,13 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        self : HankelCovariances instance
-            The HankelCovariances instance.
+        self : TimeDelayCovariances instance
+            The TimeDelayCovariances instance.
         """
         return self
 
     def transform(self, X):
-        """Estimate the Hankel covariance matrices.
+        """Estimate the time delay covariance matrices.
 
         Parameters
         ----------
@@ -709,7 +718,7 @@ class HankelCovariances(BaseEstimator, TransformerMixin):
         -------
         covmats : ndarray, shape (n_matrices, n_delays x n_channels, \
                 n_delays x n_channels)
-            Hankel covariance matrices, where n_delays is equal to `delays`
+            Time delay covariance matrices, where n_delays is equal to `delays`
             when it is a int, and to `1 + len(delays)` when it is a list.
         """
 

--- a/pyriemann/utils/test.py
+++ b/pyriemann/utils/test.py
@@ -17,7 +17,7 @@ def is_square(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if matrices are square.
     """
     return X.ndim >= 2 and X.shape[-2] == X.shape[-1]
@@ -33,7 +33,7 @@ def is_sym(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are symmetric.
     """
     return is_square(X) and np.allclose(X, np.swapaxes(X, -2, -1))
@@ -49,7 +49,7 @@ def is_skew_sym(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are skew-symmetric.
     """
     return is_square(X) and np.allclose(X, -np.swapaxes(X, -2, -1))
@@ -65,7 +65,7 @@ def is_hankel(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if Hankel matrix.
     """
     if not is_square(X) or X.ndim != 2:
@@ -74,7 +74,6 @@ def is_hankel(X):
 
     for i in range(n):
         for j in range(n):
-
             if (i + j < n):
                 if (X[i, j] != X[i + j, 0]):
                     return False
@@ -97,7 +96,7 @@ def is_real(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are strictly real.
     """
     return np.allclose(X.imag, np.zeros_like(X.imag))
@@ -113,7 +112,7 @@ def is_real_type(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if matrices are real type.
 
     Notes
@@ -136,7 +135,7 @@ def is_hermitian(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are Hermitian.
     """
     return is_sym(X.real) and is_skew_sym(X.imag)
@@ -155,12 +154,12 @@ def is_pos_def(X, tol=0.0, fast_mode=False):
         The set of square matrices, at least 2D ndarray.
     tol : float, default 0.0
         Threshold below which eigen values are considered zero.
-    fast_mode : boolean, default=False
+    fast_mode : bool, default=False
         Use Cholesky decomposition to avoid computing all eigenvalues.
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are positive definite.
     """
     if fast_mode:
@@ -183,7 +182,7 @@ def is_pos_semi_def(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are positive semi-definite.
     """
     return is_square(X) and np.all(_get_eigenvals(X) >= 0.0)
@@ -201,7 +200,7 @@ def is_sym_pos_def(X, tol=0.0):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are symmetric positive-definite.
     """
     return is_sym(X) and is_pos_def(X, tol=tol)
@@ -217,7 +216,7 @@ def is_sym_pos_semi_def(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are symmetric positive semi-definite.
     """
     return is_sym(X) and is_pos_semi_def(X)
@@ -235,7 +234,7 @@ def is_herm_pos_def(X, tol=0.0):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are Hermitian positive-definite.
     """
     return is_hermitian(X) and is_pos_def(X, tol=tol)
@@ -251,7 +250,7 @@ def is_herm_pos_semi_def(X):
 
     Returns
     -------
-    ret : boolean
+    ret : bool
         True if all matrices are Hermitian positive semi-definite.
     """
     return is_hermitian(X) and is_pos_semi_def(X)

--- a/pyriemann/utils/test.py
+++ b/pyriemann/utils/test.py
@@ -55,6 +55,36 @@ def is_skew_sym(X):
     return is_square(X) and np.allclose(X, -np.swapaxes(X, -2, -1))
 
 
+def is_hankel(X):
+    """Check if matrix is an Hankel matrix.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n, n)
+        Square matrix.
+
+    Returns
+    -------
+    ret : boolean
+        True if Hankel matrix.
+    """
+    if not is_square(X) or X.ndim != 2:
+        return False
+    n, _ = X.shape
+
+    for i in range(0, n):
+        for j in range(0, n):
+
+            if (i + j < n):
+                if (X[i, j] != X[i + j, 0]):
+                    return False
+            else :
+                if (X[i, j] != X[i + j - n + 1, n - 1]):
+                    return False
+
+    return True
+
+
 def is_real(X):
     """Check if all matrices are strictly real.
 

--- a/pyriemann/utils/test.py
+++ b/pyriemann/utils/test.py
@@ -72,13 +72,13 @@ def is_hankel(X):
         return False
     n, _ = X.shape
 
-    for i in range(0, n):
-        for j in range(0, n):
+    for i in range(n):
+        for j in range(n):
 
             if (i + j < n):
                 if (X[i, j] != X[i + j, 0]):
                     return False
-            else :
+            else:
                 if (X[i, j] != X[i + j - n + 1, n - 1]):
                     return False
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -11,7 +11,7 @@ from pyriemann.estimation import (
     ERPCovariances,
     XdawnCovariances,
     CospCovariances,
-    HankelCovariances,
+    TimeDelayCovariances,
     Coherences,
     Shrinkage,
     BlockCovariances,
@@ -20,6 +20,7 @@ from pyriemann.estimation import (
 from pyriemann.utils.test import (
     is_sym_pos_def as is_spd,
     is_sym_pos_semi_def as is_spsd,
+    is_hankel
 )
 
 estim = ['corr', 'cov', 'lwf', 'mcd', 'oas', 'sch', 'scm']
@@ -63,10 +64,10 @@ def test_covariances_kwds(estimator, kwds, rndstate):
 
 
 @pytest.mark.parametrize("delays", [4, [1, 2]])
-def test_hankel_covariances_delays(delays, rndstate):
+def test_time_delay_covariances(delays, rndstate):
     n_matrices, n_channels, n_times = 2, 3, 100
     x = rndstate.randn(n_matrices, n_channels, n_times)
-    cov = HankelCovariances(delays=delays).fit(x)
+    cov = TimeDelayCovariances(delays=delays).fit(x)
     covmats = cov.fit_transform(x)
     assert cov.get_params() == dict(estimator="scm", delays=delays)
     if isinstance(delays, list):
@@ -76,6 +77,7 @@ def test_hankel_covariances_delays(delays, rndstate):
     assert covmats.shape == (n_matrices, n_delays * n_channels,
                              n_delays * n_channels)
     assert is_spd(covmats)
+    assert ~is_hankel(covmats[0])
 
 
 @pytest.mark.parametrize("estimator", estim)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -12,6 +12,7 @@ from pyriemann.estimation import (
     XdawnCovariances,
     CospCovariances,
     TimeDelayCovariances,
+    HankelCovariances,
     Coherences,
     Shrinkage,
     BlockCovariances,
@@ -78,6 +79,15 @@ def test_time_delay_covariances(delays, rndstate):
                              n_delays * n_channels)
     assert is_spd(covmats)
     assert ~is_hankel(covmats[0])
+
+
+def test_hankel_covariances():
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        HankelCovariances()
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
 
 
 @pytest.mark.parametrize("estimator", estim)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -64,19 +64,31 @@ def test_covariances_kwds(estimator, kwds, rndstate):
     )
 
 
-@pytest.mark.parametrize("delays", [4, [1, 2]])
+def test_time_delay_covariances_xtd():
+    x = np.array([[[1, 2, 3, 4, 5], [11, 12, 13, 14, 15]]])
+    cov = TimeDelayCovariances(delays=[1])
+    cov.fit_transform(x)
+
+    xtd = np.array([[1, 2, 3, 4, 5], [11, 12, 13, 14, 15],
+                    [5, 1, 2, 3, 4], [15, 11, 12, 13, 14]])
+    assert_array_equal(cov.Xtd_[0], xtd)
+
+
+@pytest.mark.parametrize("delays", [4, [1, 5]])
 def test_time_delay_covariances(delays, rndstate):
     n_matrices, n_channels, n_times = 2, 3, 100
     x = rndstate.randn(n_matrices, n_channels, n_times)
-    cov = TimeDelayCovariances(delays=delays).fit(x)
+    cov = TimeDelayCovariances(delays=delays)
     covmats = cov.fit_transform(x)
     assert cov.get_params() == dict(estimator="scm", delays=delays)
-    if isinstance(delays, list):
-        n_delays = 1 + len(delays)
-    elif isinstance(delays, int):
+    if isinstance(delays, int):
         n_delays = delays
+    elif isinstance(delays, list):
+        n_delays = 1 + len(delays)
+
     assert covmats.shape == (n_matrices, n_delays * n_channels,
                              n_delays * n_channels)
+    assert cov.Xtd_.shape == (n_matrices, n_delays * n_channels, n_times)
     assert is_spd(covmats)
     assert ~is_hankel(covmats[0])
 

--- a/tests/test_utils_test.py
+++ b/tests/test_utils_test.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from pyriemann.utils.test import (
-    is_square, is_sym, is_skew_sym, is_real, is_real_type, is_hermitian,
+    is_square, is_sym, is_skew_sym, is_hankel,
+    is_real, is_real_type, is_hermitian,
     is_pos_def, is_pos_semi_def,
     is_sym_pos_def, is_sym_pos_semi_def,
     is_herm_pos_def, is_herm_pos_semi_def,
@@ -32,6 +33,12 @@ def test_is_skew_sym(rndstate):
     assert not is_skew_sym(np.eye(n))
     assert not is_skew_sym(A + A.T)
     assert not is_skew_sym(np.ones((n, n + 1)))
+
+
+def test_is_hankel():
+    assert is_hankel(np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]]))
+    assert not is_hankel(np.array([[1, 2, 3], [1, 3, 4], [3, 4, 5]]))
+    assert not is_hankel(np.array([[1, 2, 3], [2, 3, 3], [3, 4, 5]]))
 
 
 def test_is_real(rndstate):


### PR DESCRIPTION
I wanted to explicitly test if `HankelCovariances`  were Hankel matrices, ie with constant anti-diagonals. And that's not the case.

I therefore suggest to deprecate the name to `TimeDelayCovariances`.