### PR TITLE
Improve clustering module

### DIFF
--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -64,7 +64,8 @@ def _fit_single(X, y=None, n_clusters=2, init="random", random_state=None,
 class Kmeans(BaseEstimator, ClassifierMixin, ClusterMixin, TransformerMixin):
     """Clustering by k-means with SPD matrices as inputs.
 
-    Find clusters that minimize the sum of squared distance to their centroids.
+    The k-means is a clustering method used to find clusters that minimize the
+    sum of squared distances to their centroids.
     This is a direct implementation of the k-means algorithm with a Riemannian
     metric [1]_.
 
@@ -324,8 +325,9 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
     """Artefact detection with the Riemannian Potato.
 
     The Riemannian Potato [1]_ is a clustering method used to detect artifact
-    in EEG signals. The algorithm iteratively estimates the centroid of clean
-    signal by rejecting every trial that is too far from it.
+    in multichannel signals. Processing SPD matrices,
+    the algorithm iteratively estimates the centroid of clean
+    matrices by rejecting every matrix that is too far from it.
 
     Parameters
     ----------
@@ -384,9 +386,9 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         self.neg_label = neg_label
 
     def fit(self, X, y=None):
-        """Fit the potato from covariance matrices.
+        """Fit the potato from SPD matrices.
 
-        Fit the potato from covariance matrices, with an iterative outlier
+        Fit the potato from SPD matrices, with an iterative outlier
         removal to obtain a reliable potato.
 
         Parameters
@@ -431,10 +433,10 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         return self
 
     def partial_fit(self, X, y=None, alpha=0.1):
-        """Partially fit the potato from covariance matrices.
+        """Partially fit the potato from SPD matrices.
 
         This partial fit can be used to update dynamic or semi-dymanic online
-        potatoes with clean EEG.
+        potatoes with clean matrices.
 
         Parameters
         ----------
@@ -470,7 +472,7 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
         if alpha == 0:
             return self
 
-        Xm = mean_covariance(X[(y == self.pos_label)], metric=self.metric)
+        Xm = mean_covariance(X[y == self.pos_label], metric=self.metric)
         self._mdm.covmeans_[0] = geodesic(
             self._mdm.covmeans_[0], Xm, alpha, metric=self.metric
         )
@@ -586,8 +588,9 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
     """Artefact detection with the Riemannian Potato Field.
 
     The Riemannian Potato Field [1]_ is a clustering method used to detect
-    artifact in EEG signals. The algorithm combines several potatoes of low
-    dimension, each one being designed to capture specific artifact typically
+    artifact in multichannel signals. Processing SPD matrices,
+    the algorithm combines several potatoes of low dimension,
+    each one being designed to capture specific artifact typically
     affecting specific subsets of channels and/or specific frequency bands.
 
     Parameters
@@ -609,9 +612,9 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         in order to pass different metrics.
     n_iter_max : int, default=10
         The maximum number of iteration to reach convergence.
-    pos_label: int, default=1
+    pos_label : int, default=1
         The positive label corresponding to clean data.
-    neg_label: int, default=0
+    neg_label : int, default=0
         The negative label corresponding to artifact data.
 
     Notes
@@ -644,9 +647,9 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         self.neg_label = neg_label
 
     def fit(self, X, y=None):
-        """Fit the potato field from covariance matrices.
+        """Fit the potato field from SPD matrices.
 
-        Fit the potato field from covariance matrices, with iterative
+        Fit the potato field from SPD matrices, with iterative
         outlier removal to obtain reliable potatoes.
 
         Parameters
@@ -655,8 +658,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels) with same n_matrices but potentially different \
                 n_channels
             List of sets of SPD matrices, each corresponding to a different
-            subset of EEG channels and/or filtering with a specific frequency
-            band.
+            subset of channels and/or filtering with a specific frequency band.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
             label corresponds to a clean (resp. artifact) matrix.
@@ -689,10 +691,10 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
         return self
 
     def partial_fit(self, X, y=None, alpha=0.1):
-        """Partially fit the potato field from covariance matrices.
+        """Partially fit the potato field from SPD matrices.
 
         This partial fit can be used to update dynamic or semi-dymanic online
-        potatoes with clean EEG.
+        potatoes with clean matrices.
 
         Parameters
         ----------
@@ -700,8 +702,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels) with same n_matrices but potentially different \
                 n_channels
             List of sets of SPD matrices, each corresponding to a different
-            subset of EEG channels and/or filtering with a specific frequency
-            band.
+            subset of channels and/or filtering with a specific frequency band.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
             label corresponds to a clean (resp. artifact) matrix.
@@ -739,8 +740,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels) with same n_matrices but potentially different \
                 n_channels
             List of sets of SPD matrices, each corresponding to a different
-            subset of EEG channels and/or filtering with a specific frequency
-            band.
+            subset of channels and/or filtering with a specific frequency band.
 
         Returns
         -------
@@ -765,8 +765,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels) with same n_matrices but potentially different \
                 n_channels
             List of sets of SPD matrices, each corresponding to a different
-            subset of EEG channels and/or filtering with a specific frequency
-            band.
+            subset of channels and/or filtering with a specific frequency band.
 
         Returns
         -------
@@ -792,8 +791,7 @@ class PotatoField(BaseEstimator, TransformerMixin, ClassifierMixin):
                 n_channels) with same n_matrices but potentially different \
                 n_channels
             List of sets of SPD matrices, each corresponding to a different
-            subset of EEG channels and/or filtering with a specific frequency
-            band.
+            subset of channels and/or filtering with a specific frequency band.
 
         Returns
         -------

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -472,12 +472,14 @@ class Potato(BaseEstimator, TransformerMixin, ClassifierMixin):
 
         Xm = mean_covariance(X[(y == self.pos_label)], metric=self.metric)
         self._mdm.covmeans_[0] = geodesic(
-            self._mdm.covmeans_[0], Xm, alpha, metric=self.metric)
+            self._mdm.covmeans_[0], Xm, alpha, metric=self.metric
+        )
 
         d = np.squeeze(np.log(self._mdm.transform(Xm[np.newaxis, ...])))
         self._mean = (1 - alpha) * self._mean + alpha * d
         self._std = np.sqrt(
-            (1 - alpha) * self._std**2 + alpha * (d - self._mean)**2)
+            (1 - alpha) * self._std**2 + alpha * (d - self._mean)**2
+        )
 
         self.covmean_ = self._mdm.covmeans_[0]
         return self

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -129,6 +129,9 @@ def mean_alm(X=None, tol=1e-14, maxiter=100, sample_weight=None, covmats=None):
     n_matrices, _, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
 
+    if n_matrices == 1:
+        return X[0]
+
     if n_matrices == 2:
         alpha = sample_weight[1] / sample_weight[0] / 2
         M = geodesic_riemann(X[0], X[1], alpha=alpha)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -40,8 +40,8 @@ class ClusteringTestCase:
         if clust is PotatoField:
             n_potatoes = 3
             mats = [get_mats(n_matrices, n_channels, "spd"),
-                       get_mats(n_matrices, n_channels + 2, "spd"),
-                       get_mats(n_matrices, n_channels + 1, "spd")]
+                    get_mats(n_matrices, n_channels + 2, "spd"),
+                    get_mats(n_matrices, n_channels + 1, "spd")]
             self.clf_transform(clust, mats, n_potatoes)
             self.clf_predict(clust, mats, n_potatoes)
             self.clf_predict_proba(clust, mats, n_potatoes)
@@ -77,11 +77,11 @@ class TestRiemannianClustering(ClusteringTestCase):
         else:
             clf = clust(n_clusters=n_clusters)
         clf.fit(mats)
-        transformed = clf.transform(mats)
+        transf = clf.transform(mats)
         if n_clusters is None:
-            assert transformed.shape == (n_matrices,)
+            assert transf.shape == (n_matrices,)
         else:
-            assert transformed.shape == (n_matrices, n_clusters)
+            assert transf.shape == (n_matrices, n_clusters)
 
     def clf_jobs(self, clust, mats, n_clusters, labels=None):
         n_matrices = mats.shape[0]
@@ -90,23 +90,22 @@ class TestRiemannianClustering(ClusteringTestCase):
             clf.fit(mats)
         else:
             clf.fit(mats, labels)
-        transformed = clf.transform(mats)
-        assert len(transformed) == (n_matrices)
+        transf = clf.transform(mats)
+        assert len(transf) == (n_matrices)
 
     def clf_centroids(self, clust, mats, n_clusters):
         _, n_channels, n_channels = mats.shape
         clf = clust(n_clusters=n_clusters).fit(mats)
         centroids = clf.centroids()
-        shape = (n_clusters, n_channels, n_channels)
-        assert np.array(centroids).shape == shape
+        assert centroids.shape == (n_clusters, n_channels, n_channels)
 
     def clf_transform_per_class(self, clust, mats, n_clusters, labels):
         n_classes = len(np.unique(labels))
         n_matrices = mats.shape[0]
         clf = clust(n_clusters=n_clusters)
         clf.fit(mats, labels)
-        transformed = clf.transform(mats)
-        assert transformed.shape == (n_matrices, n_classes * n_clusters)
+        transf = clf.transform(mats)
+        assert transf.shape == (n_matrices, n_classes * n_clusters)
 
     def clf_predict(self, clust, mats, n_clusters=None):
         n_matrices = len(mats)
@@ -118,8 +117,8 @@ class TestRiemannianClustering(ClusteringTestCase):
         else:
             clf = clust(n_clusters=n_clusters)
         clf.fit(mats)
-        predicted = clf.predict(mats)
-        assert predicted.shape == (n_matrices,)
+        pred = clf.predict(mats)
+        assert pred.shape == (n_matrices,)
 
     def clf_predict_proba(self, clust, mats, n=None):
         if n is None:
@@ -129,8 +128,8 @@ class TestRiemannianClustering(ClusteringTestCase):
             n_matrices = len(mats[0])
             clf = clust(n_potatoes=n)
         clf.fit(mats)
-        probabilities = clf.predict(mats)
-        assert probabilities.shape == (n_matrices,)
+        proba = clf.predict_proba(mats)
+        assert proba.shape == (n_matrices,)
 
     def clf_partial_fit(self, clust, mats, n=None):
         if n is None:

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -18,281 +18,298 @@ class ClusteringTestCase:
     def test_two_clusters(self, clust, get_mats, get_labels):
         n_clusters = 2
         n_matrices, n_channels = 6, 4
-        covmats = get_mats(n_matrices, n_channels, "spd")
+        mats = get_mats(n_matrices, n_channels, "spd")
         if clust is Kmeans:
-            self.clf_predict(clust, covmats, n_clusters)
-            self.clf_transform(clust, covmats, n_clusters)
-            self.clf_jobs(clust, covmats, n_clusters)
-            self.clf_centroids(clust, covmats, n_clusters)
-            self.clf_fit_independence(clust, covmats)
+            self.clf_predict(clust, mats, n_clusters)
+            self.clf_transform(clust, mats, n_clusters)
+            self.clf_jobs(clust, mats, n_clusters)
+            self.clf_centroids(clust, mats, n_clusters)
+            self.clf_fit_independence(clust, mats)
         if clust is KmeansPerClassTransform:
             n_classes = 2
             labels = get_labels(n_matrices, n_classes)
-            self.clf_transform_per_class(clust, covmats, n_clusters, labels)
-            self.clf_jobs(clust, covmats, n_clusters, labels)
-            self.clf_fit_labels_independence(clust, covmats, labels)
+            self.clf_transform_per_class(clust, mats, n_clusters, labels)
+            self.clf_jobs(clust, mats, n_clusters, labels)
+            self.clf_fit_labels_independence(clust, mats, labels)
         if clust is Potato:
-            self.clf_transform(clust, covmats)
-            self.clf_predict(clust, covmats)
-            self.clf_predict_proba(clust, covmats)
-            self.clf_partial_fit(clust, covmats)
-            self.clf_fit_independence(clust, covmats)
+            self.clf_transform(clust, mats)
+            self.clf_predict(clust, mats)
+            self.clf_predict_proba(clust, mats)
+            self.clf_partial_fit(clust, mats)
+            self.clf_fit_independence(clust, mats)
         if clust is PotatoField:
             n_potatoes = 3
-            covmats = [get_mats(n_matrices, n_channels, "spd"),
+            mats = [get_mats(n_matrices, n_channels, "spd"),
                        get_mats(n_matrices, n_channels + 2, "spd"),
                        get_mats(n_matrices, n_channels + 1, "spd")]
-            self.clf_transform(clust, covmats, n_potatoes)
-            self.clf_predict(clust, covmats, n_potatoes)
-            self.clf_predict_proba(clust, covmats, n_potatoes)
-            self.clf_partial_fit(clust, covmats, n_potatoes)
-            self.clf_fit_independence(clust, covmats, n_potatoes)
+            self.clf_transform(clust, mats, n_potatoes)
+            self.clf_predict(clust, mats, n_potatoes)
+            self.clf_predict_proba(clust, mats, n_potatoes)
+            self.clf_partial_fit(clust, mats, n_potatoes)
+            self.clf_fit_independence(clust, mats, n_potatoes)
 
     def test_three_clusters(self, clust, get_mats, get_labels):
         n_clusters = 3
         n_matrices, n_channels = 6, 3
-        covmats = get_mats(n_matrices, n_channels, "spd")
+        mats = get_mats(n_matrices, n_channels, "spd")
         if clust is Kmeans:
-            self.clf_predict(clust, covmats, n_clusters)
-            self.clf_transform(clust, covmats, n_clusters)
-            self.clf_jobs(clust, covmats, n_clusters)
-            self.clf_centroids(clust, covmats, n_clusters)
-            self.clf_fit_independence(clust, covmats)
+            self.clf_predict(clust, mats, n_clusters)
+            self.clf_transform(clust, mats, n_clusters)
+            self.clf_jobs(clust, mats, n_clusters)
+            self.clf_centroids(clust, mats, n_clusters)
+            self.clf_fit_independence(clust, mats)
         if clust is KmeansPerClassTransform:
             n_classes = 2
             labels = get_labels(n_matrices, n_classes)
-            self.clf_transform_per_class(clust, covmats, n_clusters, labels)
-            self.clf_jobs(clust, covmats, n_clusters, labels)
-            self.clf_fit_labels_independence(clust, covmats, labels)
+            self.clf_transform_per_class(clust, mats, n_clusters, labels)
+            self.clf_jobs(clust, mats, n_clusters, labels)
+            self.clf_fit_labels_independence(clust, mats, labels)
 
 
 class TestRiemannianClustering(ClusteringTestCase):
-    def clf_transform(self, clust, covmats, n_clusters=None):
-        n_matrices = len(covmats)
+    def clf_transform(self, clust, mats, n_clusters=None):
+        n_matrices = len(mats)
         if n_clusters is None:
             clf = clust()
         elif clust is PotatoField:
-            n_matrices = len(covmats[0])
+            n_matrices = len(mats[0])
             clf = clust(n_potatoes=n_clusters)
         else:
             clf = clust(n_clusters=n_clusters)
-        clf.fit(covmats)
-        transformed = clf.transform(covmats)
+        clf.fit(mats)
+        transformed = clf.transform(mats)
         if n_clusters is None:
             assert transformed.shape == (n_matrices,)
         else:
             assert transformed.shape == (n_matrices, n_clusters)
 
-    def clf_jobs(self, clust, covmats, n_clusters, labels=None):
-        n_matrices = covmats.shape[0]
+    def clf_jobs(self, clust, mats, n_clusters, labels=None):
+        n_matrices = mats.shape[0]
         clf = clust(n_clusters=n_clusters, n_jobs=2)
         if labels is None:
-            clf.fit(covmats)
+            clf.fit(mats)
         else:
-            clf.fit(covmats, labels)
-        transformed = clf.transform(covmats)
+            clf.fit(mats, labels)
+        transformed = clf.transform(mats)
         assert len(transformed) == (n_matrices)
 
-    def clf_centroids(self, clust, covmats, n_clusters):
-        _, n_channels, n_channels = covmats.shape
-        clf = clust(n_clusters=n_clusters).fit(covmats)
+    def clf_centroids(self, clust, mats, n_clusters):
+        _, n_channels, n_channels = mats.shape
+        clf = clust(n_clusters=n_clusters).fit(mats)
         centroids = clf.centroids()
         shape = (n_clusters, n_channels, n_channels)
         assert np.array(centroids).shape == shape
 
-    def clf_transform_per_class(self, clust, covmats, n_clusters, labels):
+    def clf_transform_per_class(self, clust, mats, n_clusters, labels):
         n_classes = len(np.unique(labels))
-        n_matrices = covmats.shape[0]
+        n_matrices = mats.shape[0]
         clf = clust(n_clusters=n_clusters)
-        clf.fit(covmats, labels)
-        transformed = clf.transform(covmats)
+        clf.fit(mats, labels)
+        transformed = clf.transform(mats)
         assert transformed.shape == (n_matrices, n_classes * n_clusters)
 
-    def clf_predict(self, clust, covmats, n_clusters=None):
-        n_matrices = len(covmats)
+    def clf_predict(self, clust, mats, n_clusters=None):
+        n_matrices = len(mats)
         if n_clusters is None:
             clf = clust()
         elif clust is PotatoField:
-            n_matrices = len(covmats[0])
+            n_matrices = len(mats[0])
             clf = clust(n_potatoes=n_clusters)
         else:
             clf = clust(n_clusters=n_clusters)
-        clf.fit(covmats)
-        predicted = clf.predict(covmats)
+        clf.fit(mats)
+        predicted = clf.predict(mats)
         assert predicted.shape == (n_matrices,)
 
-    def clf_predict_proba(self, clust, covmats, n=None):
+    def clf_predict_proba(self, clust, mats, n=None):
         if n is None:
-            n_matrices = len(covmats)
+            n_matrices = len(mats)
             clf = clust()
         else:  # PotatoField
-            n_matrices = len(covmats[0])
+            n_matrices = len(mats[0])
             clf = clust(n_potatoes=n)
-        clf.fit(covmats)
-        probabilities = clf.predict(covmats)
+        clf.fit(mats)
+        probabilities = clf.predict(mats)
         assert probabilities.shape == (n_matrices,)
 
-    def clf_partial_fit(self, clust, covmats, n=None):
+    def clf_partial_fit(self, clust, mats, n=None):
         if n is None:
             clf = clust()
         else:  # PotatoField
             clf = clust(n_potatoes=n)
-        clf.fit(covmats)
-        clf.partial_fit(covmats)
+        clf.fit(mats)
+        clf.partial_fit(mats)
         if n is None:
-            clf.partial_fit(covmats[np.newaxis, 0])  # fit one covmat at a time
+            clf.partial_fit(mats[np.newaxis, 0])  # fit one covmat at a time
         else:
-            clf.partial_fit([c[np.newaxis, 0] for c in covmats])
+            clf.partial_fit([c[np.newaxis, 0] for c in mats])
 
-    def clf_fit_independence(self, clust, covmats, n=None):
+    def clf_fit_independence(self, clust, mats, n=None):
         if n is None:
             clf = clust()
         else:  # PotatoField
             clf = clust(n_potatoes=n)
-        clf.fit(covmats).transform(covmats)
+        clf.fit(mats).transform(mats)
         # retraining with different size should erase previous fit
         if n is None:
-            new_covmats = covmats[:, :-1, :-1]
+            new_mats = mats[:, :-1, :-1]
         else:
-            new_covmats = [c[:, :-1, :-1] for c in covmats]
-        clf.fit(new_covmats).transform(new_covmats)
+            new_mats = [c[:, :-1, :-1] for c in mats]
+        clf.fit(new_mats).transform(new_mats)
 
-    def clf_fit_labels_independence(self, clust, covmats, labels):
+    def clf_fit_labels_independence(self, clust, mats, labels):
         clf = clust()
-        clf.fit(covmats, labels).transform(covmats)
+        clf.fit(mats, labels).transform(mats)
         # retraining with different size should erase previous fit
-        new_covmats = covmats[:, :-1, :-1]
-        clf.fit(new_covmats, labels).transform(new_covmats)
+        new_mats = mats[:, :-1, :-1]
+        clf.fit(new_mats, labels).transform(new_mats)
 
 
 @pytest.mark.parametrize("clust", [Kmeans, KmeansPerClassTransform])
 @pytest.mark.parametrize("init", ["random", "ndarray"])
 @pytest.mark.parametrize("n_init", [1, 5])
 @pytest.mark.parametrize("metric", get_metrics())
-def test_km_init_metric(clust, init, n_init, metric, get_mats, get_labels):
-    n_clusters, n_matrices, n_channels = 2, 6, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
-    labels = get_labels(n_matrices, n_clusters)
+def test_kmeans_init(clust, init, n_init, metric, get_mats, get_labels):
+    n_clusters, n_classes, n_matrices, n_channels = 2, 3, 9, 5
+    mats = get_mats(n_matrices, n_channels, "spd")
+    labels = get_labels(n_matrices, n_classes)
+    print(labels)
+
     if init == "ndarray":
         clf = clust(
             n_clusters=n_clusters,
             metric=metric,
-            init=covmats[:n_clusters],
+            init=mats[:n_clusters],
             n_init=n_init,
         )
     else:
         clf = clust(
-            n_clusters=n_clusters, metric=metric, init=init, n_init=n_init
+            n_clusters=n_clusters,
+            metric=metric,
+            init=init,
+            n_init=n_init
         )
-    clf.fit(covmats, labels)
-    transformed = clf.transform(covmats)
-    assert len(transformed) == n_matrices
+    clf.fit(mats, labels)
+
+    if clust is Kmeans:
+        assert clf.labels_.shape == (n_matrices,)
+        centroids = clf.centroids()
+        assert centroids.shape == (n_clusters, n_channels, n_channels)
+    elif clust is KmeansPerClassTransform:
+        assert clf.classes_.shape == (n_classes,)
+        assert len(clf.covmeans_) <= n_clusters * n_classes
+
+    dists = clf.transform(mats)
+    if clust is Kmeans:
+        assert dists.shape == (n_matrices, n_clusters)
+    elif clust is KmeansPerClassTransform:
+        assert dists.shape == (n_matrices, clf.covmeans_.shape[0])
 
 
 def test_potato_fit_equal_labels(get_mats):
     n_matrices, n_channels = 6, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     with pytest.raises(ValueError):
-        Potato(pos_label=0).fit(covmats)
+        Potato(pos_label=0).fit(mats)
 
 
 @pytest.mark.parametrize("y_fail", [[1], [0] * 6, [0] * 7, [0, 1, 2] * 2])
 def test_potato_fit_error(y_fail, get_mats):
     n_matrices, n_channels = 6, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     with pytest.raises(ValueError):
-        Potato().fit(covmats, y=y_fail)
+        Potato().fit(mats, y=y_fail)
 
 
 def test_potato_partial_fit_not_fitted(get_mats):
     n_matrices, n_channels = 6, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     with pytest.raises(ValueError):  # potato not fitted
-        Potato().partial_fit(covmats)
+        Potato().partial_fit(mats)
 
 
 def test_potato_partial_fit_diff_channels(get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
-    pt = Potato().fit(covmats, labels)
+    pt = Potato().fit(mats, labels)
     with pytest.raises(ValueError):  # unequal # of chans
         pt.partial_fit(get_mats(2, n_channels + 1, "spd"))
 
 
 def test_potato_partial_fit_no_poslabel(get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
-    pt = Potato().fit(covmats, labels)
+    pt = Potato().fit(mats, labels)
     with pytest.raises(ValueError):  # no positive labels
-        pt.partial_fit(covmats, [0] * n_matrices)
+        pt.partial_fit(mats, [0] * n_matrices)
 
 
 @pytest.mark.parametrize("alpha", [-0.1, 1.1])
 def test_potato_partial_fit_alpha(alpha, get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
-    pt = Potato().fit(covmats, labels)
+    pt = Potato().fit(mats, labels)
     with pytest.raises(ValueError):
-        pt.partial_fit(covmats, labels, alpha=alpha)
+        pt.partial_fit(mats, labels, alpha=alpha)
 
 
 def test_potato_1channel(get_mats):
     n_matrices, n_channels = 6, 1
-    covmats_1chan = get_mats(n_matrices, n_channels, "spd")
+    mats_1chan = get_mats(n_matrices, n_channels, "spd")
     pt = Potato()
-    pt.fit_transform(covmats_1chan)
-    pt.predict(covmats_1chan)
-    pt.predict_proba(covmats_1chan)
+    pt.fit_transform(mats_1chan)
+    pt.predict(mats_1chan)
+    pt.predict_proba(mats_1chan)
 
 
 def test_potato_threshold(get_mats):
     n_matrices, n_channels = 6, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, "spd")
     pt = Potato(threshold=2.5)
-    pt.fit(covmats)
+    pt.fit(mats)
 
 
 def test_potato_specific_labels(get_mats):
     n_matrices, n_channels = 10, 3
-    covmats = get_mats(n_matrices, n_channels, "spd")
-    covmats[-1] = 10 * np.eye(n_channels)
+    mats = get_mats(n_matrices, n_channels, "spd")
+    mats[-1] = 10 * np.eye(n_channels)
     pt = Potato(threshold=2.0, pos_label=2, neg_label=7)
-    pt.fit(covmats)
-    assert_array_equal(np.unique(pt.predict(covmats)), [2, 7])
+    pt.fit(mats)
+    assert_array_equal(np.unique(pt.predict(mats)), [2, 7])
     # fit with custom positive label
-    pt.fit(covmats, y=[2] * n_matrices)
+    pt.fit(mats, y=[2] * n_matrices)
 
 
 def test_potato_field_fit(get_mats):
     n_potatoes, n_matrices, n_channels = 2, 6, 3
-    covmats1 = get_mats(n_matrices, n_channels, "spd")
-    covmats2 = get_mats(n_matrices, n_channels + 1, "spd")
-    covmats = [covmats1, covmats2]
+    mats1 = get_mats(n_matrices, n_channels, "spd")
+    mats2 = get_mats(n_matrices, n_channels + 1, "spd")
+    mats = [mats1, mats2]
     with pytest.raises(ValueError):  # n_potatoes too low
-        PotatoField(n_potatoes=0).fit(covmats)
+        PotatoField(n_potatoes=0).fit(mats)
     with pytest.raises(ValueError):   # p_threshold out of bounds
-        PotatoField(p_threshold=0).fit(covmats)
+        PotatoField(p_threshold=0).fit(mats)
     with pytest.raises(ValueError):  # p_threshold out of bounds
-        PotatoField(p_threshold=1).fit(covmats)
+        PotatoField(p_threshold=1).fit(mats)
     pf = PotatoField(n_potatoes=n_potatoes)
     with pytest.raises(ValueError):  # n_potatoes not equal to input length
-        pf.fit([covmats1, covmats1, covmats2])
+        pf.fit([mats1, mats1, mats2])
     with pytest.raises(ValueError):  # n_matrices not equal
-        pf.fit([covmats1, covmats2[:1]])
+        pf.fit([mats1, mats2[:1]])
 
 
 @pytest.mark.parametrize("method",
                          ["partial_fit", "transform", "predict_proba"])
 def test_potato_field_method(get_mats, method):
     n_potatoes, n_matrices, n_channels = 2, 6, 3
-    covmats1 = get_mats(n_matrices, n_channels, "spd")
-    covmats2 = get_mats(n_matrices, n_channels + 1, "spd")
-    covmats = [covmats1, covmats2]
-    pf = PotatoField(n_potatoes=n_potatoes).fit(covmats)
+    mats1 = get_mats(n_matrices, n_channels, "spd")
+    mats2 = get_mats(n_matrices, n_channels + 1, "spd")
+    mats = [mats1, mats2]
+    pf = PotatoField(n_potatoes=n_potatoes).fit(mats)
     with pytest.raises(ValueError):  # n_potatoes not equal to input length
-        getattr(pf, method)([covmats1, covmats1, covmats2])
+        getattr(pf, method)([mats1, mats1, mats2])
     with pytest.raises(ValueError):  # n_matrices not equal
-        getattr(pf, method)([covmats1, covmats2[:1]])
+        getattr(pf, method)([mats1, mats2[:1]])

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -167,6 +167,33 @@ def test_mean_of_means(kind, mean, get_mats):
     assert C3 == approx(C, 6)
 
 
+@pytest.mark.parametrize(
+    "mean",
+    [
+        mean_ale,
+        mean_alm,
+        mean_euclid,
+        mean_harmonic,
+        mean_kullback_sym,
+        mean_logdet,
+        mean_logeuclid,
+        mean_power,
+        mean_riemann,
+        mean_wasserstein,
+        nanmean_riemann,
+    ],
+)
+def test_mean_of_single_matrix(mean, get_mats):
+    """Test the mean of a single matrix"""
+    n_channels = 3
+    mats = get_mats(1, n_channels, "spd")
+    if mean == mean_power:
+        M = mean(mats, 0.42)
+    else:
+        M = mean(mats)
+    assert M == approx(mats[0])
+
+
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 def test_mean_alm(kind, get_mats):
     """Test the ALM mean"""


### PR DESCRIPTION
This PR:

- corrects `PotatoField`, raising is an error when ` partial_fit ` is called without having called `fit`
```AttributeError: 'PotatoField' object has no attribute '_potatoes' ```
Corrected adding an explicit message.

- corrects `Kmeans`: `mdm.predict` in `_fit_single` raises an error when the number of classes is not equal to the number of clusters: `IndexError: index 2 is out of bounds for axis 0 with size 2`
Corrected modifying initialization of `mdm.classes_ `.

- completes doc and tests of `KmeansPerClassTransform`.

- simplifies code for `partial_fit` of `Potato`, merging batch and online updates.
This requires that the `mean` function can be called on a single matrix, which was not the case for `mean_alm`. Corrected.

- completes tests for attributes of different classes.

- completes documentation. 