### PR TITLE
Remove deprecated classes and inputs

### DIFF
--- a/examples/stats/plot_oneway_manova_frequency.py
+++ b/examples/stats/plot_oneway_manova_frequency.py
@@ -16,7 +16,7 @@ import numpy as np
 from pylab import plt
 import seaborn as sns
 
-from pyriemann.estimation import CospCovariances
+from pyriemann.estimation import CoSpectra
 from pyriemann.stats import PermutationDistance
 
 sns.set_style("whitegrid")
@@ -64,7 +64,7 @@ epochs_data = epochs.get_data(copy=False)
 # compute cospectral covariance matrices
 fmin = 2.0
 fmax = 40.0
-cosp = CospCovariances(
+cosp = CoSpectra(
     window=128, overlap=0.98, fmin=fmin, fmax=fmax, fs=160.0)
 covmats = cosp.fit_transform(epochs_data[:, ::4, :])
 

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7'
+__version__ = "0.8.dev"

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.dev"
+__version__ = '0.8.dev'

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -1,6 +1,5 @@
 """Module for classification function."""
 import functools
-import warnings
 
 from joblib import Parallel, delayed
 import numpy as np

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -529,7 +529,7 @@ class KNearestNeighbor(MDM):
 
         return self
 
-    def predict(self, X=None, covtest=None):
+    def predict(self, X):
         """Get the predictions.
 
         Parameters
@@ -542,12 +542,6 @@ class KNearestNeighbor(MDM):
         pred : ndarray of int, shape (n_matrices,)
             Predictions for each matrix according to the nearest neighbors.
         """
-        if covtest is not None:
-            warnings.warn("Input covtest has been renamed into X and will be "
-                          "removed in 0.8.0.", category=DeprecationWarning)
-            assert (X is None)
-            X = covtest
-
         dist = self._predict_distances(X)
         neighbors_classes = self.classmeans_[np.argsort(dist)]
         pred = _mode_2d(neighbors_classes[:, 0:self.n_neighbors], axis=1)

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -7,7 +7,6 @@ from sklearn.metrics.pairwise import pairwise_kernels
 from .spatialfilters import Xdawn
 from .utils.covariance import (covariances, covariances_EP, cross_spectrum,
                                coherence, block_covariances)
-from .utils import deprecated
 
 
 def _nextpow2(i):
@@ -580,15 +579,7 @@ class CoSpectra(CrossSpectra):
         return X_new.real
 
 
-@deprecated(
-    "CospCovariances is deprecated and will be removed in 0.8.0; "
-    "please use CoSpectra."
-)
-class CospCovariances(CoSpectra):
-    pass
-
-
-class Coherences(CospCovariances):
+class Coherences(CoSpectra):
     """Estimation of squared coherence matrices.
 
     Squared coherence matrices estimation [1]_. This method will return a 4-d
@@ -793,14 +784,6 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
 
         covmats = covariances(self.Xtd_, estimator=self.estimator, **self.kwds)
         return covmats
-
-
-@deprecated(
-    "HankelCovariances is deprecated and will be removed in 0.8.0; "
-    "please use TimeDelayCovariances."
-)
-class HankelCovariances(TimeDelayCovariances):
-    pass
 
 
 ###############################################################################

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -585,7 +585,7 @@ class AJDC(BaseEstimator, TransformerMixin):
 
     See Also
     --------
-    CospCovariances
+    CoSpectra
 
     References
     ----------
@@ -641,7 +641,7 @@ class AJDC(BaseEstimator, TransformerMixin):
             The AJDC instance.
         """
         # definition of params for Welch's method
-        cospcov = est.CospCovariances(
+        cospest = est.CoSpectra(
             window=self.window,
             overlap=self.overlap,
             fmin=self.fmin,
@@ -651,11 +651,11 @@ class AJDC(BaseEstimator, TransformerMixin):
         # estimation of cospectra on subjects and conditions
         cosp = []
         for s in range(len(X)):
-            cosp_ = cospcov.transform(X[s])
+            cosp_ = cospest.transform(X[s])
             if s == 0:
                 n_conditions = cosp_.shape[0]
                 self.n_channels_ = cosp_.shape[1]
-                self.freqs_ = cospcov.freqs_
+                self.freqs_ = cospest.freqs_
             else:
                 if n_conditions != cosp_.shape[0]:
                     raise ValueError("Unequal number of conditions")

--- a/pyriemann/utils/mean.py
+++ b/pyriemann/utils/mean.py
@@ -11,15 +11,7 @@ from .geodesic import geodesic_riemann
 from .utils import check_weights, check_function
 
 
-def _deprecate_covmats(covmats, X):
-    if covmats is not None:
-        print("DeprecationWarning: input covmats has been renamed into X and "
-              "will be removed in 0.8.0.")
-        X = covmats
-    return X
-
-
-def mean_ale(X=None, tol=10e-7, maxiter=50, sample_weight=None, covmats=None):
+def mean_ale(X, *, tol=10e-7, maxiter=50, sample_weight=None):
     """AJD-based log-Euclidean (ALE) mean of SPD matrices.
 
     Return the mean of a set of SPD matrices using the approximate joint
@@ -56,7 +48,6 @@ def mean_ale(X=None, tol=10e-7, maxiter=50, sample_weight=None, covmats=None):
         <https://arxiv.org/abs/1505.07343>`_
         M. Congedo, B. Afsari, A. Barachant, M. Moakher. PLOS ONE, 2015
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, n, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
 
@@ -82,7 +73,7 @@ def mean_ale(X=None, tol=10e-7, maxiter=50, sample_weight=None, covmats=None):
     return M
 
 
-def mean_alm(X=None, tol=1e-14, maxiter=100, sample_weight=None, covmats=None):
+def mean_alm(X, *, tol=1e-14, maxiter=100, sample_weight=None):
     r"""Ando-Li-Mathias (ALM) mean of SPD/HPD matrices.
 
     Return the geometric mean recursively [1]_, generalizing from:
@@ -125,7 +116,6 @@ def mean_alm(X=None, tol=1e-14, maxiter=100, sample_weight=None, covmats=None):
         T. Ando, C.-K. Li, and R. Mathias. Linear Algebra and its Applications.
         Volume 385, July 2004, Pages 305-334.
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, _, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
 
@@ -155,7 +145,7 @@ def mean_alm(X=None, tol=1e-14, maxiter=100, sample_weight=None, covmats=None):
     return M_iter.mean(axis=0)
 
 
-def mean_euclid(X=None, sample_weight=None, covmats=None):
+def mean_euclid(X, sample_weight=None):
     r"""Mean of matrices according to the Euclidean metric.
 
     .. math::
@@ -179,11 +169,10 @@ def mean_euclid(X=None, sample_weight=None, covmats=None):
     --------
     mean_covariance
     """
-    X = _deprecate_covmats(covmats, X)
     return np.average(X, axis=0, weights=sample_weight)
 
 
-def mean_harmonic(X=None, sample_weight=None, covmats=None):
+def mean_harmonic(X, sample_weight=None):
     r"""Harmonic mean of invertible matrices.
 
     .. math::
@@ -205,13 +194,12 @@ def mean_harmonic(X=None, sample_weight=None, covmats=None):
     --------
     mean_covariance
     """
-    X = _deprecate_covmats(covmats, X)
     T = mean_euclid(np.linalg.inv(X), sample_weight=sample_weight)
     M = np.linalg.inv(T)
     return M
 
 
-def mean_identity(X=None, sample_weight=None, covmats=None):
+def mean_identity(X, sample_weight=None):
     r"""Identity matrix corresponding to the matrices dimension.
 
     .. math::
@@ -233,12 +221,11 @@ def mean_identity(X=None, sample_weight=None, covmats=None):
     --------
     mean_covariance
     """
-    X = _deprecate_covmats(covmats, X)
     M = np.eye(X.shape[-1])
     return M
 
 
-def mean_kullback_sym(X=None, sample_weight=None, covmats=None):
+def mean_kullback_sym(X, sample_weight=None):
     """Mean of SPD/HPD matrices according to Kullback-Leibler divergence.
 
     Symmetrized Kullback-Leibler mean is the geometric mean between the
@@ -268,7 +255,6 @@ def mean_kullback_sym(X=None, sample_weight=None, covmats=None):
         M. Moakher and P. Batchelor. Visualization and Processing of Tensor
         Fields, pp. 285-298, 2006
     """
-    X = _deprecate_covmats(covmats, X)
     M_euclid = mean_euclid(X, sample_weight=sample_weight)
     M_harmonic = mean_harmonic(X, sample_weight=sample_weight)
     M = geodesic_riemann(M_euclid, M_harmonic, 0.5)
@@ -338,8 +324,7 @@ def mean_logchol(X, sample_weight=None):
     return mean @ mean.conj().T
 
 
-def mean_logdet(X=None, tol=10e-5, maxiter=50, init=None, sample_weight=None,
-                covmats=None):
+def mean_logdet(X, *, tol=10e-5, maxiter=50, init=None, sample_weight=None):
     r"""Mean of SPD/HPD matrices according to the log-det metric.
 
     Log-det mean is obtained by an iterative procedure where the update is:
@@ -371,7 +356,6 @@ def mean_logdet(X=None, tol=10e-5, maxiter=50, init=None, sample_weight=None,
     --------
     mean_covariance
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, _, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
     if init is None:
@@ -395,7 +379,7 @@ def mean_logdet(X=None, tol=10e-5, maxiter=50, init=None, sample_weight=None,
     return M
 
 
-def mean_logeuclid(X=None, sample_weight=None, covmats=None):
+def mean_logeuclid(X, sample_weight=None):
     r"""Mean of SPD/HPD matrices according to the log-Euclidean metric.
 
     Log-Euclidean mean is [1]_:
@@ -427,13 +411,12 @@ def mean_logeuclid(X=None, sample_weight=None, covmats=None):
         V. Arsigny, P. Fillard, X. Pennec, and N. Ayache. SIAM Journal on
         Matrix Analysis and Applications. Volume 29, Issue 1 (2007).
     """
-    X = _deprecate_covmats(covmats, X)
     M = expm(mean_euclid(logm(X), sample_weight=sample_weight))
     return M
 
 
-def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
-               covmats=None, init=None):
+def mean_power(X, p, *, sample_weight=None, zeta=10e-10, maxiter=100,
+               init=None):
     r"""Power mean of SPD/HPD matrices.
 
     Power mean of order :math:`p` is the solution of [1]_ [2]_:
@@ -486,9 +469,6 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
         M. Congedo, A. Barachant, and R. Bhatia. IEEE Transactions on Signal
         Processing, Volume 65, Issue 9, pp.2211-2220, May 2017
     """
-    X = _deprecate_covmats(covmats, X)
-    if p is None:
-        raise ValueError("Exponent p can not be None")
     if not isinstance(p, (int, float)):
         raise ValueError(f"Exponent p must be a scalar (Got {type(p)})")
     if p < -1 or 1 < p:
@@ -537,7 +517,7 @@ def mean_power(X=None, p=None, *, sample_weight=None, zeta=10e-10, maxiter=100,
     return M
 
 
-def mean_poweuclid(X, p, sample_weight=None):
+def mean_poweuclid(X, p, *, sample_weight=None):
     r"""Mean of SPD/HPD matrices according to the power Euclidean metric.
 
     Power Euclidean mean of order :math:`p` is [1]_:
@@ -584,8 +564,7 @@ def mean_poweuclid(X, p, sample_weight=None):
     return M
 
 
-def mean_riemann(X=None, tol=10e-9, maxiter=50, init=None, sample_weight=None,
-                 covmats=None):
+def mean_riemann(X, *, tol=10e-9, maxiter=50, init=None, sample_weight=None):
     r"""Mean of SPD/HPD matrices according to the Riemannian metric.
 
     The affine-invariant Riemannian mean minimizes the sum of squared
@@ -630,7 +609,6 @@ def mean_riemann(X=None, tol=10e-9, maxiter=50, init=None, sample_weight=None,
         <https://epubs.siam.org/doi/10.1137/S0895479803436937>`_
         M. Moakher. SIAM J Matrix Anal Appl, 2005, 26 (3), pp. 735-747
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, _, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
     if init is None:
@@ -661,8 +639,7 @@ def mean_riemann(X=None, tol=10e-9, maxiter=50, init=None, sample_weight=None,
     return M
 
 
-def mean_wasserstein(X=None, tol=10e-4, maxiter=50, init=None,
-                     sample_weight=None, covmats=None):
+def mean_wasserstein(X, tol=10e-4, maxiter=50, init=None, sample_weight=None):
     r"""Mean of SPD/HPD matrices according to the Wasserstein metric.
 
     Wasserstein mean is obtained by an iterative procedure where the update is
@@ -704,7 +681,6 @@ def mean_wasserstein(X=None, tol=10e-4, maxiter=50, init=None,
         <https://ieeexplore.ieee.org/document/6042179>`_
         F. Barbaresco. 12th International Radar Symposium (IRS), October 2011
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, _, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
     if init is None:
@@ -747,8 +723,7 @@ mean_functions = {
 }
 
 
-def mean_covariance(X=None, metric="riemann", sample_weight=None, covmats=None,
-                    **kwargs):
+def mean_covariance(X, metric="riemann", sample_weight=None, **kwargs):
     """Mean of matrices according to a metric.
 
     Compute the mean of a set of matrices according to a metric [1]_.
@@ -780,7 +755,6 @@ def mean_covariance(X=None, metric="riemann", sample_weight=None, covmats=None,
         S. Chevallier, E. K. Kalunga, Q. Barthélemy, E. Monacelli.
         Neuroinformatics, Springer, 2021, 19 (1), pp.93-106
     """
-    X = _deprecate_covmats(covmats, X)
     mean_function = check_function(metric, mean_functions)
     M = mean_function(
         X,
@@ -821,8 +795,8 @@ def _apply_masks(X, masks):
     return maskedX
 
 
-def maskedmean_riemann(X=None, masks=None, tol=10e-9, maxiter=100, init=None,
-                       sample_weight=None, covmats=None):
+def maskedmean_riemann(X, masks, *, tol=10e-9, maxiter=100, init=None,
+                       sample_weight=None):
     """Masked Riemannian mean of SPD/HPD matrices.
 
     Given masks defined as semi-orthogonal matrices, the masked Riemannian mean
@@ -869,9 +843,6 @@ def maskedmean_riemann(X=None, masks=None, tol=10e-9, maxiter=100, init=None,
         F. Yger, S. Chevallier, Q. Barthélemy, and S. Sra. Asian Conference on
         Machine Learning (ACML), Nov 2020, Bangkok, Thailand. pp.417 - 432.
     """
-    if masks is None:
-        raise ValueError("Input masks can not be None")
-    X = _deprecate_covmats(covmats, X)
     n_matrices, n, _ = X.shape
     sample_weight = check_weights(sample_weight, n_matrices)
     maskedX = _apply_masks(X, masks)
@@ -908,8 +879,7 @@ def maskedmean_riemann(X=None, masks=None, tol=10e-9, maxiter=100, init=None,
     return M
 
 
-def nanmean_riemann(X=None, tol=10e-9, maxiter=100, init=None,
-                    sample_weight=None, covmats=None):
+def nanmean_riemann(X, tol=10e-9, maxiter=100, init=None, sample_weight=None):
     """Riemannian NaN-mean of SPD/HPD matrices.
 
     The Riemannian NaN-mean is the masked Riemannian mean applied to SPD/HPD
@@ -951,7 +921,6 @@ def nanmean_riemann(X=None, tol=10e-9, maxiter=100, init=None,
         F. Yger, S. Chevallier, Q. Barthélemy, and S. Sra. Asian Conference on
         Machine Learning (ACML), Nov 2020, Bangkok, Thailand. pp.417 - 432.
     """
-    X = _deprecate_covmats(covmats, X)
     n_matrices, n, _ = X.shape
     if init is None:
         Minit = np.nanmean(X, axis=0) + 1e-6 * np.eye(n)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -13,9 +13,7 @@ from pyriemann.estimation import (
     XdawnCovariances,
     CrossSpectra,
     CoSpectra,
-    CospCovariances,
     TimeDelayCovariances,
-    HankelCovariances,
     Coherences,
     Shrinkage,
     BlockCovariances,
@@ -105,15 +103,6 @@ def test_time_delay_covariances(delays, rndstate):
     assert covest.Xtd_.shape == (n_matrices, n_delays * n_channels, n_times)
     assert is_spd(covmats)
     assert ~is_hankel(covmats[0])
-
-
-def test_hankel_covariances():
-    import warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        HankelCovariances()
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
 
 
 @pytest.mark.parametrize("estimator", estim)
@@ -288,15 +277,6 @@ def test_xspectra(estim, rndstate):
         assert is_spsd(spmats.transpose(0, 3, 1, 2))
     else:
         assert is_hpsd(spmats.transpose(0, 3, 1, 2))
-
-
-def test_cosp_covariances():
-    import warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        CospCovariances()
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
 
 
 @pytest.mark.parametrize("coh", coh)


### PR DESCRIPTION
Remove deprecated elements:
- classes `CospCovariances` and `HankelCovariances`
- inputs `covmats` in all `utils.mean` functions
- input `covtest` in `kNN.predict`