### PR TITLE
Speed up doc action

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,6 +170,8 @@ html_theme_options = {
     'bootstrap_version':
     "3",
     'navbar_links': [("API", "api"), ("Gallery", "auto_examples/index")],
+    'navigation_depth': 2,
+    'collapse_navigation': True,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -72,7 +72,15 @@ def plot_detection(ax, rp_label, rpf_label):
 # -------------
 
 # Load motor imagery data
-raw = read_raw_edf(eegbci.load_data(7, [6], update_path=True)[0], preload=True, verbose=False)
+subject = 7
+runs = [6]
+raw = read_raw_edf(
+    eegbci.load_data(
+        subject,
+        runs,
+        update_path=True
+    )[0], preload=True, verbose=False
+)
 eegbci.standardize(raw)
 raw.set_montage(make_standard_montage('standard_1005'))
 sfreq = int(raw.info['sfreq'])  # 160 Hz

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -72,7 +72,7 @@ def plot_detection(ax, rp_label, rpf_label):
 # -------------
 
 # Load motor imagery data
-raw = read_raw_edf(eegbci.load_data(2, [5])[0], preload=True, verbose=False)
+raw = read_raw_edf(eegbci.load_data(7, [6], update_path=True)[0], preload=True, verbose=False)
 eegbci.standardize(raw)
 raw.set_montage(make_standard_montage('standard_1005'))
 sfreq = int(raw.info['sfreq'])  # 160 Hz

--- a/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
+++ b/examples/artifacts/plot_detect_riemannian_potato_field_EEG.py
@@ -72,14 +72,10 @@ def plot_detection(ax, rp_label, rpf_label):
 # -------------
 
 # Load motor imagery data
-subject = 7
-runs = [6]
 raw = read_raw_edf(
-    eegbci.load_data(
-        subject,
-        runs,
-        update_path=True
-    )[0], preload=True, verbose=False
+    eegbci.load_data(2, [5], update_path=True)[0],
+    preload=True,
+    verbose=False,
 )
 eegbci.standardize(raw)
 raw.set_montage(make_standard_montage('standard_1005'))

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -75,11 +75,8 @@ subject = 7
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(
-                                            subject,
-                                            runs,
-                                            update_path=True
-                                           )
+    read_raw_edf(f, preload=True)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -72,7 +72,7 @@ class AugmentedDataset(BaseEstimator, TransformerMixin):
 tmin, tmax = 1., 2.
 event_id = dict(hands=2, feet=3)
 subject = 7
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True) for f in eegbci.load_data(

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -72,7 +72,7 @@ class AugmentedDataset(BaseEstimator, TransformerMixin):
 tmin, tmax = 1., 2.
 event_id = dict(hands=2, feet=3)
 subject = 7
-runs = [6, 10]  # motor imagery: hands vs feet
+runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True) for f in eegbci.load_data(
@@ -146,8 +146,8 @@ inner_cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=42)
 
 # Define the hyper-parameters to test in the nested cross-validation
 param_grid = {
-    'augmenteddataset__order': [1, 2, 3, 4, 5, 6, 7],
-    'augmenteddataset__lag': [1, 2, 3, 4, 5, 6, 7],
+    'augmenteddataset__order': [2, 3, 4],
+    'augmenteddataset__lag': [5, 7, 9],
 }
 
 pipelines_grid = {}

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -75,7 +75,11 @@ subject = 7
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(
+                                            subject,
+                                            runs,
+                                            update_path=True
+                                           )
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_augmented.py
+++ b/examples/motor-imagery/plot_augmented.py
@@ -75,7 +75,7 @@ subject = 7
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_ensemble_coherence.py
+++ b/examples/motor-imagery/plot_ensemble_coherence.py
@@ -79,7 +79,7 @@ subject = 7
 runs = [4, 8]  # motor imagery: left vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_ensemble_coherence.py
+++ b/examples/motor-imagery/plot_ensemble_coherence.py
@@ -79,11 +79,8 @@ subject = 7
 runs = [4, 8]  # motor imagery: left vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(
-                                            subject,
-                                            runs,
-                                            update_path=True
-                                           )
+    read_raw_edf(f, preload=True)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_ensemble_coherence.py
+++ b/examples/motor-imagery/plot_ensemble_coherence.py
@@ -79,7 +79,11 @@ subject = 7
 runs = [4, 8]  # motor imagery: left vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(
+                                            subject,
+                                            runs,
+                                            update_path=True
+                                           )
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_frequency_band_selection.py
+++ b/examples/motor-imagery/plot_frequency_band_selection.py
@@ -37,11 +37,8 @@ subject = 7
 runs = [4, 8]  # motor imagery: left hand vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(
-                                                subject,
-                                                runs,
-                                                update_path=True
-                                           )
+    read_raw_edf(f, preload=True)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 picks = pick_types(

--- a/examples/motor-imagery/plot_frequency_band_selection.py
+++ b/examples/motor-imagery/plot_frequency_band_selection.py
@@ -34,7 +34,7 @@ from helpers.frequencybandselection_helpers import freq_selection_class_dis
 tmin, tmax = 0.5, 2.5
 event_id = dict(T1=2, T2=3)
 subject = 7
-runs = [4, 8, 12]  # motor imagery: left hand vs right hand
+runs = [4, 8]  # motor imagery: left hand vs right hand
 
 raw_files = [
     read_raw_edf(f, preload=True) for f in eegbci.load_data(

--- a/examples/motor-imagery/plot_frequency_band_selection.py
+++ b/examples/motor-imagery/plot_frequency_band_selection.py
@@ -37,7 +37,11 @@ subject = 7
 runs = [4, 8, 12]  # motor imagery: left hand vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(
+                                                subject,
+                                                runs,
+                                                update_path=True
+                                           )
 ]
 raw = concatenate_raws(raw_files)
 picks = pick_types(

--- a/examples/motor-imagery/plot_frequency_band_selection.py
+++ b/examples/motor-imagery/plot_frequency_band_selection.py
@@ -37,7 +37,7 @@ subject = 7
 runs = [4, 8, 12]  # motor imagery: left hand vs right hand
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 picks = pick_types(

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -35,7 +35,7 @@ subject = 7
 runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) 
+    read_raw_edf(f, preload=True)
     for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -32,7 +32,7 @@ from pyriemann.estimation import Covariances
 tmin, tmax = 1., 2.
 event_id = dict(hands=2, feet=3)
 subject = 7
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True) for f in eegbci.load_data(

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -35,7 +35,7 @@ subject = 7
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -35,11 +35,8 @@ subject = 7
 runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(
-                                            subject,
-                                            runs,
-                                            update_path=True
-                                           )
+    read_raw_edf(f, preload=True) 
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/motor-imagery/plot_single.py
+++ b/examples/motor-imagery/plot_single.py
@@ -35,7 +35,11 @@ subject = 7
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
-    read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
+    read_raw_edf(f, preload=True) for f in eegbci.load_data(
+                                            subject,
+                                            runs,
+                                            update_path=True
+                                           )
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/remote-sensing/plot_hs_clustering.py
+++ b/examples/remote-sensing/plot_hs_clustering.py
@@ -53,7 +53,7 @@ X_image, Y_image = np.meshgrid(x_values, y_values)
 if small_dataset:
     reduce_factor = 5
     data = data[::reduce_factor, ::reduce_factor]
-    max_iter = 9
+    max_iter = 5
     resolution = reduce_factor*resolution
 height, width, n_features = data.shape
 

--- a/examples/remote-sensing/plot_hs_clustering.py
+++ b/examples/remote-sensing/plot_hs_clustering.py
@@ -51,9 +51,9 @@ y_values = np.arange(0, data.shape[0]) * resolution
 X_image, Y_image = np.meshgrid(x_values, y_values)
 
 if small_dataset:
-    reduce_factor = 4
+    reduce_factor = 5
     data = data[::reduce_factor, ::reduce_factor]
-    max_iter = 10
+    max_iter = 9
     resolution = reduce_factor*resolution
 height, width, n_features = data.shape
 

--- a/examples/remote-sensing/plot_sar_clustering.py
+++ b/examples/remote-sensing/plot_sar_clustering.py
@@ -53,8 +53,8 @@ y_values = np.arange(0, data.shape[0]) * resolution_y
 X_image, Y_image = np.meshgrid(x_values, y_values)
 
 if small_dataset:
-    reduce_factor_y = 12
-    reduce_factor_x = 6
+    reduce_factor_y = 14
+    reduce_factor_x = 8
     data = data[::reduce_factor_y, ::reduce_factor_x]
     max_iter = 9
     resolution_x = reduce_factor_x*resolution_x

--- a/examples/remote-sensing/plot_sar_clustering.py
+++ b/examples/remote-sensing/plot_sar_clustering.py
@@ -56,7 +56,7 @@ if small_dataset:
     reduce_factor_y = 14
     reduce_factor_x = 8
     data = data[::reduce_factor_y, ::reduce_factor_x]
-    max_iter = 9
+    max_iter = 5
     resolution_x = reduce_factor_x*resolution_x
     resolution_y = reduce_factor_y*resolution_y
 height, width, n_features = data.shape

--- a/examples/remote-sensing/plot_sar_clustering.py
+++ b/examples/remote-sensing/plot_sar_clustering.py
@@ -53,10 +53,10 @@ y_values = np.arange(0, data.shape[0]) * resolution_y
 X_image, Y_image = np.meshgrid(x_values, y_values)
 
 if small_dataset:
-    reduce_factor_y = 13
-    reduce_factor_x = 7
+    reduce_factor_y = 12
+    reduce_factor_x = 6
     data = data[::reduce_factor_y, ::reduce_factor_x]
-    max_iter = 10
+    max_iter = 9
     resolution_x = reduce_factor_x*resolution_x
     resolution_y = reduce_factor_y*resolution_y
 height, width, n_features = data.shape

--- a/examples/signal/plot_covariance_estimation.py
+++ b/examples/signal/plot_covariance_estimation.py
@@ -89,7 +89,7 @@ plt.show()
 
 event_id = dict(hands=2, feet=3)
 subject = 1
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 raw_files = [
     read_raw_edf(f, preload=True, stim_channel="auto")
     for f in eegbci.load_data(subject, runs, update_path=True)

--- a/examples/signal/plot_covariance_estimation.py
+++ b/examples/signal/plot_covariance_estimation.py
@@ -92,7 +92,7 @@ subject = 1
 runs = [6, 10, 14]  # motor imagery: hands vs feet
 raw_files = [
     read_raw_edf(f, preload=True, stim_channel="auto")
-    for f in eegbci.load_data(subject, runs)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 picks = pick_types(raw.info, eeg=True, exclude="bads")

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -181,18 +181,34 @@ def plot_classifiers(metric):
 # Classifiers and Datasets
 # ------------------------
 
-names = [
-    "MDM",
-    "k-NN",
-    "SVC",
-    "MeanField",
-]
-classifiers = [
-    MDM(),
-    KNearestNeighbor(n_neighbors=3),
-    SVC(probability=True),
-    MeanField(power_list=[-1, 0, 1]),
-]
+# Usefull for Ci for example
+reduced_example = True
+
+if reduced_example:
+    names = [
+        "MDM",
+        "k-NN",
+        "MeanField",
+    ]
+    classifiers = [
+        MDM(),
+        KNearestNeighbor(n_neighbors=2),
+        MeanField(power_list=[-1, 0, 1]),
+    ]
+else:
+    names = [
+        "MDM",
+        "k-NN",
+        "SVC",
+        "MeanField",
+    ]
+    classifiers = [
+        MDM(),
+        KNearestNeighbor(n_neighbors=3),
+        SVC(probability=True),
+        MeanField(power_list=[-1, 0, 1]),
+    ]
+
 n_classifs = len(classifiers)
 
 rs = np.random.RandomState(2022)

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -32,7 +32,6 @@ from pyriemann.classification import (
     MDM,
     KNearestNeighbor,
     SVC,
-    MeanField,
 )
 
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -188,7 +188,7 @@ if reduced_example:
     names = [
         "MDM",
         "k-NN",
-        "MeanField",
+        "SVC",
     ]
     classifiers = [
         MDM(),

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -193,7 +193,7 @@ if reduced_example:
     classifiers = [
         MDM(),
         KNearestNeighbor(n_neighbors=2),
-        MeanField(power_list=[-1, 0, 1]),
+        SVC(probability=True),
     ]
 else:
     names = [

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -181,34 +181,16 @@ def plot_classifiers(metric):
 # Classifiers and Datasets
 # ------------------------
 
-# Usefull for Ci for example
-reduced_example = True
-
-if reduced_example:
-    names = [
-        "MDM",
-        "k-NN",
-        "SVC",
-    ]
-    classifiers = [
-        MDM(),
-        KNearestNeighbor(n_neighbors=2),
-        SVC(probability=True),
-    ]
-else:
-    names = [
-        "MDM",
-        "k-NN",
-        "SVC",
-        "MeanField",
-    ]
-    classifiers = [
-        MDM(),
-        KNearestNeighbor(n_neighbors=3),
-        SVC(probability=True),
-        MeanField(power_list=[-1, 0, 1]),
-    ]
-
+names = [
+    "MDM",
+    "k-NN",
+    "SVC",
+]
+classifiers = [
+    MDM(),
+    KNearestNeighbor(n_neighbors=3),
+    SVC(probability=True),
+]
 n_classifs = len(classifiers)
 
 rs = np.random.RandomState(2022)

--- a/examples/stats/plot_oneWay_Manova.py
+++ b/examples/stats/plot_oneWay_Manova.py
@@ -32,7 +32,7 @@ sns.set_style('whitegrid')
 tmin, tmax = 1., 3.
 event_id = dict(hands=2, feet=3)
 subject = 1
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)

--- a/examples/stats/plot_oneWay_Manova.py
+++ b/examples/stats/plot_oneWay_Manova.py
@@ -36,7 +36,7 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)
-    for f in eegbci.load_data(subject, runs)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/stats/plot_oneWay_Manova_frequency.py
+++ b/examples/stats/plot_oneWay_Manova_frequency.py
@@ -29,7 +29,7 @@ sns.set_style('whitegrid')
 tmin, tmax = 1., 3.
 event_id = dict(hands=2, feet=3)
 subject = 1
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)

--- a/examples/stats/plot_oneWay_Manova_frequency.py
+++ b/examples/stats/plot_oneWay_Manova_frequency.py
@@ -33,7 +33,7 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)
-    for f in eegbci.load_data(subject, runs)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/stats/plot_oneWay_Manova_time.py
+++ b/examples/stats/plot_oneWay_Manova_time.py
@@ -34,7 +34,7 @@ runs = [6, 10, 14]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)
-    for f in eegbci.load_data(subject, runs)
+    for f in eegbci.load_data(subject, runs, update_path=True)
 ]
 raw = concatenate_raws(raw_files)
 

--- a/examples/stats/plot_oneWay_Manova_time.py
+++ b/examples/stats/plot_oneWay_Manova_time.py
@@ -30,7 +30,7 @@ sns.set_style('whitegrid')
 tmin, tmax = -2., 6.
 event_id = dict(hands=2, feet=3)
 subject = 1
-runs = [6, 10, 14]  # motor imagery: hands vs feet
+runs = [6, 10]  # motor imagery: hands vs feet
 
 raw_files = [
     read_raw_edf(f, preload=True, verbose=False)

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -45,7 +45,7 @@ def get_subject_dataset(subject):
     # Consider epochs that start 1s after cue onset.
     tmin, tmax = 1., 2.
     event_id = dict(hands=2, feet=3)
-    runs = [6, 10, 14]  # motor imagery: hands vs feet
+    runs = [6, 10]  # motor imagery: hands vs feet
 
     # Download data with MNE
     raw_files = [

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -49,7 +49,7 @@ def get_subject_dataset(subject):
 
     # Download data with MNE
     raw_files = [
-        read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs)
+        read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
     ]
     raw = concatenate_raws(raw_files)
 
@@ -90,7 +90,7 @@ def get_subject_dataset(subject):
 ###############################################################################
 # We will consider subjects from the Physionet EEG database for which the
 # intra-subject classification has been checked to be > 0.70
-subject_list = [1, 2, 4, 7]
+subject_list = [1, 7]
 n_subjects = len(subject_list)
 
 # Load the data from subjects

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -49,7 +49,11 @@ def get_subject_dataset(subject):
 
     # Download data with MNE
     raw_files = [
-        read_raw_edf(f, preload=True) for f in eegbci.load_data(subject, runs, update_path=True)
+        read_raw_edf(f, preload=True) for f in eegbci.load_data(
+                                                subject,
+                                                runs,
+                                                update_path=True
+                                               )
     ]
     raw = concatenate_raws(raw_files)
 

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -193,7 +193,6 @@ for i_subject in tqdm(range(n_subjects)):
 
 fig, ax = plt.subplots(figsize=(7, 6))
 ax.boxplot(x=[scores[meth] for meth in scores.keys()])
-ax.set_ylim(0.45, 0.8)
 ax.set_xticklabels(['Dummy', 'Recentering'])
 ax.set_ylabel('Classification accuracy')
 ax.set_xlabel('Method')

--- a/examples/transfer/plot_bci_example.py
+++ b/examples/transfer/plot_bci_example.py
@@ -49,11 +49,8 @@ def get_subject_dataset(subject):
 
     # Download data with MNE
     raw_files = [
-        read_raw_edf(f, preload=True) for f in eegbci.load_data(
-                                                subject,
-                                                runs,
-                                                update_path=True
-                                               )
+        read_raw_edf(f, preload=True)
+        for f in eegbci.load_data(subject, runs, update_path=True)
     ]
     raw = concatenate_raws(raw_files)
 


### PR DESCRIPTION
- Just keep subjects 1 and 7
- Reduce the number of runs
- Reduce datasets for plot hs and sar clustering
- Remove SVC and reduce the number of neighbours from 3 to 2 for KNN in the example with classifiers comparison
- Reduce the navigation_depth from 4 to 2 in sphinx conf
- Add update_path=True, where eegbci.load_data is called.