### PR TITLE
Fix for the initialization of the power means

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,9 +35,9 @@ v0.7.dev
 
 - Add :func:`pyriemann.utils.distance.distance_poweuclid` and :func:`pyriemann.utils.mean.mean_poweuclid` to use power Euclidean metric. :pr:`312` by :user:`qbarthelemy`
 
-- Add ``init`` parameter to :class:`pyriemann.utils.mean.mean_power`. It allows initialization of the power mean. :pr:`324` by :user:`toncho11`
+- Add ``init`` parameter to :class:`pyriemann.utils.mean.mean_power`, and 
+  fix :func:`pyriemann.utils.mean.mean_power` to use the correct initialization provided in the associated paper. :pr:`324` by :user:`toncho11`
 
-- Fix :func:`pyriemann.utils.mean.mean_power` to use the correct initialization provided in the associated paper. :pr:`324` by :user:`toncho11`
 v0.6 (April 2024)
 -----------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,8 +35,7 @@ v0.7.dev
 
 - Add :func:`pyriemann.utils.distance.distance_poweuclid` and :func:`pyriemann.utils.mean.mean_poweuclid` to use power Euclidean metric. :pr:`312` by :user:`qbarthelemy`
 
-- Add ``init`` parameter to :class:`pyriemann.utils.mean.mean_power`, and 
-  fix :func:`pyriemann.utils.mean.mean_power` to use the correct initialization provided in the associated paper. :pr:`324` by :user:`toncho11`
+- Enhance :func:`pyriemann.utils.mean.mean_power`: add ``init`` parameter and fix default initialization provided in the associated paper. :pr:`324` by :user:`toncho11`
 
 v0.6 (April 2024)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,6 +35,9 @@ v0.7.dev
 
 - Add :func:`pyriemann.utils.distance.distance_poweuclid` and :func:`pyriemann.utils.mean.mean_poweuclid` to use power Euclidean metric. :pr:`312` by :user:`qbarthelemy`
 
+- Add ``init`` parameter to :class:`pyriemann.utils.mean.mean_power`. It allows initialization of the power mean. :pr:`324` by :user:`toncho11`
+
+- Fix :func:`pyriemann.utils.mean.mean_power` to use the correct initialization provided in the associated paper. :pr:`324` by :user:`toncho11`
 v0.6 (April 2024)
 -----------------
 

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -396,7 +396,7 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
         The maximum number of iterations.
     init : None | ndarray, shape (n, n), default=None
         A SPD/HPD matrix used to initialize the gradient descent.
-        If None, a naive weighted power mean is used.
+        If None, the weighted power Euclidean mean is used.
 
     Returns
     -------

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -369,8 +369,8 @@ def mean_logeuclid(X=None, sample_weight=None, covmats=None):
     return M
 
 
-def mean_power(X=None, p=None, *, init=None, sample_weight=None, zeta=10e-10, maxiter=100,
-               covmats=None):
+def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
+               covmats=None, init=None):
     r"""Power mean of SPD/HPD matrices.
 
     Power mean of order :math:`p` is the solution of [1]_ [2]_:

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -369,7 +369,7 @@ def mean_logeuclid(X=None, sample_weight=None, covmats=None):
     return M
 
 
-def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
+def mean_power(X=None, p=None, *, init=None, sample_weight=None, zeta=10e-10, maxiter=100,
                covmats=None):
     r"""Power mean of SPD/HPD matrices.
 
@@ -439,7 +439,11 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
     sample_weight = check_weights(sample_weight, n_matrices)
     phi = 0.375 / np.abs(p)
 
-    G = np.einsum("a,abc->bc", sample_weight, powm(X, p))
+    if init is None:
+        G = powm(np.einsum("a,abc->bc", sample_weight, powm(X, p)), 1/p)
+    else:
+        G = init
+        
     if p > 0:
         K = invsqrtm(G)
     else:

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -443,7 +443,6 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
         G = powm(np.einsum("a,abc->bc", sample_weight, powm(X, p)), 1/p)
     else:
         G = init
-        
     if p > 0:
         K = invsqrtm(G)
     else:

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -394,6 +394,9 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
         Stopping criterion.
     maxiter : int, default=100
         The maximum number of iterations.
+    init : None | ndarray, shape (n, n), default=None
+        A SPD/HPD matrix used to initialize the gradient descent.
+        If None, a naive weighted power mean is used.
 
     Returns
     -------

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -66,7 +66,10 @@ def test_mean_init(kind, mean, get_mats):
     """Test the shape of mean with init"""
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, kind)
-    M = mean(mats, init=mats[0])
+    if mean == mean_power:
+        M = mean(mats, 0.123, init=mats[0])
+    else:
+        M = mean(mats, init=mats[0])
     assert M.shape == (n_channels, n_channels)
 
 

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -53,7 +53,14 @@ def test_mean(kind, mean, get_mats):
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize(
-    "mean", [mean_logdet, mean_riemann, mean_wasserstein, nanmean_riemann]
+    "mean",
+    [
+        mean_logdet,
+        mean_power,
+        mean_riemann,
+        mean_wasserstein,
+        nanmean_riemann,
+    ]
 )
 def test_mean_init(kind, mean, get_mats):
     """Test the shape of mean with init"""


### PR DESCRIPTION
* Fix for the initialization of G. From the article https://hal.science/hal-01500514/document, equation (16) we see that an extra powm() and 1/p should be included. This fix helps with performance as it allows the algorithm to converge faster. It should not affect the classification performance.
* Added "init" parameter that allows initialization of the power mean. This is useful because it allows us to use a previously calculated power mean for the calculation of a new one especially if we know that they are close (the new one has a few samples less for example).

People involved @qbarthelemy , @Marco-Congedo