### PR TITLE
Adding Euclidean Alignment implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2023, authors of pyRiemann
+Copyright (c) 2015-2024, authors of pyRiemann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyRiemann'
-copyright = u'2015-2023, pyRiemann Contributors'
+copyright = u'2015-2024, pyRiemann Contributors'
 author = u'Alexandre Barachant'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,8 +7,8 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release.
 
-v0.6.dev
---------
+v0.6 (April 2024)
+-----------------
 
 - Update pyRiemann from Python 3.7 to 3.8. :pr:`254` by :user:`qbarthelemy`
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -7,6 +7,10 @@ What's new in the package
 
 A catalog of new features, improvements, and bug-fixes in each release.
 
+v0.7.dev
+--------
+
+
 v0.6 (April 2024)
 -----------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,9 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.7.dev
 --------
 
-- Add kernel option to :class:`pyriemann.embedding.LocallyLinearEmbedding`. :pr:`293` by :user:`gabelstein`
+- Add ``kernel`` parameter to :class:`pyriemann.embedding.LocallyLinearEmbedding`. :pr:`293` by :user:`gabelstein`
+
+- Add possibility for ``target_domain`` parameter of :class:`pyriemann.transfer._estimators.TLCenter` to be empty, forcing ``transform()`` to recenter matrices to the last fitted domain. :pr:`292` by :user:`brunaafl`
 
 v0.6 (April 2024)
 -----------------
@@ -51,8 +53,6 @@ v0.6 (April 2024)
   by :user:`qbarthelemy` and :user:`gcattan`
 
 - Add :class:`pyriemann.estimation.CrossSpectra` and deprecate `CospCovariances` renamed into :class:`pyriemann.estimation.CoSpectra`. :pr:`288` by :user:`qbarthelemy`
-
-- Adapt :class:`pyriemann.transfer._estimators.TLCenter` to allow integration with MOABB pipelines and evaluations. :pr:`292` by :user:`brunaafl`
 
 v0.5 (Jun 2023)
 ---------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,7 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.7.dev
 --------
 
+- Add kernel option to :class:`pyriemann.embedding.LocallyLinearEmbedding`. :pr:`293` by :user:`gabelstein`
 
 v0.6 (April 2024)
 -----------------

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.6'
+__version__ = '0.7.dev'

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.6.dev'
+__version__ = '0.6'

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -196,8 +196,7 @@ class TLCenter(BaseEstimator, TransformerMixin):
             target_domain = self.target_domain
         # else, use last calibrated domain as target domain
         else:
-            keys = list(self.recenter_.keys())
-            target_domain = keys[-1]
+            target_domain = list(self.recenter_.keys())[-1]
 
         X_rct = self.recenter_[target_domain].transform(X)
         return X_rct

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,11 @@ setup(
             "seaborn",
             "pandas",
         ],
-        "tests": ["pytest", "seaborn", "flake8"],
+        "tests": [
+            "pytest",
+            "seaborn",
+            "flake8"
+        ],
     },
     zip_safe=False,
 )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -56,7 +56,7 @@ def test_encode_decode_domains(rndstate):
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
 @pytest.mark.parametrize("sample_weight", [True, False])
-@pytest.mark.parametrize("target_domain", ['target_domain', None])
+@pytest.mark.parametrize("target_domain", ["target_domain", ""])
 def test_tlcenter(rndstate, metric, sample_weight, target_domain):
     """Test pipeline for recentering data to Identity"""
     # check if the global mean of the domains is indeed Identity
@@ -85,9 +85,9 @@ def test_tlcenter(rndstate, metric, sample_weight, target_domain):
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
 @pytest.mark.parametrize("sample_weight", [True, False])
-@pytest.mark.parametrize("target_domain", ['target_domain', ''])
-def test_tlcenter_fit(rndstate, metric, sample_weight, target_domain):
-    """Test pipeline for recentering data to Identity"""
+@pytest.mark.parametrize("target_domain", ["target_domain", ""])
+def test_tlcenter_fit_transf(rndstate, metric, sample_weight, target_domain):
+    """Test .fit_transform() versus .fit().transform()"""
     # check if the global mean of the domains is indeed Identity
     rct = TLCenter(target_domain=target_domain, metric=metric)
     X, y_enc = make_classification_transfer(
@@ -106,11 +106,7 @@ def test_tlcenter_fit(rndstate, metric, sample_weight, target_domain):
     X2, y2 = X[50:], y_enc[50:]
 
     X1_rct = rct.fit_transform(X1, y1, sample_weight=sample_weight_1)
-    rct.fit(X2, y2, sample_weight=sample_weight_2)
-    X2_rct = rct.transform(X2)
-
-    print(rct.recenter_.keys())
-
+    X2_rct = rct.fit(X2, y2, sample_weight=sample_weight_2).transform(X2)
     X_rct = np.concatenate((X1_rct, X2_rct))
 
     for d in np.unique(domain):


### PR DESCRIPTION
Hello!

I am adding an implementation of the Euclidean Alignment (He H. et al - 2019) used on Junqueira, B et al. (2024). The methods depend directly on the covariance estimators present on Pyriemann, and Sylvain thought about what would be a nice addition for Pyriemann.

In this re-implementation, I defined it as a scikit-learn transformation, and in a way that is not necessary to define a ‘target’ domain before. 

It would be easier to add this transformation as a preprocessing step in a pipeline, and also to integrate with MOABB, being able to use the pre-defined evaluation objects. 

This class is also adapted to align both raw trials and covariance matrices and to define the type of covariance estimator, in the case the input is raw data. Therefore, it can be used with different classifiers.

Since we were working with this transformation, we thought adding an implementation and a tutorial here in PyRiemann would be nice, but I would like to check first if the tutorial would be welcome.
