### PR TITLE
Update testing.yml

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,8 +21,10 @@ jobs:
         # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
+        - { python-version: "3.8", os: "macos-latest" }
         - { python-version: "3.9", os: "macos-latest" }
         include:
+        - { python-version: "3.8", os: "macos-13" }
         - { python-version: "3.9", os: "macos-13" }
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,12 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.9", os: "macos-13" }
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.8 and 3.9 are not available on macos-latest.
See this comment https://github.com/actions/setup-python/issues/850#issuecomment-2072657610

@qbarthelemy FYI