### PR TITLE
Add get_weights

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -18,6 +18,8 @@ v0.7.dev
 
 - Add ``partial_fit`` function to :class:`pyriemann.preprocessing.Whitening` for online applications. :pr:`277` by :user:`qbarthelemy` and :user:`brentgaisford`
 
+- Add ``get_weights`` fixture to conftest and complete tests. :pr:`305` by :user:`qbarthelemy`
+
 v0.6 (April 2024)
 -----------------
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -279,8 +279,13 @@ class TLStretch(BaseEstimator, TransformerMixin):
     .. versionadded:: 0.4
     """
 
-    def __init__(self, target_domain, final_dispersion=1.0,
-                 centered_data=False, metric="riemann"):
+    def __init__(
+        self,
+        target_domain,
+        final_dispersion=1.0,
+        centered_data=False,
+        metric="riemann",
+    ):
         """Init"""
         self.target_domain = target_domain
         self.final_dispersion = final_dispersion
@@ -479,7 +484,7 @@ class TLRotate(BaseEstimator, TransformerMixin):
     .. versionadded:: 0.4
     """
 
-    def __init__(self, target_domain, weights=None, metric='euclid', n_jobs=1):
+    def __init__(self, target_domain, weights=None, metric="euclid", n_jobs=1):
         """Init"""
         self.target_domain = target_domain
         self.weights = weights
@@ -652,7 +657,8 @@ class TLEstimator(BaseEstimator):
         """
         if not (is_regressor(self.estimator) or is_classifier(self.estimator)):
             raise TypeError(
-                'Estimator has to be either a classifier or a regressor.')
+                "Estimator has to be either a classifier or a regressor."
+            )
 
         X_dec, y_dec, domains = decode_domains(X, y_enc)
 
@@ -660,20 +666,20 @@ class TLEstimator(BaseEstimator):
             y_dec = y_dec.astype(float)
 
         if self.domain_weight is not None:
-            w = np.zeros(len(X_dec))
+            weights = np.zeros(len(X_dec))
             for d in np.unique(domains):
-                w[domains == d] = self.domain_weight[d]
+                weights[domains == d] = self.domain_weight[d]
         else:
-            w = None
+            weights = None
 
         if isinstance(self.estimator, Pipeline):
             sample_weight = {}
             for step in self.estimator.steps:
                 step_name = step[0]
-                sample_weight[step_name + '__sample_weight'] = w
+                sample_weight[step_name + "__sample_weight"] = weights
             self.estimator.fit(X_dec, y_dec, **sample_weight)
         else:
-            self.estimator.fit(X_dec, y_dec, sample_weight=w)
+            self.estimator.fit(X_dec, y_dec, sample_weight=weights)
 
         return self
 
@@ -731,7 +737,7 @@ class TLClassifier(TLEstimator):
             The TLClassifier instance.
         """
         if not is_classifier(self.estimator):
-            raise TypeError('Estimator has to be a classifier.')
+            raise TypeError("Estimator has to be a classifier.")
 
         return super().fit(X, y_enc)
 
@@ -808,7 +814,7 @@ class TLRegressor(TLEstimator):
             The TLRegressor instance.
         """
         if not is_regressor(self.estimator):
-            raise TypeError('Estimator has to be a regressor.')
+            raise TypeError("Estimator has to be a regressor.")
 
         return super().fit(X, y_enc)
 
@@ -899,11 +905,12 @@ class MDWM(MDM):
     """
 
     def __init__(
-            self,
-            domain_tradeoff,
-            target_domain,
-            metric="riemann",
-            n_jobs=1):
+        self,
+        domain_tradeoff,
+        target_domain,
+        metric="riemann",
+        n_jobs=1,
+    ):
         """Init."""
         self.domain_tradeoff = domain_tradeoff
         self.target_domain = target_domain

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -25,24 +25,24 @@ def _retract(X, v):
     return Q
 
 
-def _loss(Q, X, Y, weights, metric='euclid'):
+def _loss(Q, X, Y, weights, metric="euclid"):
     """Loss function for estimating the rotation matrix in RPA."""
 
     return weights @ distance(X, Q @ Y @ Q.T, metric=metric)
 
 
-def _grad(Q, X, Y, weights, metric='euclid'):
+def _grad(Q, X, Y, weights, metric="euclid"):
     """Gradient of loss function between class means."""
 
-    if metric == 'euclid':
-        return np.einsum('a,abc->bc', weights, -4 * (X - Q @ Y @ Q.T) @ Q @ Y)
+    if metric == "euclid":
+        return np.einsum("a,abc->bc", weights, -4 * (X - Q @ Y @ Q.T) @ Q @ Y)
 
-    elif metric == 'riemann':
+    elif metric == "riemann":
         M = np.linalg.inv(X) @ Q @ Y @ Q.T
         eigvals, eigvecs = np.linalg.eig(M)
         logeigvals = np.expand_dims(np.log(eigvals), -2)
         logM = (eigvecs * logeigvals) @ np.linalg.inv(eigvecs)
-        return np.einsum('a,abc->bc', weights, 4 * logM @ Q)
+        return np.einsum("a,abc->bc", weights, 4 * logM @ Q)
 
     else:
         raise ValueError("RPA supports only 'euclid' and 'riemann' metrics.")
@@ -90,8 +90,16 @@ def _warm_start(X, Y, weights, metric='euclid'):
     return Q0_candidates[i_min]
 
 
-def _run_minimization(Q_ini, M_source, M_target, weights=None, metric='euclid',
-                      tol_step=1e-9, maxiter=10_000, maxiter_linesearch=32):
+def _run_minimization(
+    Q_ini,
+    M_source,
+    M_target,
+    weights=None,
+    metric="euclid",
+    tol_step=1e-9,
+    maxiter=10_000,
+    maxiter_linesearch=32,
+):
 
     Q_1 = Q_ini
 
@@ -129,13 +137,20 @@ def _run_minimization(Q_ini, M_source, M_target, weights=None, metric='euclid',
         F_1 = F
 
     else:
-        warnings.warn('Convergence not reached.')
+        warnings.warn("Convergence not reached.")
 
     return Q, F
 
 
-def _get_rotation_matrix(M_source, M_target, weights=None, metric='euclid',
-                         tol_step=1e-9, maxiter=10_000, maxiter_linesearch=32):
+def _get_rotation_matrix(
+    M_source,
+    M_target,
+    weights=None,
+    metric="euclid",
+    tol_step=1e-9,
+    maxiter=10_000,
+    maxiter_linesearch=32,
+):
     r"""Calculate rotation matrix for the Riemannian Procustes Analysis.
 
     Get the rotation matrix Q that minimizes the loss function:
@@ -158,9 +173,9 @@ def _get_rotation_matrix(M_source, M_target, weights=None, metric='euclid',
     weights : None | array, shape (n_classes,), default=None
         Weights for each class. If None, then give the same weight for each
         class.
-    metric : {'euclid', 'riemann'}, default='euclid'
+    metric : {"euclid", "riemann"}, default="euclid"
         Which type of distance to minimize between the class means, either
-        'euclid' for Euclidean distance or 'riemann' for the affine-invariant
+        "euclid" for Euclidean distance or "riemann" for the affine-invariant
         Riemannian distance between SPD matrices.
     tol_step : float, default 1e-9
         Stopping criterion based on the norm of the descent direction.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,14 @@ def get_mats_params(rndstate):
 
 
 @pytest.fixture
+def get_weights(rndstate):
+    def _gen_weight(n_matrices):
+        return 1 + rndstate.rand(n_matrices)
+
+    return _gen_weight
+
+
+@pytest.fixture
 def get_labels():
     def _get_labels(n_matrices, n_classes):
         return np.arange(n_classes).repeat(n_matrices // n_classes)

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -4,20 +4,26 @@ import pytest
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 
 
-@pytest.mark.parametrize("labels", [True, False])
-def test_electrodeselection(labels, get_mats, get_labels):
+@pytest.mark.parametrize("is_label", [True, False])
+@pytest.mark.parametrize("is_weight", [True, False])
+def test_electrodeselection(is_label, is_weight,
+                            get_mats, get_labels, get_weights):
     """Test ElectrodeSelection"""
     n_matrices, n_channels, n_classes = 10, 30, 2
     mats = get_mats(n_matrices, n_channels, "spd")
-    if labels:
+    if is_label:
         labels = get_labels(n_matrices, n_classes)
     else:
         labels, n_classes = None, 1
+    if is_weight:
+        weights = get_weights(n_matrices)
+    else:
+        weights = None
 
     nelec = 16
     se = ElectrodeSelection(nelec=nelec)
 
-    se.fit(mats, labels)
+    se.fit(mats, labels, weights)
     assert se.covmeans_.shape == (n_classes, n_channels, n_channels)
     assert isinstance(se.dist_, list)
     assert len(se.subelec_) == nelec

--- a/tests/test_channelselection.py
+++ b/tests/test_channelselection.py
@@ -4,18 +4,18 @@ import pytest
 from pyriemann.channelselection import ElectrodeSelection, FlatChannelRemover
 
 
-@pytest.mark.parametrize("is_label", [True, False])
-@pytest.mark.parametrize("is_weight", [True, False])
-def test_electrodeselection(is_label, is_weight,
+@pytest.mark.parametrize("use_label", [True, False])
+@pytest.mark.parametrize("use_weight", [True, False])
+def test_electrodeselection(use_label, use_weight,
                             get_mats, get_labels, get_weights):
     """Test ElectrodeSelection"""
     n_matrices, n_channels, n_classes = 10, 30, 2
     mats = get_mats(n_matrices, n_channels, "spd")
-    if is_label:
+    if use_label:
         labels = get_labels(n_matrices, n_classes)
     else:
         labels, n_classes = None, 1
-    if is_weight:
+    if use_weight:
         weights = get_weights(n_matrices)
     else:
         weights = None

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -57,7 +57,7 @@ def test_mode(X, axis, expected):
 
 @pytest.mark.parametrize("n_classes", [2, 3])
 @pytest.mark.parametrize("classif", rclf)
-def test_classifier(n_classes, classif, get_mats, get_labels):
+def test_classifier(n_classes, classif, get_mats, get_labels, get_weights):
     if n_classes == 2:
         n_matrices, n_channels = 6, 3
     else:
@@ -65,8 +65,9 @@ def test_classifier(n_classes, classif, get_mats, get_labels):
         n_matrices, n_channels = 9, 3
     mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
+    weights = get_weights(n_matrices)
 
-    clf_fit(classif, mats, labels)
+    clf_fit(classif, mats, labels, weights)
     clf_predict(classif, mats, labels)
     clf_fit_independence(classif, mats, labels)
     clf_predict_proba(classif, mats, labels)
@@ -82,13 +83,12 @@ def test_classifier(n_classes, classif, get_mats, get_labels):
         clf_tsupdate(classif, mats, labels)
 
 
-def clf_fit(classif, mats, labels):
-    n_matrices, n_classes = len(labels), len(np.unique(labels))
-    clf = classif()
-    clf.fit(mats, labels)
+def clf_fit(classif, mats, labels, weights):
+    n_classes = len(np.unique(labels))
+    clf = classif().fit(mats, labels)
     assert clf.classes_.shape == (n_classes,)
 
-    clf.fit(mats, labels, sample_weight=np.random.uniform(size=n_matrices))
+    clf.fit(mats, labels, sample_weight=weights)
 
 
 def clf_predict(classif, mats, labels):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -50,13 +50,16 @@ def test_whitening_fit_errors(rndstate, get_mats):
 
 @pytest.mark.parametrize("dim_red", dim_red)
 @pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])
-def test_whitening_fit(dim_red, metric, rndstate, get_mats):
+def test_whitening_fit(dim_red, metric, get_mats, get_weights):
     """Test Whitening fit"""
     n_matrices, n_channels = 20, 6
     mats = get_mats(n_matrices, n_channels, "spd")
-    w = rndstate.rand(n_matrices)
+    weights = get_weights(n_matrices)
 
-    whit = Whitening(dim_red=dim_red, metric=metric).fit(mats, sample_weight=w)
+    whit = Whitening(dim_red=dim_red, metric=metric).fit(
+        mats,
+        sample_weight=weights,
+    )
     if dim_red is None:
         n_comp = n_channels
     else:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -13,27 +13,29 @@ regs = [SVR, KNearestNeighborRegressor]
 
 
 @pytest.mark.parametrize("regres", regs)
-def test_regression(regres, get_mats, get_targets):
+def test_regression(regres, get_mats, get_targets, get_weights):
     n_matrices, n_channels = 6, 3
     mats = get_mats(n_matrices, n_channels, "spd")
     targets = get_targets(n_matrices)
+    weights = get_weights(n_matrices)
 
-    reg_fit(regres, mats, targets)
+    reg_fit(regres, mats, targets, weights)
     reg_predict(regres, mats, targets)
     reg_fit_independence(regres, mats, targets)
     reg_score(regres, mats, targets)
 
 
-def reg_fit(regres, mats, targets):
+def reg_fit(regres, mats, targets, weights):
     n_matrices, n_channels, _ = mats.shape
-    clf = regres()
-    clf.fit(mats, targets)
+    clf = regres().fit(mats, targets)
 
     if clf is SVR:
         assert clf.data_.shape == (n_matrices, n_channels, n_channels)
     elif clf is KNearestNeighborRegressor:
         assert clf.covmeans_.shape == (n_matrices, n_channels, n_channels)
         assert clf.values_.shape == (n_matrices,)
+
+    clf.fit(mats, targets, sample_weight=weights)
 
 
 def reg_predict(regres, mats, targets):

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -7,12 +7,13 @@ from pyriemann.tangentspace import TangentSpace, FGDA
 
 
 @pytest.mark.parametrize("tspace", [TangentSpace, FGDA])
-def test_tangentspace(tspace, get_mats, get_labels):
+def test_tangentspace(tspace, get_mats, get_labels, get_weights):
     n_classes, n_matrices, n_channels = 2, 6, 3
     mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
+    weights = get_weights(n_matrices)
 
-    clf_fit(tspace, mats, labels)
+    clf_fit(tspace, mats, labels, weights)
     clf_transform(tspace, mats, labels)
     clf_fit_transform(tspace, mats, labels)
     clf_fit_transform_independence(tspace, mats, labels)
@@ -21,7 +22,7 @@ def test_tangentspace(tspace, get_mats, get_labels):
         clf_inversetransform(tspace, mats)
 
 
-def clf_fit(tspace, mats, labels):
+def clf_fit(tspace, mats, labels, weights):
     clf = tspace().fit(mats, labels)
 
     if tspace is TangentSpace:
@@ -31,6 +32,7 @@ def clf_fit(tspace, mats, labels):
         n_classes = len(np.unique(labels))
         assert clf.classes_.shape == (n_classes,)
 
+    clf.fit(mats, labels, sample_weight=weights)
 
 def clf_transform(tspace, mats, labels):
     n_matrices, n_channels, n_channels = mats.shape

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -21,7 +21,6 @@ def test_tangentspace(tspace, get_mats, get_labels, get_weights):
         clf_transform_wo_fit(tspace, mats)
         clf_inversetransform(tspace, mats)
 
-
 def clf_fit(tspace, mats, labels, weights):
     clf = tspace().fit(mats, labels)
 

--- a/tests/test_tangentspace.py
+++ b/tests/test_tangentspace.py
@@ -21,6 +21,7 @@ def test_tangentspace(tspace, get_mats, get_labels, get_weights):
         clf_transform_wo_fit(tspace, mats)
         clf_inversetransform(tspace, mats)
 
+
 def clf_fit(tspace, mats, labels, weights):
     clf = tspace().fit(mats, labels)
 
@@ -32,6 +33,7 @@ def clf_fit(tspace, mats, labels, weights):
         assert clf.classes_.shape == (n_classes,)
 
     clf.fit(mats, labels, sample_weight=weights)
+
 
 def clf_transform(tspace, mats, labels):
     n_matrices, n_channels, n_channels = mats.shape

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -66,16 +66,16 @@ def test_tldummy(rndstate):
 
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
-@pytest.mark.parametrize("is_weight", [True, False])
+@pytest.mark.parametrize("use_weight", [True, False])
 @pytest.mark.parametrize("target_domain", ["target_domain", ""])
-def test_tlcenter(rndstate, get_weights, metric, is_weight, target_domain):
+def test_tlcenter(rndstate, get_weights, metric, use_weight, target_domain):
     """Test pipeline for recentering data to Identity"""
     # check if the global mean of the domains is indeed Identity
     rct = TLCenter(target_domain=target_domain, metric=metric)
     X, y_enc = make_classification_transfer(
         n_matrices=25, random_state=rndstate
     )
-    if is_weight:
+    if use_weight:
         weights = get_weights(len(y_enc))
     else:
         weights = None
@@ -89,7 +89,7 @@ def test_tlcenter(rndstate, get_weights, metric, is_weight, target_domain):
     for d in np.unique(domain):
         idx = domain == d
         Xd = X_rct[idx]
-        if is_weight:
+        if use_weight:
             weights_d = check_weights(weights[idx], np.sum(idx))
             Md = mean_covariance(Xd, metric=metric, sample_weight=weights_d)
         else:
@@ -98,17 +98,17 @@ def test_tlcenter(rndstate, get_weights, metric, is_weight, target_domain):
 
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
-@pytest.mark.parametrize("is_weight", [True, False])
+@pytest.mark.parametrize("use_weight", [True, False])
 @pytest.mark.parametrize("target_domain", ["target_domain", ""])
 def test_tlcenter_fit_transf(rndstate, get_weights,
-                             metric, is_weight, target_domain):
+                             metric, use_weight, target_domain):
     """Test .fit_transform() versus .fit().transform()"""
     # check if the global mean of the domains is indeed Identity
     rct = TLCenter(target_domain=target_domain, metric=metric)
     X, y_enc = make_classification_transfer(
         n_matrices=25, random_state=rndstate
     )
-    if is_weight:
+    if use_weight:
         weights = get_weights(len(y_enc))
         weights_1, weights_2 = weights[:50], weights[50:]
     else:
@@ -127,7 +127,7 @@ def test_tlcenter_fit_transf(rndstate, get_weights,
     for d in np.unique(domain):
         idx = domain == d
         Xd = X_rct[idx]
-        if is_weight:
+        if use_weight:
             weights = np.concatenate((weights_1, weights_2))
             weights_d = check_weights(weights[idx], np.sum(idx))
             Md = mean_covariance(Xd, metric=metric, sample_weight=weights_d)
@@ -136,27 +136,27 @@ def test_tlcenter_fit_transf(rndstate, get_weights,
         assert Md == pytest.approx(np.eye(2))
 
 
-@pytest.mark.parametrize("centered_data", [True, False])
+@pytest.mark.parametrize("use_centered_data", [True, False])
 @pytest.mark.parametrize("metric", ["riemann"])
-@pytest.mark.parametrize("is_weight", [True, False])
+@pytest.mark.parametrize("use_weight", [True, False])
 def test_tlstretch(rndstate, get_weights,
-                   centered_data, metric, is_weight):
+                   use_centered_data, metric, use_weight):
     """Test pipeline for stretching data"""
     # check if the dispersion of the dataset indeed decreases to 1
     tlstr = TLStretch(
         target_domain="target_domain",
         final_dispersion=1.0,
-        centered_data=centered_data,
+        centered_data=use_centered_data,
         metric=metric
     )
     X, y_enc = make_classification_transfer(
         n_matrices=25, class_disp=2.0, random_state=rndstate)
 
-    if is_weight:
+    if use_weight:
         weights = get_weights(len(y_enc))
     else:
         weights = None
-    if centered_data:  # ensure that data is indeed centered on each domain
+    if use_centered_data:  # ensure that data is indeed centered on each domain
         tlrct = TLCenter(target_domain="target_domain", metric=metric)
         X = tlrct.fit_transform(X, y_enc, sample_weight=weights)
 
@@ -166,7 +166,7 @@ def test_tlstretch(rndstate, get_weights,
     for d in np.unique(domain):
         idx = domain == d
         Xd = X_str[idx]
-        if is_weight:
+        if use_weight:
             weights_d = check_weights(weights[idx], np.sum(idx))
             Md = mean_riemann(Xd, sample_weight=weights_d)
             dist = distance(Xd, Md, metric=metric, squared=True)
@@ -178,15 +178,15 @@ def test_tlstretch(rndstate, get_weights,
 
 
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
-@pytest.mark.parametrize("is_weight", [True, False])
-def test_tlrotate(rndstate, get_weights, metric, is_weight):
+@pytest.mark.parametrize("use_weight", [True, False])
+def test_tlrotate(rndstate, get_weights, metric, use_weight):
     """Test fit_transform method for rotating the datasets"""
     # check if the distance between the classes of each domain is reduced
     X, y_enc = make_classification_transfer(
         n_matrices=50, class_sep=3, class_disp=1.0, theta=np.pi / 2,
         random_state=rndstate)
 
-    if is_weight:
+    if use_weight:
         weights = get_weights(len(y_enc))
     else:
         weights = None

--- a/tests/test_utils_ajd.py
+++ b/tests/test_utils_ajd.py
@@ -83,30 +83,30 @@ def test_ajd_pham_weight_none_equivalent_uniform(kind, get_mats):
     mats = get_mats(n_matrices, n_channels, kind)
     V, D = ajd_pham(mats)
     Vw, Dw = ajd_pham(mats, sample_weight=np.ones(n_matrices))
-    assert_array_equal(V, Vw)  # same result as ajd_pham without weight
+    assert_array_equal(V, Vw)
     assert_array_equal(D, Dw)
 
     ajd(mats, method="ajd_pham", sample_weight=np.ones(n_matrices))
 
 
-def test_ajd_pham_weight_positive(get_mats):
+def test_ajd_pham_weight_positive(get_mats, get_weights):
     """Test pham's ajd weights: must be strictly positive"""
     n_matrices, n_channels = 4, 2
     mats = get_mats(n_matrices, n_channels, "spd")
-    w = 1.23 * np.ones(n_matrices)
+    weights = get_weights(n_matrices)
     with pytest.raises(ValueError):  # not strictly positive weight
-        w[0] = 0
-        ajd_pham(mats, sample_weight=w)
+        weights[0] = 0
+        ajd_pham(mats, sample_weight=weights)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
-def test_ajd_pham_weight_zero(kind, get_mats):
+def test_ajd_pham_weight_zero(kind, get_mats, get_weights):
     """Setting one weight to almost 0 it's almost like not passing the mat"""
     n_matrices, n_channels = 5, 4
     mats = get_mats(n_matrices, n_channels, kind)
-    w = 4.32 * np.ones(n_matrices)
-    V, D = ajd_pham(mats[1:], sample_weight=w[1:])
-    w[0] = 1e-12
-    Vw, Dw = ajd_pham(mats, sample_weight=w)
+    weights = get_weights(n_matrices)
+    V, D = ajd_pham(mats[1:], sample_weight=weights[1:])
+    weights[0] = 1e-12
+    Vw, Dw = ajd_pham(mats, sample_weight=weights)
     assert V == approx(Vw, rel=1e-4, abs=1e-8)
     assert D == approx(Dw[1:], rel=1e-4, abs=1e-8)

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -217,7 +217,7 @@ def test_distance_riemann_properties(kind, get_mats):
 
     # proportionality, Eq(6.12) in [Bhatia2007]
     alpha = np.random.uniform()
-    dist_1 = distance_riemann(A, geodesic(A, B, alpha, metric='riemann'))
+    dist_1 = distance_riemann(A, geodesic(A, B, alpha, metric="riemann"))
     dist_2 = alpha * distance_riemann(A, B)
     assert dist_1 == approx(dist_2)
 
@@ -237,9 +237,9 @@ def test_distance_wrapper_between_set_and_matrix(dist, get_mats):
     assert distance(mats, mats[-1], metric=dist).shape == (n_matrices, 1)
 
     n_sets = 5
-    covs_4d = np.asarray([mats for _ in range(n_sets)])
+    mats_4d = np.asarray([mats for _ in range(n_sets)])
     with pytest.raises(ValueError):
-        distance(covs_4d, mats, metric=dist)
+        distance(mats_4d, mats, metric=dist)
 
 
 @pytest.mark.parametrize("dist", get_distances())

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -44,10 +44,10 @@ def test_mean_shape(kind, mean, get_mats):
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
     if mean == mean_power:
-        C = mean(mats, 0.42)
+        M = mean(mats, 0.42)
     else:
-        C = mean(mats)
-    assert C.shape == (n_channels, n_channels)
+        M = mean(mats)
+    assert M.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
@@ -58,8 +58,8 @@ def test_mean_shape_with_init(kind, mean, get_mats):
     """Test the shape of mean with init"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    C = mean(mats, init=mats[0])
-    assert C.shape == (n_channels, n_channels)
+    M = mean(mats, init=mats[0])
+    assert M.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
@@ -76,15 +76,16 @@ def test_mean_shape_with_init(kind, mean, get_mats):
         nanmean_riemann,
     ],
 )
-def test_mean_weight_zero(kind, mean, get_mats):
+def test_mean_weight_zero(kind, mean, get_mats, get_weights):
     """Setting one weight to almost 0 it's almost like not passing the mat"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    w = 2.3 * np.ones(n_matrices)
-    C = mean(mats[1:], sample_weight=w[1:])
-    w[0] = 1e-12
-    Cw = mean(mats, sample_weight=w)
-    assert C == approx(Cw, rel=1e-6, abs=1e-8)
+    weights = get_weights(n_matrices)
+
+    M = mean(mats[1:], sample_weight=weights[1:])
+    weights[0] = 1e-12
+    Mw = mean(mats, sample_weight=weights)
+    assert M == approx(Mw, rel=1e-6, abs=1e-8)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_median.py
+++ b/tests/test_utils_median.py
@@ -14,8 +14,8 @@ def test_median_shape(kind, median, get_mats):
     """Test the shape of median"""
     n_matrices, n_channels = 3, 4
     mats = get_mats(n_matrices, n_channels, kind)
-    C = median(mats)
-    assert C.shape == (n_channels, n_channels)
+    M = median(mats)
+    assert M.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
@@ -24,21 +24,22 @@ def test_median_shape_with_init(kind, median, get_mats):
     """Test the shape of median with init"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    C = median(mats, init=mats[0])
-    assert C.shape == (n_channels, n_channels)
+    M = median(mats, init=mats[0])
+    assert M.shape == (n_channels, n_channels)
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("median", [median_euclid, median_riemann])
-def test_median_weight_zero(kind, median, get_mats):
+def test_median_weight_zero(kind, median, get_mats, get_weights):
     """Setting one weight to almost 0 it's almost like not passing the mat"""
-    n_matrices, n_channels, w_val = 5, 3, 2
+    n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    w = w_val * np.ones(n_matrices)
-    C = median(mats[1:], weights=w[1:])
-    w[0] = 1e-12
-    Cw = median(mats, weights=w)
-    assert C == approx(Cw, rel=1e-6, abs=1e-8)
+    weights = get_weights(n_matrices)
+
+    M = median(mats[1:], weights=weights[1:])
+    weights[0] = 1e-12
+    Mw = median(mats, weights=weights)
+    assert M == approx(Mw, rel=1e-6, abs=1e-8)
 
 
 @pytest.mark.parametrize("median", [median_euclid, median_riemann])


### PR DESCRIPTION
This PR:
- adds a new fixture `get_weights` in `conftest`,
- uses this fixture in all tests using weights,
- completes tests for `fit` function that did not check weights (classif, regression, tangentspace, channelselection).