### PR TITLE
Enhance ajd_pham to process HPD matrices

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -14,6 +14,8 @@ v0.7.dev
 
 - Add possibility for ``target_domain`` parameter of :class:`pyriemann.transfer._estimators.TLCenter` to be empty, forcing ``transform()`` to recenter matrices to the last fitted domain. :pr:`292` by :user:`brunaafl`
 
+- Enhance :func:`pyriemann.utils.ajd.ajd_pham` and :func:`pyriemann.utils.mean.mean_ale` functions to process HPD matrices. :pr:`299` by :user:`qbarthelemy`
+
 v0.6 (April 2024)
 -----------------
 

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -28,7 +28,7 @@ def mean_ale(X=None, tol=10e-7, maxiter=50, sample_weight=None, covmats=None):
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n, n)
-        Set of SPD matrices.
+        Set of SPD/HPD matrices.
     tol : float, default=10e-7
         The tolerance to stop the gradient descent.
     maxiter : int, default=50

--- a/tests/test_utils_ajd.py
+++ b/tests/test_utils_ajd.py
@@ -32,8 +32,8 @@ def test_ajd(method, algo, get_mats):
         assert D == approx(V @ mats @ V.T)
 
     V_, D_ = algo(mats, eps=eps, n_iter_max=n_iter_max)
-    assert np.all(V == V_)
-    assert np.all(D == D_)
+    assert_array_equal(V, V_)
+    assert_array_equal(D, D_)
 
 
 @pytest.mark.parametrize("method", ["rjd", "ajd_pham", "uwedge"])
@@ -67,18 +67,20 @@ def test_ajd_method_error(method):
         ajd(np.ones((3, 2, 2)), method=method)
 
 
-def test_ajd_pham(get_mats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham(kind, get_mats):
     """Test pham's ajd"""
     n_matrices, n_channels = 7, 4
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     V, D = ajd_pham(mats)
     assert D == approx(V @ mats @ V.conj().T)
 
 
-def test_ajd_pham_weight_none_equivalent_uniform(get_mats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham_weight_none_equivalent_uniform(kind, get_mats):
     """Test pham's ajd weights: none is equivalent to uniform values"""
     n_matrices, n_channels = 5, 3
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     V, D = ajd_pham(mats)
     Vw, Dw = ajd_pham(mats, sample_weight=np.ones(n_matrices))
     assert_array_equal(V, Vw)  # same result as ajd_pham without weight
@@ -97,10 +99,11 @@ def test_ajd_pham_weight_positive(get_mats):
         ajd_pham(mats, sample_weight=w)
 
 
-def test_ajd_pham_weight_zero(get_mats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+def test_ajd_pham_weight_zero(kind, get_mats):
     """Setting one weight to almost 0 it's almost like not passing the mat"""
     n_matrices, n_channels = 5, 4
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     w = 4.32 * np.ones(n_matrices)
     V, D = ajd_pham(mats[1:], sample_weight=w[1:])
     w[0] = 1e-12

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -43,8 +43,6 @@ def test_mean_shape(kind, mean, get_mats):
     """Test the shape of mean"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    if mean is mean_ale and kind == "hpd":
-        pytest.skip()
     if mean == mean_power:
         C = mean(mats, 0.42)
     else:
@@ -151,8 +149,6 @@ def test_mean_of_means(kind, mean, get_mats):
     """Test mean of submeans equal to grand mean"""
     n_matrices, n_channels = 10, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    if mean is mean_ale and kind == "hpd":
-        pytest.skip()
     if mean == mean_power:
         p = -0.42
         C = mean(mats, p)


### PR DESCRIPTION
This PR enhances `ajd_pham` to process HPD matrices,
following code https://github.com/Marco-Congedo/Diagonalizations.jl/blob/master/src/optim/LogLike.jl#L46
Note: `tau` in pyRiemann is the transpose of `Gamma` in Diagonalizations.jl

This is the continuation of  #238. Related to #204.

A consequence is that `mean_ale` supports HPD matrices.