### PR TITLE
Correct example on covariance estimation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,10 +27,7 @@ print(mne.datasets.eegbci.load_data(1, [6, 10, 14], update_path=True))
 curdir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 
-
 matplotlib.use('Agg')
-import shlex
-import sphinx_gallery
 import sphinx_bootstrap_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/examples/ERP/plot_classify_EEG_tangentspace.py
+++ b/examples/ERP/plot_classify_EEG_tangentspace.py
@@ -13,20 +13,17 @@ the tangent space and classified with a logistic regression.
 # License: BSD (3-clause)
 
 import numpy as np
-
-from pyriemann.estimation import XdawnCovariances
-from pyriemann.tangentspace import TangentSpace
-
+from matplotlib import pyplot as plt
 import mne
 from mne import io
 from mne.datasets import sample
-
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import KFold
 from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
 from sklearn.pipeline import make_pipeline
 
-from matplotlib import pyplot as plt
+from pyriemann.estimation import XdawnCovariances
+from pyriemann.tangentspace import TangentSpace
 
 print(__doc__)
 

--- a/examples/ERP/plot_classify_MEG_mdm.py
+++ b/examples/ERP/plot_classify_MEG_mdm.py
@@ -17,13 +17,9 @@ for mean-covariance matrices used by the classification algorithm.
 
 import numpy as np
 from matplotlib import pyplot as plt
-from pyriemann.estimation import XdawnCovariances
-from pyriemann.classification import MDM
-
 import mne
 from mne import io
 from mne.datasets import sample
-
 from sklearn.metrics import (
     classification_report,
     confusion_matrix,
@@ -31,6 +27,9 @@ from sklearn.metrics import (
 )
 from sklearn.model_selection import KFold
 from sklearn.pipeline import make_pipeline
+
+from pyriemann.classification import MDM
+from pyriemann.estimation import XdawnCovariances
 
 print(__doc__)
 

--- a/examples/SSVEP/plot_classify_ssvep_mdm.py
+++ b/examples/SSVEP/plot_classify_ssvep_mdm.py
@@ -14,7 +14,6 @@ is trained to predict a 4-class problem for an offline setup.
 
 import numpy as np
 import matplotlib.pyplot as plt
-
 from mne import find_events, Epochs
 from mne.io import Raw
 from sklearn.model_selection import cross_val_score, RepeatedKFold

--- a/examples/SSVEP/plot_classify_ssvep_pga.py
+++ b/examples/SSVEP/plot_classify_ssvep_pga.py
@@ -16,7 +16,6 @@ before this example.
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
-
 from mne import find_events, Epochs, make_fixed_length_epochs
 from mne.io import Raw
 from sklearn.pipeline import make_pipeline

--- a/examples/artifacts/plot_correct_ajdc_EEG.py
+++ b/examples/artifacts/plot_correct_ajdc_EEG.py
@@ -13,13 +13,12 @@ Fourier cospectra (AJDC), applied to artifact correction of EEG [1]_.
 
 import gzip
 import numpy as np
-from scipy.signal import welch
 from matplotlib import pyplot as plt
-
 from mne import create_info
 from mne.io import RawArray
 from mne.viz import plot_topomap
 from mne.preprocessing import ICA
+from scipy.signal import welch
 
 from pyriemann.spatialfilters import AJDC
 from pyriemann.utils.viz import plot_cospectra

--- a/examples/artifacts/plot_detect_riemannian_potato_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_EEG.py
@@ -12,7 +12,6 @@ intuitive visualizations.
 # License: BSD (3-clause)
 
 from functools import partial
-
 import os
 
 import numpy as np

--- a/examples/motor-imagery/helpers/coherence_helpers.py
+++ b/examples/motor-imagery/helpers/coherence_helpers.py
@@ -6,14 +6,14 @@
 This file contains helper functions for the functional connectivity example
 """
 
-from pyriemann.utils.base import nearest_sym_pos_def
-
 from sklearn.model_selection import StratifiedKFold
 from sklearn.base import clone
 from sklearn.preprocessing import LabelEncoder
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.metrics import balanced_accuracy_score
 from sklearn.ensemble import StackingClassifier
+
+from pyriemann.utils.base import nearest_sym_pos_def
 
 
 class NearestSPD(TransformerMixin, BaseEstimator):

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -19,10 +19,8 @@ from mne import Epochs, pick_types, events_from_annotations
 from mne.io import concatenate_raws
 from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
-
 from sklearn.base import clone
-from sklearn.model_selection import (StratifiedKFold,
-                                     GridSearchCV)
+from sklearn.model_selection import StratifiedKFold, GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.svm import SVC
@@ -32,7 +30,6 @@ from sklearn.metrics import accuracy_score
 from pyriemann.classification import MDM
 from pyriemann.estimation import Covariances
 from pyriemann.tangentspace import TangentSpace
-
 
 ###############################################################################
 # Define the Augmented Covariance

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -31,6 +31,7 @@ from pyriemann.classification import MDM
 from pyriemann.estimation import Covariances
 from pyriemann.tangentspace import TangentSpace
 
+
 ###############################################################################
 # Define the Augmented Covariance
 # -------------------------------

--- a/examples/motor-imagery/plot_ensemble_coherence.py
+++ b/examples/motor-imagery/plot_ensemble_coherence.py
@@ -13,21 +13,14 @@ ensemble learning [1]_.
 # License: BSD (3-clause)
 
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 
 from mne import Epochs, pick_types, events_from_annotations
 from mne.io import concatenate_raws
 from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
-
-import numpy as np
-import pandas as pd
-import seaborn as sns
-
-from pyriemann.classification import FgMDM
-from pyriemann.estimation import Covariances, Coherences
-from pyriemann.spatialfilters import CSP
-from pyriemann.tangentspace import TangentSpace
-
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.ensemble import StackingClassifier
 from sklearn.linear_model import LogisticRegression
@@ -35,10 +28,11 @@ from sklearn.model_selection import GridSearchCV, StratifiedKFold
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC
 
-from helpers.coherence_helpers import (
-    NearestSPD,
-    get_results,
-)
+from pyriemann.classification import FgMDM
+from pyriemann.estimation import Coherences, Covariances
+from pyriemann.spatialfilters import CSP
+from pyriemann.tangentspace import TangentSpace
+from helpers.coherence_helpers import NearestSPD, get_results
 
 
 ###############################################################################

--- a/examples/motor-imagery/plot_frequency_band_selection.py
+++ b/examples/motor-imagery/plot_frequency_band_selection.py
@@ -13,16 +13,14 @@ data to the baseline with no frequency band selection [1]_.
 #
 # License: BSD (3-clause)
 
+from time import time
 
 import numpy as np
-from time import time
 from matplotlib import pyplot as plt
-
 from mne import Epochs, pick_types, events_from_annotations
 from mne.io import concatenate_raws
 from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
-
 from sklearn.model_selection import cross_val_score, ShuffleSplit
 
 from pyriemann.classification import MDM

--- a/examples/signal/plot_covariance_estimation.py
+++ b/examples/signal/plot_covariance_estimation.py
@@ -128,7 +128,7 @@ estimators = [
     "ker-rbf", "ker-polynomial", "ker-laplacian",
 ]
 tmin = -0.2
-w_len = np.linspace(0.2, 2, 10)
+w_len = np.linspace(0.5, 2.5, 5)
 n_matrices = 45
 dfc = list()
 
@@ -173,7 +173,7 @@ plt.show()
 # especially when the matrices are estimated on short time windows.
 
 tmin = 0.0
-w_len = np.linspace(0.2, 2.0, 5)
+w_len = np.linspace(0.5, 2.5, 5)
 n_matrices, n_splits = 45, 5
 dfa = list()
 sc = "balanced_accuracy"

--- a/examples/stats/oneWay_Manova_ERP.py
+++ b/examples/stats/oneWay_Manova_ERP.py
@@ -9,6 +9,7 @@ Manova for ERP data
 # License: BSD (3-clause)
 
 from time import time
+
 from matplotlib import pyplot as plt
 import seaborn as sns
 

--- a/examples/stats/plot_oneWay_Manova.py
+++ b/examples/stats/plot_oneWay_Manova.py
@@ -6,6 +6,7 @@ One Way manova
 One way manova to compare Left vs Right.
 """
 from time import time
+
 from matplotlib import pyplot as plt
 import seaborn as sns
 

--- a/examples/stats/plot_oneWay_Manova_frequency.py
+++ b/examples/stats/plot_oneWay_Manova_frequency.py
@@ -5,11 +5,12 @@ One Way manova with Frequenty
 
 One way manova to compare Left vs Right for each frequency.
 """
+from time import time
+
 import numpy as np
+from pylab import plt
 import seaborn as sns
 
-from time import time
-from pylab import plt
 from mne import Epochs, pick_types, events_from_annotations
 from mne.io import concatenate_raws
 from mne.io.edf import read_raw_edf

--- a/examples/stats/plot_oneWay_Manova_time.py
+++ b/examples/stats/plot_oneWay_Manova_time.py
@@ -5,11 +5,11 @@ One Way manova time
 
 One way manova to compare Left vs Right in time.
 """
-import numpy as np
-import seaborn as sns
-
 from time import time
+
+import numpy as np
 from pylab import plt
+import seaborn as sns
 
 from mne import Epochs, pick_types, events_from_annotations
 from mne.io import concatenate_raws

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -16,8 +16,6 @@ database and compare the classification performance of MDM with each strategy.
 
 import numpy as np
 from tqdm import tqdm
-from sklearn.pipeline import make_pipeline
-from sklearn.model_selection import StratifiedShuffleSplit
 import matplotlib.pyplot as plt
 
 from mne import Epochs, pick_types, events_from_annotations
@@ -25,6 +23,8 @@ from mne.io import concatenate_raws
 from mne.io.edf import read_raw_edf
 from mne.datasets import eegbci
 from mne import set_log_level
+from sklearn.pipeline import make_pipeline
+from sklearn.model_selection import StratifiedShuffleSplit
 
 from pyriemann.classification import MDM
 from pyriemann.estimation import Covariances
@@ -35,7 +35,6 @@ from pyriemann.transfer import (
     TLClassifier,
     TLSplitter,
 )
-
 set_log_level(verbose=False)
 
 


### PR DESCRIPTION
Example on covariance estimation computes covariance matrices with different window lengths.

A length of 0.2 is too short for covariance estimation, giving ill-conditionned matrices, and providing an illegible illustration.
https://pyriemann.readthedocs.io/en/latest/_images/sphx_glr_plot_covariance_estimation_002.png

Moreover, I clean imports in examples.