### PR TITLE
Fix LLE warning mistake

### DIFF
--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -445,9 +445,9 @@ def _check_dimensions(X, Y=None, n_components=None, n_neighbors=None):
     if n_neighbors is None:
         n_neighbors = n_matrices - 1
     elif n_matrices <= n_neighbors:
-        n_neighbors = n_matrices - 1
         warnings.warn(f"n_neighbors (is {n_neighbors}) must be smaller than "
                       f"n_matrices (is {n_matrices}). Setting n_neighbors to "
                       f"{n_matrices - 1}.")
+        n_neighbors = n_matrices - 1
 
     return n_components, n_neighbors


### PR DESCRIPTION
Stupid error, obviously always printed     `n_neighbors = n_matrices - 1` in the warning.

Also, this warning clogs my console extremely on large comparisons. Maybe we could just not proint a warning @qbarthelemy ? 

Or introduce some variable that suppresses it? But this would be more of a global thing, I guess. 