### PR TITLE
Improve doc rendering

### DIFF
--- a/doc/_templates/class.rst
+++ b/doc/_templates/class.rst
@@ -8,3 +8,8 @@
    {% block methods %}
    .. automethod:: __init__
    {% endblock %}
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -355,7 +355,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ('https://docs.python.org/', None)
+    "python": ('https://docs.python.org/', None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,9 @@ curdir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(curdir, 'sphinxext')))
 
 matplotlib.use('Agg')
+
 import sphinx_bootstrap_theme
+from sphinx_gallery.sorting import ExplicitOrder
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -65,8 +67,22 @@ plot_html_show_formats = False
 plot_html_show_source_link = False
 
 sphinx_gallery_conf = {
-    'examples_dirs': ['../examples', '../tutorials'],
-    'gallery_dirs': ['auto_examples']
+    'examples_dirs': ['../examples'],
+    'gallery_dirs': ['auto_examples'],
+    'subsection_order': ExplicitOrder([
+        '../examples/signal',
+        '../examples/simulated',
+        '../examples/motor-imagery',
+        '../examples/ERP',
+        '../examples/SSVEP',
+        '../examples/artifacts',
+        '../examples/remote-sensing',
+        '../examples/transfer',
+        '../examples/stats',
+    ]),
+    'doc_module': 'pyriemann',
+    'backreferences_dir': 'generated',
+    'plot_gallery': 'True',
 }
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/examples/remote-sensing/README.txt
+++ b/examples/remote-sensing/README.txt
@@ -1,4 +1,4 @@
-Remote Sensing
---------------
+Clustering of radar images
+--------------------------
 
-Using Riemannian geometry for remote sensing applications.
+Using Riemannian geometry for clustering of radar images.


### PR DESCRIPTION
This PR aims to:

- [x] sort sections in the gallery of examples. Solved using `ExplicitOrder`.
- [x] remove a hundred warnings `'undefined label: 'metadata_routing'`
https://github.com/pyRiemann/pyRiemann/actions/runs/10709407617/job/29693973533#step:4:875
Solved adding `sklearn` to intersphinx mapping.
- [x] plot a mini-gallery of examples at the bottom of each class, 
see https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation

Last point fails. Help needed!