### PR TITLE
Use a unique function check_metric

### DIFF
--- a/pyriemann/channelselection.py
+++ b/pyriemann/channelselection.py
@@ -21,13 +21,12 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
     nelec : int, default=16
         The number of electrode to keep in the final subset.
     metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the selection.
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, "mean" and "distance"
+        in order to pass different metrics.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel.
@@ -57,7 +56,7 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
         on Neural Engineering, Apr 2011, Cancun, Mexico.
     """
 
-    def __init__(self, nelec=16, metric='riemann', n_jobs=1):
+    def __init__(self, nelec=16, metric="riemann", n_jobs=1):
         """Init."""
         self.nelec = nelec
         self.metric = metric

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -216,7 +216,7 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         for distance estimation (see :func:`pyriemann.utils.distance.distance`)
         and for tangent space map
         (see :func:`pyriemann.utils.tangent_space.tangent_space`).
-        The metric can be a dict with three keys, `mean`, `dist` and `map` in
+        The metric can be a dict with three keys, "mean", "dist" and "map" in
         order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
@@ -347,12 +347,13 @@ class TSclassifier(BaseEstimator, ClassifierMixin):
     Parameters
     ----------
     metric : string | dict, default="riemann"
-        The type of metric used for reference matrix estimation (see
-        `mean_covariance` for the list of supported metric) and for tangent
-        space map (see `tangent_space` for the list of supported metric).
-        The metric could be a dict with two keys, `mean` and `map` in
-        order to pass different metrics for the reference matrix estimation
-        and the tangent space mapping.
+        The type of metric used
+        for reference matrix estimation (for the list of supported metrics
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for tangent space map
+        (see :func:`pyriemann.utils.tangent_space.tangent_space`).
+        The metric can be a dict with two keys, "mean" and "map"
+        in order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariate shift correction between
         training and test, as described in [2]. This is not compatible with
@@ -460,7 +461,7 @@ class KNearestNeighbor(MDM):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
@@ -977,7 +978,7 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
         The original equation of class distinctiveness in [1]_ uses "riemann"
         for both the centroid estimation and the distance estimation but you
@@ -1009,10 +1010,10 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
        15(4), 046030, 2018.
     """
 
-    metric_mean, metric_dist = check_metric(metric, ['mean', 'distance'])
+    metric_mean, metric_dist = check_metric(metric, ["mean", "distance"])
     classes = np.unique(y)
     if len(classes) <= 1:
-        raise ValueError('X must contain at least two classes')
+        raise ValueError("X must contain at least two classes")
 
     means = np.array([
         mean_covariance(X[y == ll], metric=metric_mean) for ll in classes

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -33,6 +33,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     For each of the given classes :math:`k = 1, \ldots, K`, a centroid
     :math:`\mathbf{M}^k` is estimated according to the chosen metric.
+
     Then, for each new matrix :math:`\mathbf{X}`, the class is affected
     according to the nearest centroid [1]_:
 
@@ -46,11 +47,11 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
-        Typical usecase is to pass 'logeuclid' metric for the mean
-        in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
+        Typical usecase is to pass "logeuclid" metric for the "mean" in order
+        to boost the computional speed, and "riemann" for the "distance" in
+        order to keep the good sensitivity for the classification.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel.

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -110,7 +110,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
             The MDM instance.
         """
         self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
         self.classes_ = np.unique(y)
 
@@ -509,7 +509,7 @@ class KNearestNeighbor(MDM):
             The NearestNeighbor instance.
         """
         self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
         self.covmeans_ = X
         self.classmeans_ = y

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -13,27 +13,8 @@ import warnings
 from .utils.kernel import kernel
 from .utils.mean import mean_covariance, mean_power
 from .utils.distance import distance
+from .utils.utils import check_metric
 from .tangentspace import FGDA, TangentSpace
-
-
-def _check_metric(metric):
-    if isinstance(metric, str):
-        metric_mean = metric
-        metric_dist = metric
-
-    elif isinstance(metric, dict):
-        # check keys
-        for key in ['mean', 'distance']:
-            if key not in metric.keys():
-                raise KeyError('metric must contain "mean" and "distance"')
-
-        metric_mean = metric['mean']
-        metric_dist = metric['distance']
-
-    else:
-        raise TypeError('metric must be dict or str')
-
-    return metric_mean, metric_dist
 
 
 def _mode_1d(X):
@@ -60,13 +41,15 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     Parameters
     ----------
-    metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metrics for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
+        Typical usecase is to pass 'logeuclid' metric for the mean
+        in order to boost the computional speed and 'riemann' for the
         distance in order to keep the good sensitivity for the classification.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
@@ -103,7 +86,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         (LVA/ICA 2010), LNCS vol. 6365, 2010, p. 629-636.
     """
 
-    def __init__(self, metric='riemann', n_jobs=1):
+    def __init__(self, metric="riemann", n_jobs=1):
         """Init."""
         self.metric = metric
         self.n_jobs = n_jobs
@@ -125,7 +108,9 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         self : MDM instance
             The MDM instance.
         """
-        self.metric_mean, self.metric_dist = _check_metric(self.metric)
+        self.metric_mean, self.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
+        )
         self.classes_ = np.unique(y)
 
         if sample_weight is None:
@@ -224,14 +209,14 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     Parameters
     ----------
-    metric : string | dict, default='riemann'
-        The type of metric used for reference matrix estimation (see
-        `mean_covariance` for the list of supported metric), for distance
-        estimation, and for tangent space map (see `tangent_space` for the list
-        of supported metric).
-        The metric could be a dict with three keys, `mean`, `dist` and `map` in
-        order to pass different metrics for the reference matrix estimation,
-        the distance estimation, and the tangent space mapping.
+    metric : string | dict, default="riemann"
+        Metric used for reference matrix estimation (for the list of supported
+        metrics, see :func:`pyriemann.utils.mean.mean_covariance`),
+        for distance estimation (see :func:`pyriemann.utils.distance.distance`)
+        and for tangent space map
+        (see :func:`pyriemann.utils.tangent_space.tangent_space`).
+        The metric can be a dict with three keys, `mean`, `dist` and `map` in
+        order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
         training and test, as described in [2]_. This is not compatible with
@@ -270,7 +255,7 @@ class FgMDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         Elsevier, 2013, 112, pp.172-178.
     """
 
-    def __init__(self, metric='riemann', tsupdate=False, n_jobs=1):
+    def __init__(self, metric="riemann", tsupdate=False, n_jobs=1):
         """Init."""
         self.metric = metric
         self.n_jobs = n_jobs
@@ -360,7 +345,7 @@ class TSclassifier(BaseEstimator, ClassifierMixin):
 
     Parameters
     ----------
-    metric : string | dict, default='riemann'
+    metric : string | dict, default="riemann"
         The type of metric used for reference matrix estimation (see
         `mean_covariance` for the list of supported metric) and for tangent
         space map (see `tangent_space` for the list of supported metric).
@@ -389,7 +374,7 @@ class TSclassifier(BaseEstimator, ClassifierMixin):
     .. versionadded:: 0.2.4
     """
 
-    def __init__(self, metric='riemann', tsupdate=False,
+    def __init__(self, metric="riemann", tsupdate=False,
                  clf=LogisticRegression()):
         """Init."""
         self.metric = metric
@@ -469,9 +454,13 @@ class KNearestNeighbor(MDM):
     ----------
     n_neighbors : int, default=5
         Number of neighbors.
-    metric : string | dict, default='riemann'
-        The type of metric used for distance estimation.
-        see `distance` for the list of supported metric.
+    metric : string | dict, default="riemann"
+        Metric used for means estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the distance to the training set in parallel.
@@ -496,7 +485,7 @@ class KNearestNeighbor(MDM):
 
     """
 
-    def __init__(self, n_neighbors=5, metric='riemann', n_jobs=1):
+    def __init__(self, n_neighbors=5, metric="riemann", n_jobs=1):
         """Init."""
         self.n_neighbors = n_neighbors
         MDM.__init__(self, metric=metric, n_jobs=n_jobs)
@@ -518,7 +507,9 @@ class KNearestNeighbor(MDM):
         self : NearestNeighbor instance
             The NearestNeighbor instance.
         """
-        self.metric_mean, self.metric_dist = _check_metric(self.metric)
+        self.metric_mean, self.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
+        )
         self.covmeans_ = X
         self.classmeans_ = y
         self.classes_ = np.unique(y)
@@ -588,7 +579,7 @@ class SVC(sklearnSVC):
 
     Parameters
     ----------
-    metric : {"riemann", "euclid", "logeuclid"}, default="riemann"
+    metric : {"euclid", "logeuclid", "riemann"}, default="riemann"
         Metric for kernel matrix computation.
     Cref : None | callable | ndarray, shape (n_channels, n_channels)
         Reference point for kernel matrix computation.
@@ -766,9 +757,10 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
           distances to means of the field is the lowest;
         * inf_means: it assigns the covariance to the class of the closest mean
           of the field.
-    metric : string | dict, default='riemann'
-        The type of metric used for distance estimation during prediction.
-        See `distance` for the list of supported metric.
+    metric : string, default="riemann"
+        Metric used for distance estimation during prediction.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.distance.distance`.
 
     Attributes
     ----------
@@ -795,7 +787,7 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
     """
 
     def __init__(self, power_list=[-1, 0, 1], method_label='sum_means',
-                 metric='riemann', n_jobs=1):
+                 metric="riemann", n_jobs=1):
         """Init."""
         self.power_list = power_list
         self.method_label = method_label
@@ -944,8 +936,7 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
         {\frac{1}{2} \left( \sigma_{K_1}^p + \sigma_{K_2}^p \right)}
 
     where :math:`\mathbf{M}_K` is the center of class :math:`K`, ie the mean of
-    matrices from class :math:`K`
-    (see :func:`pyriemann.utils.mean.mean_covariance`); and
+    matrices from class :math:`K`; and
     :math:`\sigma_K` is the class dispersion, ie the mean of distances between
     matrices from class :math:`K` and their center of class
     :math:`\mathbf{M}_K`:
@@ -980,15 +971,16 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
         - exponent = 2 gives the Fisher criterion generalized on the manifold,
           ie the ratio of the variance between the classes to the variance
           within the classes.
-    metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        See `mean_covariance` for the list of supported metric.
-        The metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metrics for the centroid estimation and the
-        distance estimation. The original equation of class distinctiveness
-        in [1]_ uses 'riemann' for both the centroid estimation and the
-        distance estimation but you can customize other metrics with your
-        interests.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
+        The original equation of class distinctiveness in [1]_ uses "riemann"
+        for both the centroid estimation and the distance estimation but you
+        can customize other metrics with your interests.
     return_num_denom : bool, default=False
         Whether to return numerator and denominator of class_dis.
 
@@ -1016,7 +1008,7 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
        15(4), 046030, 2018.
     """
 
-    metric_mean, metric_dist = _check_metric(metric)
+    metric_mean, metric_dist = check_metric(metric, ['mean', 'distance'])
     classes = np.unique(y)
     if len(classes) <= 1:
         raise ValueError('X must contain at least two classes')

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -109,9 +109,7 @@ class MDM(BaseEstimator, ClassifierMixin, TransformerMixin):
         self : MDM instance
             The MDM instance.
         """
-        self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        self.metric_mean, self.metric_dist = check_metric(self.metric)
         self.classes_ = np.unique(y)
 
         if sample_weight is None:
@@ -509,9 +507,7 @@ class KNearestNeighbor(MDM):
         self : NearestNeighbor instance
             The NearestNeighbor instance.
         """
-        self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        self.metric_mean, self.metric_dist = check_metric(self.metric)
         self.covmeans_ = X
         self.classmeans_ = y
         self.classes_ = np.unique(y)
@@ -925,7 +921,7 @@ class MeanField(BaseEstimator, ClassifierMixin, TransformerMixin):
         return softmax(-self._predict_distances(X) ** 2)
 
 
-def class_distinctiveness(X, y, exponent=1, metric='riemann',
+def class_distinctiveness(X, y, exponent=1, metric="riemann",
                           return_num_denom=False):
     r"""Measure class distinctiveness between classes of SPD matrices.
 
@@ -982,7 +978,7 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
         in order to pass different metrics.
         The original equation of class distinctiveness in [1]_ uses "riemann"
         for both the centroid estimation and the distance estimation but you
-        can customize other metrics with your interests.
+        can provide other metrics depending on your interests.
     return_num_denom : bool, default=False
         Whether to return numerator and denominator of class_dis.
 
@@ -1010,7 +1006,7 @@ def class_distinctiveness(X, y, exponent=1, metric='riemann',
        15(4), 046030, 2018.
     """
 
-    metric_mean, metric_dist = check_metric(metric, ["mean", "distance"])
+    metric_mean, metric_dist = check_metric(metric)
     classes = np.unique(y)
     if len(classes) <= 1:
         raise ValueError("X must contain at least two classes")

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -88,7 +88,7 @@ class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     random_state : integer or np.RandomState, optional
         The generator used to initialize the centers. If an integer is
@@ -302,7 +302,7 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     threshold : float, default=3
         Threshold on z-score of distance to reject artifacts. It is the number
@@ -578,7 +578,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     n_iter_max : int, default=10
         The maximum number of iteration to reach convergence.

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -42,7 +42,10 @@ def _fit_single(X, y=None, n_clusters=2, init='random', random_state=None,
     """helper to fit a single run of centroid."""
     # init random state if provided
     mdm = MDM(metric=metric, n_jobs=n_jobs)
-    mdm.metric_mean, mdm.metric_dist = check_metric(metric, ['mean', 'distance'])
+    mdm.metric_mean, mdm.metric_dist = check_metric(
+        metric,
+        ['mean', 'distance']
+    )
     squared_norms = [np.linalg.norm(x, ord='fro')**2 for x in X]
     mdm.covmeans_ = _init_centroids(X, n_clusters, init,
                                     random_state=random_state,
@@ -279,7 +282,10 @@ class KmeansPerClassTransform(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Transform."""
         mdm = MDM(metric=self.metric, n_jobs=self.km.n_jobs)
-        mdm.metric_mean, mdm.metric_dist = check_metric(self.metric, ['mean', 'distance'])
+        mdm.metric_mean, mdm.metric_dist = check_metric(
+            self.metric,
+            ['mean', 'distance']
+        )
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)
 

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -42,9 +42,7 @@ def _fit_single(X, y=None, n_clusters=2, init='random', random_state=None,
     """helper to fit a single run of centroid."""
     # init random state if provided
     mdm = MDM(metric=metric, n_jobs=n_jobs)
-    mdm.metric_mean, mdm.metric_dist = check_metric(
-        metric, ["mean", "distance"]
-    )
+    mdm.metric_mean, mdm.metric_dist = check_metric(metric)
     squared_norms = [np.linalg.norm(x, ord='fro')**2 for x in X]
     mdm.covmeans_ = _init_centroids(X, n_clusters, init,
                                     random_state=random_state,
@@ -281,9 +279,7 @@ class KmeansPerClassTransform(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Transform."""
         mdm = MDM(metric=self.metric, n_jobs=self.km.n_jobs)
-        mdm.metric_mean, mdm.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        mdm.metric_mean, mdm.metric_dist = check_metric(self.metric)
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)
 
@@ -377,7 +373,7 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         self._mdm = MDM(metric=self.metric)
         self._mdm.metric_mean, self._mdm.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
+            self.metric
         )
 
         y_old = self._check_labels(X, y)

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -43,8 +43,7 @@ def _fit_single(X, y=None, n_clusters=2, init='random', random_state=None,
     # init random state if provided
     mdm = MDM(metric=metric, n_jobs=n_jobs)
     mdm.metric_mean, mdm.metric_dist = check_metric(
-        metric,
-        ['mean', 'distance']
+        metric, ["mean", "distance"]
     )
     squared_norms = [np.linalg.norm(x, ord='fro')**2 for x in X]
     mdm.covmeans_ = _init_centroids(X, n_clusters, init,
@@ -283,8 +282,7 @@ class KmeansPerClassTransform(BaseEstimator, TransformerMixin):
         """Transform."""
         mdm = MDM(metric=self.metric, n_jobs=self.km.n_jobs)
         mdm.metric_mean, mdm.metric_dist = check_metric(
-            self.metric,
-            ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)
@@ -379,7 +377,7 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         self._mdm = MDM(metric=self.metric)
         self._mdm.metric_mean, self._mdm.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
 
         y_old = self._check_labels(X, y)

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -7,9 +7,10 @@ from sklearn.base import (BaseEstimator, ClassifierMixin, TransformerMixin,
                           ClusterMixin, clone)
 from sklearn.cluster import KMeans as _KMeans
 
-from .classification import MDM, _check_metric
+from .classification import MDM
 from .utils.mean import mean_covariance
 from .utils.geodesic import geodesic
+from .utils.utils import check_metric
 
 
 def _init_centroids(X, n_clusters, init, random_state, x_squared_norms):
@@ -41,7 +42,7 @@ def _fit_single(X, y=None, n_clusters=2, init='random', random_state=None,
     """helper to fit a single run of centroid."""
     # init random state if provided
     mdm = MDM(metric=metric, n_jobs=n_jobs)
-    mdm.metric_mean, mdm.metric_dist = _check_metric(metric)
+    mdm.metric_mean, mdm.metric_dist = check_metric(metric, ['mean', 'distance'])
     squared_norms = [np.linalg.norm(x, ord='fro')**2 for x in X]
     mdm.covmeans_ = _init_centroids(X, n_clusters, init,
                                     random_state=random_state,
@@ -80,8 +81,13 @@ class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
         Number of clusters.
     max_iter : int, default=100
         The maximum number of iteration to reach convergence.
-    metric : string, default='riemann'
-        The type of metric used for centroid and distance estimation.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     random_state : integer or np.RandomState, optional
         The generator used to initialize the centers. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
@@ -127,7 +133,7 @@ class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
     MDM
     """
 
-    def __init__(self, n_clusters=2, max_iter=100, metric='riemann',
+    def __init__(self, n_clusters=2, max_iter=100, metric="riemann",
                  random_state=None, init='random', n_init=10, n_jobs=1,
                  tol=1e-4):
         """Init."""
@@ -273,7 +279,7 @@ class KmeansPerClassTransform(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Transform."""
         mdm = MDM(metric=self.metric, n_jobs=self.km.n_jobs)
-        mdm.metric_mean, mdm.metric_dist = _check_metric(self.metric)
+        mdm.metric_mean, mdm.metric_dist = check_metric(self.metric, ['mean', 'distance'])
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)
 
@@ -287,8 +293,13 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
 
     Parameters
     ----------
-    metric : string, default='riemann'
-        The type of metric used for centroid and distance estimation.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     threshold : float, default=3
         Threshold on z-score of distance to reject artifacts. It is the number
         of standard deviations from the mean of distances to the centroid.
@@ -361,8 +372,8 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
             raise ValueError("Positive and negative labels must be different")
 
         self._mdm = MDM(metric=self.metric)
-        self._mdm.metric_mean, self._mdm.metric_dist = _check_metric(
-            self.metric
+        self._mdm.metric_mean, self._mdm.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
         )
 
         y_old = self._check_labels(X, y)
@@ -558,8 +569,13 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
     z_threshold : float, default=3
         Threshold on z-score of distance to reject artifacts. It is the number
         of standard deviations from the mean of distances to the centroid.
-    metric : string, default='riemann'
-        The type of metric used for centroid and distance estimation.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     n_iter_max : int, default=10
         The maximum number of iteration to reach convergence.
     pos_label: int, default=1
@@ -586,7 +602,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
     """
 
     def __init__(self, n_potatoes=1, p_threshold=0.01, z_threshold=3,
-                 metric='riemann', n_iter_max=10, pos_label=1, neg_label=0):
+                 metric="riemann", n_iter_max=10, pos_label=1, neg_label=0):
         """Init."""
         self.n_potatoes = int(n_potatoes)
         self.p_threshold = p_threshold

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -25,9 +25,10 @@ class SpectralEmbedding(BaseEstimator):
     ----------
     n_components : integer, default=2
         The dimension of the projected subspace.
-    metric : string | dict, default='riemann'
-        The type of metric to be used for defining pairwise distance between
-        SPD matrices.
+    metric : string, default="riemann"
+        Metric used for defining pairwise distance between SPD matrices.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.distance.pairwise_distance`.
     eps : None | float, default=None
         The scaling of the Gaussian kernel. If none is given it will use the
         square of the median of pairwise distances between points.
@@ -41,7 +42,7 @@ class SpectralEmbedding(BaseEstimator):
         p. 1373-1396 , 2003
     """
 
-    def __init__(self, n_components=2, metric='riemann', eps=None):
+    def __init__(self, n_components=2, metric="riemann", eps=None):
         """Init."""
         self.metric = metric
         self.n_components = n_components
@@ -136,7 +137,7 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
         Dimensionality of projected space.
     n_neighbors : int, default=5
         Number of neighbors for reconstruction of each point.
-    metric : {'riemann', 'logeuclid', 'euclid'}, default: 'riemann'
+    metric : {"euclid", "logeuclid", "riemann"}, default: "riemann"
         Metric used for KNN and Kernel estimation.
     reg : float, default=1e-3
         Regularization parameter.
@@ -168,7 +169,7 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
         Pattern Recognition
     """
 
-    def __init__(self, n_components=2, n_neighbors=5, metric='riemann',
+    def __init__(self, n_components=2, n_neighbors=5, metric="riemann",
                  reg=1e-3):
         self.n_components = n_components
         self.n_neighbors = n_neighbors
@@ -265,7 +266,7 @@ class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
         return self.embedding_
 
 
-def barycenter_weights(X, Y, indices, metric='riemann', reg=1e-3):
+def barycenter_weights(X, Y, indices, metric="riemann", reg=1e-3):
     """Compute Riemannian barycenter weights of X from Y along the first axis.
 
     Estimates the weights to assign to each point in Y[indices] to recover
@@ -279,7 +280,7 @@ def barycenter_weights(X, Y, indices, metric='riemann', reg=1e-3):
         Set of SPD matrices.
     indices : ndarray, shape (n_matrices, n_neighbors)
         Indices of the points in Y used to compute the barycenter
-    metric : {'riemann', 'logeuclid', 'euclid'}, default='riemann'
+    metric : {"euclid", "logeuclid", "riemann"}, default="riemann"
         Kernel metric.
     reg : float, default=1e-3
         Amount of regularization to add for the problem to be
@@ -320,7 +321,7 @@ def locally_linear_embedding(X,
                              *,
                              n_components=2,
                              n_neighbors=5,
-                             metric='riemann',
+                             metric="riemann",
                              reg=1e-3):
     """Perform a Locally Linear Embedding (LLE) of SPD matrices.
 
@@ -342,7 +343,7 @@ def locally_linear_embedding(X,
         Dimensionality of projected space.
     n_neighbors : int, default=5
         Number of neighbors for reconstruction of each point.
-    metric : {'riemann', 'logeuclid', 'euclid'}, default: 'riemann'
+    metric : {"euclid", "logeuclid", "riemann"}, default: "riemann"
         Metric used for KNN and Kernel estimation.
     reg : float, default=1e-3
         Regularization parameter.

--- a/pyriemann/preprocessing.py
+++ b/pyriemann/preprocessing.py
@@ -18,9 +18,11 @@ class Whitening(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    metric : str, default='euclid'
-        The metric for the estimation of mean matrix used for whitening and
+    metric : str, default="euclid"
+        Metric for the estimation of mean matrix used for whitening and
         dimension reduction.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`.
     dim_red : None | dict, default=None
         If ``None`` :
             no dimension reduction during whitening.
@@ -58,7 +60,7 @@ class Whitening(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, metric='euclid', dim_red=None, verbose=False):
+    def __init__(self, metric="euclid", dim_red=None, verbose=False):
         """Init."""
         self.metric = metric
         self.dim_red = dim_red

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -216,7 +216,7 @@ class KNearestNeighborRegressor(MDM):
             The KNearestNeighborRegressor instance.
         """
         self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
         self.values_ = y
         self.covmeans_ = X

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -176,7 +176,7 @@ class KNearestNeighborRegressor(MDM):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
 
     Attributes

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -215,9 +215,7 @@ class KNearestNeighborRegressor(MDM):
         self : KNearestNeighborRegressor instance
             The KNearestNeighborRegressor instance.
         """
-        self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        self.metric_mean, self.metric_dist = check_metric(self.metric)
         self.values_ = y
         self.covmeans_ = X
 

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -2,14 +2,14 @@
 import functools
 
 import numpy as np
-
 from sklearn.metrics import r2_score
 from sklearn.svm import SVR as sklearnSVR
 from sklearn.utils.extmath import softmax
 
 from .utils.kernel import kernel
-from .classification import MDM, _check_metric
+from .classification import MDM
 from .utils.mean import mean_covariance
+from .utils.utils import check_metric
 
 
 class SVR(sklearnSVR):
@@ -21,7 +21,7 @@ class SVR(sklearnSVR):
 
     Parameters
     ----------
-    metric : {'riemann', 'euclid', 'logeuclid'}, default='riemann'
+    metric : {"euclid", "logeuclid", "riemann"}, default="riemann"
         Metric for kernel matrix computation.
     Cref : None | ndarray, shape (n_channels, n_channels)
         Reference point for kernel matrix computation. If None, the mean of
@@ -171,9 +171,13 @@ class KNearestNeighborRegressor(MDM):
     ----------
     n_neighbors : int, default=5
         Number of neighbors.
-    metric : string | dict, default='riemann'
-        The type of metric used for distance estimation.
-        See `distance` for the list of supported metric.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
 
     Attributes
     ----------
@@ -188,7 +192,7 @@ class KNearestNeighborRegressor(MDM):
 
     """
 
-    def __init__(self, n_neighbors=5, metric='riemann'):
+    def __init__(self, n_neighbors=5, metric="riemann"):
         """Init."""
         self.n_neighbors = n_neighbors
         self._estimator_type = "regressor"
@@ -211,7 +215,9 @@ class KNearestNeighborRegressor(MDM):
         self : KNearestNeighborRegressor instance
             The KNearestNeighborRegressor instance.
         """
-        self.metric_mean, self.metric_dist = _check_metric(self.metric)
+        self.metric_mean, self.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
+        )
         self.values_ = y
         self.covmeans_ = X
 

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -258,8 +258,10 @@ class CSP(BilinearFilter):
     ----------
     nfilter : int, default=4
         The number of components to decompose M/EEG signals.
-    metric : str, default='euclid'
-        The metric for the estimation of mean covariance matrices.
+    metric : str, default="euclid"
+        Metric used for the estimation of mean covariance matrices.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`.
     log : bool, default=True
         If true, return the log variance, otherwise return the spatially
         filtered covariance matrices.
@@ -296,7 +298,7 @@ class CSP(BilinearFilter):
         August 2008. pp. 1991 - 2000
     """
 
-    def __init__(self, nfilter=4, metric='euclid', log=True):
+    def __init__(self, nfilter=4, metric="euclid", log=True):
         """Init."""
         self.nfilter = nfilter
         self.metric = metric
@@ -403,8 +405,10 @@ class SPoC(CSP):
     ----------
     nfilter : int, default=4
         The number of components to decompose M/EEG signals.
-    metric : str, default='euclid'
-        The metric for the estimation of mean covariance matrices.
+    metric : str, default="euclid"
+        Metric used for the estimation of mean covariance matrices.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`.
     log : bool, default=True
         If true, return the log variance, otherwise return the spatially
         filtered covariance matrices.

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -349,7 +349,7 @@ class PermutationDistance(BasePermutation):
         """Init tr"""
         self.mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
         self.mdm.metric_mean, self.mdm.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
         if self.mode == 'ftest':
             self.global_mean = mean_covariance(X, metric=self.mdm.metric_mean)

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -264,7 +264,7 @@ class PermutationDistance(BasePermutation):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     mode : string, default='pairwise'
         Type of statistic to use. could be 'pairwise', 'ttest' of 'ftest'

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -5,7 +5,8 @@ from sklearn.model_selection import cross_val_score
 
 from .utils.distance import distance, pairwise_distance
 from .utils.mean import mean_covariance
-from .classification import MDM, _check_metric
+from .utils.utils import check_metric
+from .classification import MDM
 
 
 def multiset_perm_number(y):
@@ -258,14 +259,13 @@ class PermutationDistance(BasePermutation):
     n_perms : int, default=100
         The number of permutation. The minimum should be 20 for a resolution of
         0.05 p-value.
-    metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `distance` anb `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     mode : string, default='pairwise'
         Type of statistic to use. could be 'pairwise', 'ttest' of 'ftest'
     n_jobs : integer, default=1
@@ -299,7 +299,7 @@ class PermutationDistance(BasePermutation):
 
     def __init__(self,
                  n_perms=100,
-                 metric='riemann',
+                 metric="riemann",
                  mode='pairwise',
                  n_jobs=1,
                  random_state=42,
@@ -348,8 +348,8 @@ class PermutationDistance(BasePermutation):
     def __init_transform(self, X):
         """Init tr"""
         self.mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
-        self.mdm.metric_mean, self.mdm.metric_dist = _check_metric(
-            self.metric
+        self.mdm.metric_mean, self.mdm.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
         )
         if self.mode == 'ftest':
             self.global_mean = mean_covariance(X, metric=self.mdm.metric_mean)

--- a/pyriemann/stats.py
+++ b/pyriemann/stats.py
@@ -348,9 +348,7 @@ class PermutationDistance(BasePermutation):
     def __init_transform(self, X):
         """Init tr"""
         self.mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
-        self.mdm.metric_mean, self.mdm.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        self.mdm.metric_mean, self.mdm.metric_dist = check_metric(self.metric)
         if self.mode == 'ftest':
             self.global_mean = mean_covariance(X, metric=self.mdm.metric_mean)
         elif self.mode == 'pairwise':

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -5,6 +5,7 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 
 from .utils.mean import mean_covariance
 from .utils.tangentspace import tangent_space, untangent_space
+from .utils.utils import check_metric
 
 
 class TangentSpace(BaseEstimator, TransformerMixin):
@@ -37,12 +38,13 @@ class TangentSpace(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     metric : string | dict, default='riemann'
-        The type of metric used for reference matrix estimation (see
-        `mean_covariance` for the list of supported metric) and for tangent
-        space map (see `tangent_space` for the list of supported metric).
-        The metric could be a dict with two keys, `mean` and `map` in
-        order to pass different metrics for the reference matrix estimation
-        and the tangent space mapping.
+        The type of metric used
+        for reference matrix estimation (for the list of supported metrics
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for tangent space map
+        (see :func:`pyriemann.utils.tangent_space.tangent_space`).
+        The metric can be a dict with two keys, `mean` and `map`
+        in order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
         training and test, as described in [2]_. This is not compatible with
@@ -95,7 +97,9 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         self : TangentSpace instance
             The TangentSpace instance.
         """
-        self.metric_mean, self.metric_map = self._check_metric(self.metric)
+        self.metric_mean, self.metric_map = check_metric(
+            self.metric, ['mean', 'map']
+        )
 
         self.reference_ = mean_covariance(
             X,
@@ -103,26 +107,6 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             sample_weight=sample_weight
         )
         return self
-
-    def _check_metric(self, metric):
-
-        if isinstance(metric, str):
-            metric_mean = metric
-            metric_map = metric
-
-        elif isinstance(metric, dict):
-            # check keys
-            for key in ['mean', 'map']:
-                if key not in metric.keys():
-                    raise KeyError('metric must contain "mean" and "map"')
-
-            metric_mean = metric['mean']
-            metric_map = metric['map']
-
-        else:
-            raise TypeError('metric must be dict or str')
-
-        return metric_mean, metric_map
 
     def _check_data_dim(self, X):
         """Check data shape and return the size of SPD matrix."""
@@ -164,7 +148,9 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         ts : ndarray, shape (n_matrices, n_ts)
             Tangent space projections of SPD matrices.
         """
-        self.metric_mean, self.metric_map = self._check_metric(self.metric)
+        self.metric_mean, self.metric_map = check_metric(
+            self.metric, ['mean', 'map']
+        )
         self._check_reference_points(X)
 
         if self.tsupdate:
@@ -190,7 +176,9 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         ts : ndarray, shape (n_matrices, n_ts)
             Tangent space projections of SPD matrices.
         """
-        self.metric_mean, self.metric_map = self._check_metric(self.metric)
+        self.metric_mean, self.metric_map = check_metric(
+            self.metric, ['mean', 'map']
+        )
 
         self.reference_ = mean_covariance(
             X,
@@ -216,7 +204,9 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         cov : ndarray, shape (n_matrices, n_channels, n_channels)
             Set of SPD matrices corresponding to each of tangent vector.
         """
-        self.metric_mean, self.metric_map = self._check_metric(self.metric)
+        self.metric_mean, self.metric_map = check_metric(
+            self.metric, ['mean', 'map']
+        )
         self._check_reference_points(X)
         return untangent_space(X, self.reference_, metric=self.metric_map)
 
@@ -231,13 +221,14 @@ class FGDA(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    metric : string | dict, default='riemann'
-        The type of metric used for reference matrix estimation (see
-        `mean_covariance` for the list of supported metric) and for tangent
-        space map (see `tangent_space` for the list of supported metric).
-        The metric could be a dict with two keys, `mean` and `map` in
-        order to pass different metrics for the reference matrix estimation
-        and the tangent space mapping.
+    metric : string | dict, default="riemann"
+        The type of metric used
+        for reference matrix estimation (for the list of supported metrics
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for tangent space map
+        (see :func:`pyriemann.utils.tangent_space.tangent_space`).
+        The metric can be a dict with two keys, `mean` and `map`
+        in order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
         training and test, as described in [2]_. This is not compatible with
@@ -263,7 +254,7 @@ class FGDA(BaseEstimator, TransformerMixin):
         Elsevier, 2013, 112, pp.172-178.
     """
 
-    def __init__(self, metric='riemann', tsupdate=False):
+    def __init__(self, metric="riemann", tsupdate=False):
         """Init."""
         self.metric = metric
         self.tsupdate = tsupdate

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -98,7 +98,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             The TangentSpace instance.
         """
         self.metric_mean, self.metric_map = check_metric(
-            self.metric, ['mean', 'map']
+            self.metric, ["mean", "map"]
         )
 
         self.reference_ = mean_covariance(
@@ -149,7 +149,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             Tangent space projections of SPD matrices.
         """
         self.metric_mean, self.metric_map = check_metric(
-            self.metric, ['mean', 'map']
+            self.metric, ["mean", "map"]
         )
         self._check_reference_points(X)
 
@@ -177,7 +177,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             Tangent space projections of SPD matrices.
         """
         self.metric_mean, self.metric_map = check_metric(
-            self.metric, ['mean', 'map']
+            self.metric, ["mean", "map"]
         )
 
         self.reference_ = mean_covariance(
@@ -205,7 +205,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
             Set of SPD matrices corresponding to each of tangent vector.
         """
         self.metric_mean, self.metric_map = check_metric(
-            self.metric, ['mean', 'map']
+            self.metric, ["mean", "map"]
         )
         self._check_reference_points(X)
         return untangent_space(X, self.reference_, metric=self.metric_map)

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -43,7 +43,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for tangent space map
         (see :func:`pyriemann.utils.tangent_space.tangent_space`).
-        The metric can be a dict with two keys, `mean` and `map`
+        The metric can be a dict with two keys, "mean" and "map"
         in order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between
@@ -227,7 +227,7 @@ class FGDA(BaseEstimator, TransformerMixin):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for tangent space map
         (see :func:`pyriemann.utils.tangent_space.tangent_space`).
-        The metric can be a dict with two keys, `mean` and `map`
+        The metric can be a dict with two keys, "mean" and "map"
         in order to pass different metrics.
     tsupdate : bool, default=False
         Activate tangent space update for covariante shift correction between

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -13,9 +13,9 @@ from ..utils.mean import mean_covariance, mean_riemann
 from ..utils.distance import distance
 from ..utils.base import invsqrtm, powm, sqrtm
 from ..utils.geodesic import geodesic
-from ..utils.utils import check_weights
+from ..utils.utils import check_weights, check_metric
 from ._rotate import _get_rotation_matrix
-from ..classification import MDM, _check_metric
+from ..classification import MDM
 from ..preprocessing import Whitening
 from ._tools import decode_domains
 
@@ -104,12 +104,11 @@ class TLCenter(BaseEstimator, TransformerMixin):
     ----------
     target_domain : str
         Domain to consider as target.
-    metric : str, default='riemann'
-        The metric for mean, can be: 'ale', 'alm', 'euclid', 'harmonic',
-        'identity', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',
-        'wasserstein', or a callable function. Note, however, that only when
-        using the 'riemann' metric that we are ensured to re-center the data
-        points precisely to the Identity.
+    metric : str, default="riemann"
+        Metric used for mean estimation. For the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`.
+        Note, however, that only when using the "riemann" metric that we are
+        ensured to re-center the data points precisely to the Identity.
 
     Attributes
     ----------
@@ -129,7 +128,7 @@ class TLCenter(BaseEstimator, TransformerMixin):
     .. versionadded:: 0.4
     """
 
-    def __init__(self, target_domain, metric='riemann'):
+    def __init__(self, target_domain, metric="riemann"):
         """Init"""
         self.target_domain = target_domain
         self.metric = metric
@@ -239,10 +238,10 @@ class TLStretch(BaseEstimator, TransformerMixin):
         Target value for the dispersion of the data points.
     centered_data : bool, default=False
         Whether the data has been re-centered to the Identity beforehand.
-    metric : str, default='riemann'
-        The metric for calculating the dispersion can be: 'ale', 'alm',
-        'euclid', 'harmonic', 'identity', 'kullback_sym', 'logdet',
-        'logeuclid', 'riemann', 'wasserstein', or a callable function.
+    metric : str, default="riemann"
+        Metric used for calculating the dispersion.
+        For the list of supported metrics,
+        see :func:`pyriemann.utils.distance.distance`.
 
     Attributes
     ----------
@@ -263,7 +262,7 @@ class TLStretch(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, target_domain, final_dispersion=1.0,
-                 centered_data=False, metric='riemann'):
+                 centered_data=False, metric="riemann"):
         """Init"""
         self.target_domain = target_domain
         self.final_dispersion = final_dispersion
@@ -434,9 +433,8 @@ class TLRotate(BaseEstimator, TransformerMixin):
     weights : None | array, shape (n_classes,), default=None
         Weights to assign for each class. If None, then give the same weight
         for each class.
-    metric : {'euclid', 'riemann'}, default='euclid'
-        Metric for the distance to minimize between class means. Options are
-        either the Euclidean ('euclid') or Riemannian ('riemann') distance.
+    metric : {"euclid", "riemann"}, default="euclid"
+        Metric for the distance to minimize between class means.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         the rotation matrix for each source domain in parallel. If -1 all CPUs
@@ -837,14 +835,13 @@ class MDWM(MDM):
         from the source domain.
     target_domain : string
         Name of the target domain in extended labels.
-    metric : string | dict, default='riemann'
-        The type of metric used for centroid and distance estimation.
-        see `mean_covariance` for the list of supported metric.
-        the metric could be a dict with two keys, `mean` and `distance` in
-        order to pass different metric for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.utils.mean.mean_covariance`) and
+        for distance estimation
+        (see :func:`pyriemann.utils.distance.distance`).
+        The metric can be a dict with two keys, `mean` and `distance`
+        in order to pass different metrics.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel.
@@ -887,7 +884,7 @@ class MDWM(MDM):
             self,
             domain_tradeoff,
             target_domain,
-            metric='riemann',
+            metric="riemann",
             n_jobs=1):
         """Init."""
         self.domain_tradeoff = domain_tradeoff
@@ -914,7 +911,9 @@ class MDWM(MDM):
         self : MDWM instance
             The MDWM instance.
         """
-        self.metric_mean, self.metric_dist = _check_metric(self.metric)
+        self.metric_mean, self.metric_dist = check_metric(
+            self.metric, ['mean', 'distance']
+        )
 
         if not 0 <= self.domain_tradeoff <= 1:
             raise ValueError(

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -840,7 +840,7 @@ class MDWM(MDM):
         see :func:`pyriemann.utils.mean.mean_covariance`) and
         for distance estimation
         (see :func:`pyriemann.utils.distance.distance`).
-        The metric can be a dict with two keys, `mean` and `distance`
+        The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     n_jobs : int, default=1
         The number of jobs to use for the computation. This works by computing

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -912,7 +912,7 @@ class MDWM(MDM):
             The MDWM instance.
         """
         self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ['mean', 'distance']
+            self.metric, ["mean", "distance"]
         )
 
         if not 0 <= self.domain_tradeoff <= 1:

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -911,13 +911,11 @@ class MDWM(MDM):
         self : MDWM instance
             The MDWM instance.
         """
-        self.metric_mean, self.metric_dist = check_metric(
-            self.metric, ["mean", "distance"]
-        )
+        self.metric_mean, self.metric_dist = check_metric(self.metric)
 
         if not 0 <= self.domain_tradeoff <= 1:
             raise ValueError(
-                'Value domain_tradeoff must be included in [0, 1] (Got %d)'
+                "Value domain_tradeoff must be included in [0, 1] (Got %d)"
                 % self.domain_tradeoff)
 
         X_dec, y_dec, domains = decode_domains(X, y_enc)

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -395,7 +395,7 @@ def _check_distance_function(metric):
     return metric
 
 
-def distance(A, B, metric='riemann', squared=False):
+def distance(A, B, metric="riemann", squared=False):
     """Distance between matrices according to a metric.
 
     Compute the distance between two matrices A and B according to a metric
@@ -407,10 +407,10 @@ def distance(A, B, metric='riemann', squared=False):
         First matrix, or set of matrices.
     B : ndarray, shape (n, n)
         Second matrix.
-    metric : string, default='riemann'
-        The metric for distance, can be: 'euclid', 'harmonic', 'kullback',
-        'kullback_right', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',
-        'wasserstein', or a callable function.
+    metric : string, default="riemann"
+        Metric for distance, can be: "euclid", "harmonic", "kullback",
+        "kullback_right", "kullback_sym", "logdet", "logeuclid", "riemann",
+        "wasserstein", or a callable function.
     squared : bool, default False
         Return squared distance.
 
@@ -603,7 +603,7 @@ def _pairwise_distance_riemann(X, Y=None, squared=False):
     return dist if squared else np.sqrt(dist)
 
 
-def pairwise_distance(X, Y=None, metric='riemann', squared=False):
+def pairwise_distance(X, Y=None, metric="riemann", squared=False):
     """Pairwise distance matrix.
 
     Compute the matrix of distances between pairs of elements of X and Y.
@@ -615,9 +615,8 @@ def pairwise_distance(X, Y=None, metric='riemann', squared=False):
     Y : None | ndarray, shape (n_matrices_Y, n, n), default=None
         Second set of matrices. If None, Y is set to X.
     metric : string, default='riemann'
-        The metric for distance, can be: 'euclid', 'harmonic', 'kullback',
-        'kullback_right', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',
-        'wasserstein', or a callable function.
+        Metric for pairwise distance. For the list of supported metrics,
+        see :func:`pyriemann.utils.distance.distance`.
     squared : bool, default False
         Return squared distances.
 

--- a/pyriemann/utils/distance.py
+++ b/pyriemann/utils/distance.py
@@ -633,13 +633,13 @@ def pairwise_distance(X, Y=None, metric="riemann", squared=False):
     --------
     distance
     """
-    if metric == 'euclid':
+    if metric == "euclid":
         return _pairwise_distance_euclid(X, Y=Y, squared=squared)
-    elif metric == 'harmonic':
+    elif metric == "harmonic":
         return _pairwise_distance_harmonic(X, Y=Y, squared=squared)
-    elif metric == 'logeuclid':
+    elif metric == "logeuclid":
         return _pairwise_distance_logeuclid(X, Y=Y, squared=squared)
-    elif metric == 'riemann':
+    elif metric == "riemann":
         return _pairwise_distance_riemann(X, Y=Y, squared=squared)
 
     n_matrices_X, _, _ = X.shape

--- a/pyriemann/utils/geodesic.py
+++ b/pyriemann/utils/geodesic.py
@@ -22,7 +22,7 @@ def geodesic_euclid(A, B, alpha=0.5):
     B : ndarray, shape (..., n, m)
         Second matrices.
     alpha : float, default=0.5
-        The position on the geodesic.
+        Position on the geodesic.
 
     Returns
     -------
@@ -52,7 +52,7 @@ def geodesic_logeuclid(A, B, alpha=0.5):
     B : ndarray, shape (..., n, n)
         Second SPD/HPD matrices.
     alpha : float, default=0.5
-        The position on the geodesic.
+        Position on the geodesic.
 
     Returns
     -------
@@ -83,7 +83,7 @@ def geodesic_riemann(A, B, alpha=0.5):
     B : ndarray, shape (..., n, n)
         Second SPD/HPD matrices.
     alpha : float, default=0.5
-        The position on the geodesic.
+        Position on the geodesic.
 
     Returns
     -------
@@ -100,7 +100,7 @@ def geodesic_riemann(A, B, alpha=0.5):
 ###############################################################################
 
 
-def geodesic(A, B, alpha, metric='riemann'):
+def geodesic(A, B, alpha, metric="riemann"):
     """Geodesic between matrices according to a metric.
 
     Return the matrix at the position alpha on the geodesic between matrices
@@ -113,9 +113,9 @@ def geodesic(A, B, alpha, metric='riemann'):
     B : ndarray, shape (..., n, n)
         Second matrices.
     alpha : float
-        The position on the geodesic.
-    metric : string, default='riemann'
-        The metric used for geodesic, can be: 'euclid', 'logeuclid', 'riemann'.
+        Position on the geodesic.
+    metric : string, default="riemann"
+        Metric used for geodesic, can be: "euclid", "logeuclid", "riemann".
 
     Returns
     -------

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -208,7 +208,7 @@ def kernel(X, Y=None, *, Cref=None, metric="riemann", reg=1e-10):
     Cref : None | ndarray, shape (n, n), default=None
         Reference point for the tangent space and inner product
         calculation. Only used if metric='riemann'.
-    metric : str, default="riemann"
+    metric : string, default="riemann"
         Metric used for tangent space and mean estimation, can be:
         "euclid", "logeuclid", "riemann".
     reg : float, default=1e-10

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -193,7 +193,7 @@ def _apply_matrix_kernel(kernel_fct, X, Y=None, *, Cref=None, reg=1e-10):
     return K
 
 
-def kernel(X, Y=None, *, Cref=None, metric='riemann', reg=1e-10):
+def kernel(X, Y=None, *, Cref=None, metric="riemann", reg=1e-10):
     """Kernel matrix between matrices according to a specified metric.
 
     Calculates the kernel matrix K of inner products of two sets X and Y of
@@ -208,8 +208,9 @@ def kernel(X, Y=None, *, Cref=None, metric='riemann', reg=1e-10):
     Cref : None | ndarray, shape (n, n), default=None
         Reference point for the tangent space and inner product
         calculation. Only used if metric='riemann'.
-    metric : {'euclid', 'logeuclid', 'riemann'}, default='riemann'
-        The type of metric used for tangent space and mean estimation.
+    metric : str, default="riemann"
+        Metric used for tangent space and mean estimation, can be:
+        "euclid", "logeuclid", "riemann".
     reg : float, default=1e-10
         Regularization parameter to mitigate numerical errors in kernel
         matrix estimation, to provide a positive-definite kernel matrix.

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -640,7 +640,7 @@ def _check_mean_function(metric):
     return metric
 
 
-def mean_covariance(X=None, metric='riemann', sample_weight=None, covmats=None,
+def mean_covariance(X=None, metric="riemann", sample_weight=None, covmats=None,
                     **kwargs):
     """Mean of matrices according to a metric.
 
@@ -650,10 +650,10 @@ def mean_covariance(X=None, metric='riemann', sample_weight=None, covmats=None,
     ----------
     X : ndarray, shape (n_matrices, n, n)
         Set of matrices.
-    metric : string, default='riemann'
-        The metric for mean, can be: 'ale', 'alm', 'euclid', 'harmonic',
-        'identity', 'kullback_sym', 'logdet', 'logeuclid', 'riemann',
-        'wasserstein', or a callable function.
+    metric : string, default="riemann"
+        Metric for mean estimation, can be: "ale", "alm", "euclid", "harmonic",
+        "identity", "kullback_sym", "logdet", "logeuclid", "riemann",
+        "wasserstein", or a callable function.
     sample_weight : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. If None, it uses equal weights.
     **kwargs : dict

--- a/pyriemann/utils/tangentspace.py
+++ b/pyriemann/utils/tangentspace.py
@@ -28,7 +28,7 @@ def exp_map_euclid(X, Cref):
     X : ndarray, shape (..., n, m)
         Matrices in tangent space.
     Cref : ndarray, shape (n, m)
-        The reference matrix.
+        Reference matrix.
 
     Returns
     -------
@@ -58,7 +58,7 @@ def exp_map_logeuclid(X, Cref):
     X : ndarray, shape (..., n, n)
         Matrices in tangent space.
     Cref : ndarray, shape (n, n)
-        The reference SPD/HPD matrix.
+        Reference SPD/HPD matrix.
 
     Returns
     -------
@@ -95,7 +95,7 @@ def exp_map_riemann(X, Cref, Cm12=False):
     X : ndarray, shape (..., n, n)
         Matrices in tangent space.
     Cref : ndarray, shape (n, n)
-        The reference SPD/HPD matrix.
+        Reference SPD/HPD matrix.
     Cm12 : bool, default=False
         If True, it returns the full Riemannian exponential map.
 
@@ -128,9 +128,9 @@ def log_map_euclid(X, Cref):
     Parameters
     ----------
     X : ndarray, shape (..., n, m)
-        Matrices in manidold.
+        Matrices in manifold.
     Cref : ndarray, shape (n, m)
-        The reference matrix.
+        Reference matrix.
 
     Returns
     -------
@@ -157,9 +157,9 @@ def log_map_logeuclid(X, Cref):
     Parameters
     ----------
     X : ndarray, shape (..., n, n)
-        Matrices in SPD/HPD manidold.
+        Matrices in SPD/HPD manifold.
     Cref : ndarray, shape (n, n)
-        The reference SPD matrix.
+        Reference SPD matrix.
 
     Returns
     -------
@@ -195,9 +195,9 @@ def log_map_riemann(X, Cref, C12=False):
     Parameters
     ----------
     X : ndarray, shape (..., n, n)
-        Matrices in SPD/HPD manidold.
+        Matrices in SPD/HPD manifold.
     Cref : ndarray, shape (n, n)
-        The reference SPD/HPD matrix.
+        Reference SPD/HPD matrix.
     C12 : bool, default=False
         If True, it returns the full Riemannian logarithmic map.
 
@@ -292,7 +292,7 @@ def unupper(T):
     return X
 
 
-def tangent_space(X, Cref, *, metric='riemann'):
+def tangent_space(X, Cref, *, metric="riemann"):
     """Transform matrices into tangent vectors.
 
     Transform matrices into tangent vectors, according to a reference
@@ -301,12 +301,12 @@ def tangent_space(X, Cref, *, metric='riemann'):
     Parameters
     ----------
     X : ndarray, shape (..., n, n)
-        Matrices in manidold.
+        Matrices in manifold.
     Cref : ndarray, shape (n, n)
-        The reference matrix.
-    metric : string, default='riemann'
-        The metric used for logarithmic map, can be: 'euclid', 'logeuclid',
-        'riemann'.
+        Reference matrix.
+    metric : string, default="riemann"
+        Metric used for logarithmic map, can be:
+        "euclid", "logeuclid", "riemann".
 
     Returns
     -------
@@ -331,7 +331,7 @@ def tangent_space(X, Cref, *, metric='riemann'):
     return T
 
 
-def untangent_space(T, Cref, *, metric='riemann'):
+def untangent_space(T, Cref, *, metric="riemann"):
     """Transform tangent vectors back to matrices.
 
     Transform tangent vectors back to matrices, according to a reference
@@ -342,15 +342,15 @@ def untangent_space(T, Cref, *, metric='riemann'):
     T : ndarray, shape (..., n * (n + 1) / 2)
         Tangent vectors.
     Cref : ndarray, shape (n, n)
-        The reference matrix.
-    metric : string, default='riemann'
-        The metric used for exponential map, can be: 'euclid', 'logeuclid',
-        'riemann'.
+        Reference matrix.
+    metric : string, default="riemann"
+        Metric used for exponential map, can be:
+        "euclid", "logeuclid", "riemann".
 
     Returns
     -------
     X : ndarray, shape (..., n, n)
-        Matrices in manidold.
+        Matrices in manifold.
 
     See Also
     --------

--- a/pyriemann/utils/utils.py
+++ b/pyriemann/utils/utils.py
@@ -102,24 +102,24 @@ def check_weights(weights, n_weights, *, check_positivity=False):
     return weights
 
 
-def check_metric(metric, expected_keys=['mean', 'distance']):
+def check_metric(metric, expected_keys=["mean", "distance"]):
     """Check metric argument.
 
     Parameters
     ----------
-     metric : str or dict
-        Metric used in the algorithm: it can be a string, or a dictionary defining
-        different metrics for the different steps of the algorithm.
-        Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed of training, and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
-     expected_keys : list, default  ['mean', 'distance']
-        List of names of the steps of the algorithm requiring a metric argument.
+     metric : str | dict
+        Metric to check in the algorithm: it can be a string, or a dictionary
+        defining different metrics for the different steps of the algorithm.
+        Typical usecase is to pass "logeuclid" metric for the "mean" in order
+        to boost the computional speed, and "riemann" for the "distance" in
+        order to keep the good sensitivity for the classification.
+     expected_keys : list of str, default ["mean", "distance"]
+        Names of the steps of the algorithm requiring a metric argument.
 
     Returns
     -------
-     metric : list
-        List of metrics for each expected key.
+     metric : list of str
+        Metrics for each expected key.
     """
     if isinstance(metric, str):
         return [metric] * len(expected_keys)

--- a/pyriemann/utils/utils.py
+++ b/pyriemann/utils/utils.py
@@ -107,13 +107,13 @@ def check_metric(metric, expected_keys=["mean", "distance"]):
 
     Parameters
     ----------
-     metric : str | dict
+     metric : string | dict
         Metric to check in the algorithm: it can be a string, or a dictionary
         defining different metrics for the different steps of the algorithm.
         Typical usecase is to pass "logeuclid" metric for the "mean" in order
         to boost the computional speed, and "riemann" for the "distance" in
         order to keep the good sensitivity for the classification.
-     expected_keys : list of str, default ["mean", "distance"]
+     expected_keys : list of str, default=["mean", "distance"]
         Names of the steps of the algorithm requiring a metric argument.
 
     Returns
@@ -126,9 +126,11 @@ def check_metric(metric, expected_keys=["mean", "distance"]):
 
     elif isinstance(metric, dict):
         if not all(k in metric.keys() for k in expected_keys):
-            raise KeyError(f"metric must contain {expected_keys}")
+            raise KeyError(
+                f"metric must contain {expected_keys}, but got {metric.keys()}"
+            )
 
         return [metric[k] for k in expected_keys]
 
     else:
-        raise TypeError("metric must be str or dict")
+        raise TypeError("metric must be str or dict, but got {type(metric)}")

--- a/pyriemann/utils/utils.py
+++ b/pyriemann/utils/utils.py
@@ -100,3 +100,35 @@ def check_weights(weights, n_weights, *, check_positivity=False):
 
     weights /= np.sum(weights)
     return weights
+
+
+def check_metric(metric, expected_keys=['mean', 'distance']):
+    """Check metric argument.
+
+    Parameters
+    ----------
+     metric : str or dict
+        Metric used in the algorithm: it can be a string, or a dictionary defining
+        different metrics for the different steps of the algorithm.
+        Typical usecase is to pass 'logeuclid' metric for
+        the mean in order to boost the computional speed of training, and 'riemann' for the
+        distance in order to keep the good sensitivity for the classification.
+     expected_keys : list, default  ['mean', 'distance']
+        List of names of the steps of the algorithm requiring a metric argument.
+
+    Returns
+    -------
+     metric : list
+        List of metrics for each expected key.
+    """
+    if isinstance(metric, str):
+        return [metric] * len(expected_keys)
+
+    elif isinstance(metric, dict):
+        if not all(k in metric.keys() for k in expected_keys):
+            raise KeyError(f"metric must contain {expected_keys}")
+
+        return [metric[k] for k in expected_keys]
+
+    else:
+        raise TypeError("metric must be str or dict")

--- a/tests/test_utils_utils.py
+++ b/tests/test_utils_utils.py
@@ -39,13 +39,13 @@ def test_check_metric_str():
 
 
 def test_check_metric_dict():
-    given_dict = {"mean": "aaa", "distance": "bbb" }
+    given_dict = {"mean": "aaa", "distance": "bbb"}
     expected_keys = ['mean', 'distance']
     metrics = check_metric(given_dict, expected_keys)
     assert len(metrics) == len(expected_keys)
 
     with pytest.raises(KeyError):
-        check_metric({"mean": "aaa", "map": "bbb" }, expected_keys)
+        check_metric({"mean": "aaa", "map": "bbb"}, expected_keys)
 
 
 def test_check_metric_errortype():

--- a/tests/test_utils_utils.py
+++ b/tests/test_utils_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pyriemann.utils.utils import check_weights
+from pyriemann.utils.utils import check_weights, check_metric
 
 
 @pytest.mark.parametrize("n_matrices", [3, 4, 5])
@@ -29,3 +29,25 @@ def test_check_weights_error_positivity():
     w[0] = 0
     with pytest.raises(ValueError):  # not strictly positive weight
         check_weights(w, n_matrices, check_positivity=True)
+
+
+def test_check_metric_str():
+    given_metric = "abc"
+    expected_keys = ['mean', 'distance']
+    metrics = check_metric(given_metric, expected_keys)
+    assert len(metrics) == len(expected_keys)
+
+
+def test_check_metric_dict():
+    given_dict = {"mean": "aaa", "distance": "bbb" }
+    expected_keys = ['mean', 'distance']
+    metrics = check_metric(given_dict, expected_keys)
+    assert len(metrics) == len(expected_keys)
+
+    with pytest.raises(KeyError):
+        check_metric({"mean": "aaa", "map": "bbb" }, expected_keys)
+
+
+def test_check_metric_errortype():
+    with pytest.raises(TypeError):
+        check_metric(3)


### PR DESCRIPTION
Many classes and functions check `metric` argument,
but each module has its own function (classification, tangentspace, transfer).

This PR:
- uses a single function,
- completes docs giving the link towards possible values, 
- and completes tests.