### PR TITLE
Remove make_covariances

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -182,7 +182,6 @@ Datasets
 
     make_gaussian_blobs
     make_outliers
-    make_covariances
     make_matrices
     make_masks
     sample_gaussian_spd

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -36,6 +36,8 @@ v0.6.dev
 
 - Add an example on augmented covariance matrix. :pr:`276` by :user:`carraraig`
 
+- Remove function `make_covariances`. :pr:`280` by :user:`qbarthelemy`
+
 v0.5 (Jun 2023)
 ---------------
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from sklearn.model_selection import train_test_split
 
-from pyriemann.datasets import make_covariances, make_gaussian_blobs
+from pyriemann.datasets import make_matrices, make_gaussian_blobs
 from pyriemann.classification import (
     MDM,
     KNearestNeighbor,
@@ -202,28 +202,28 @@ y = np.concatenate([np.zeros(n_matrices), np.ones(n_matrices)])
 datasets = [
     (
         np.concatenate([
-            make_covariances(
-                n_matrices, n_channels, rs, evals_mean=10, evals_std=1
+            make_matrices(
+                n_matrices, n_channels, "spd", rs, evals_low=10, evals_high=14
             ),
-            make_covariances(
-                n_matrices, n_channels, rs, evals_mean=15, evals_std=1
+            make_matrices(
+                n_matrices, n_channels, "spd", rs, evals_low=13, evals_high=17
             )
         ]),
         y
     ),
     (
         np.concatenate([
-            make_covariances(
-                n_matrices, n_channels, rs, evals_mean=10, evals_std=2
+            make_matrices(
+                n_matrices, n_channels, "spd", rs, evals_low=10, evals_high=14
             ),
-            make_covariances(
-                n_matrices, n_channels, rs, evals_mean=12, evals_std=2
+            make_matrices(
+                n_matrices, n_channels, "spd", rs, evals_low=11, evals_high=15
             )
         ]),
         y
     ),
     make_gaussian_blobs(
-        2*n_matrices, n_channels, random_state=rs, class_sep=1., class_disp=.2,
+        2*n_matrices, n_channels, random_state=rs, class_sep=1., class_disp=.5,
         n_jobs=4
     ),
     make_gaussian_blobs(

--- a/pyriemann/datasets/__init__.py
+++ b/pyriemann/datasets/__init__.py
@@ -1,6 +1,5 @@
 from .sampling import sample_gaussian_spd, generate_random_spd_matrix
 from .simulated import (
-    make_covariances,
     make_matrices,
     make_masks,
     make_gaussian_blobs,
@@ -12,7 +11,6 @@ from .simulated import (
 __all__ = [
     "sample_gaussian_spd",
     "generate_random_spd_matrix",
-    "make_covariances",
     "make_matrices",
     "make_masks",
     "make_gaussian_blobs",

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -6,56 +6,6 @@ from ..utils.distance import distance_riemann
 from ..utils.base import invsqrtm, powm, sqrtm, expm
 from .sampling import generate_random_spd_matrix, sample_gaussian_spd
 from ..transfer import encode_domains
-from ..utils import deprecated
-
-
-@deprecated(
-    "make_covariances is deprecated and will be removed in 0.6.0; "
-    "please use make_matrices."
-)
-def make_covariances(n_matrices, n_channels, rs=None, return_params=False,
-                     evals_mean=2.0, evals_std=0.1):
-    """Generate a set of covariances matrices, with the same eigenvectors.
-
-    Parameters
-    ----------
-    n_matrices : int
-        Number of matrices to generate.
-    n_channels : int
-        Number of channels in covariance matrices.
-    rs : RandomState instance, default=None
-        Random state for reproducible output across multiple function calls.
-    return_params : bool, default=False
-        If True, then return parameters.
-    evals_mean : float, default=2.0
-        Mean of eigen values.
-    evals_std : float, default=0.1
-        Standard deviation of eigen values.
-
-    Returns
-    -------
-    covmats : ndarray, shape (n_matrices, n_channels, n_channels)
-        Covariances matrices.
-    evals : ndarray, shape (n_matrices, n_channels)
-        Eigen values used for each covariance matrix.
-        Only returned if ``return_params=True``.
-    evecs : ndarray, shape (n_channels, n_channels)
-        Eigen vectors used for all covariance matrices.
-        Only returned if ``return_params=True``.
-    """
-    rs = check_random_state(rs)
-
-    evals = np.abs(evals_mean + evals_std * rs.randn(n_matrices, n_channels))
-    evecs, _ = np.linalg.qr(rs.randn(n_channels, n_channels))
-
-    covmats = np.empty((n_matrices, n_channels, n_channels))
-    for i in range(n_matrices):
-        covmats[i] = evecs @ np.diag(evals[i]) @ evecs.T
-
-    if return_params:
-        return covmats, evals, evecs
-    else:
-        return covmats
 
 
 def make_matrices(n_matrices, n_dim, kind, rs=None, return_params=False,

--- a/tests/test_simulated.py
+++ b/tests/test_simulated.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_array_almost_equal
 
 from pyriemann.datasets.sampling import generate_random_spd_matrix
 from pyriemann.datasets.simulated import (
-    make_covariances,
     make_matrices,
     make_masks,
     make_gaussian_blobs,
@@ -17,18 +16,6 @@ from pyriemann.utils.test import (
     is_herm_pos_def as is_hpd,
     is_herm_pos_semi_def as is_hpsd,
 )
-
-
-def test_make_covariances(rndstate):
-    """Test function for make covariances."""
-    n_matrices, n_channels = 5, 4
-    X, evals, evecs = make_covariances(n_matrices=n_matrices,
-                                       n_channels=n_channels,
-                                       return_params=True,
-                                       rs=rndstate)
-    assert X.shape == (n_matrices, n_channels, n_channels)  # X shape mismatch
-    assert evals.shape == (n_matrices, n_channels)  # evals shape mismatch
-    assert evecs.shape == (n_channels, n_channels)  # evecs shape mismatch
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Function `make_covariances` is deprecated from version 0.4 and must be removed in 0.6.