### PR TITLE
Update numpy version and remove warning

### DIFF
--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -1,7 +1,6 @@
 """Base functions for SPD/HPD matrices."""
 
 import numpy as np
-from numpy._core.numerictypes import typecodes
 
 from .test import is_pos_def
 
@@ -10,7 +9,7 @@ def _matrix_operator(C, operator):
     """Matrix function."""
     if not isinstance(C, np.ndarray) or C.ndim < 2:
         raise ValueError("Input must be at least a 2D ndarray")
-    if C.dtype.char in typecodes['AllFloat'] and (
+    if C.dtype.char in np.typecodes['AllFloat'] and (
             np.isinf(C).any() or np.isnan(C).any()):
         raise ValueError(
             "Matrices must be positive definite. Add "

--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -1,7 +1,8 @@
 """Base functions for SPD/HPD matrices."""
 
 import numpy as np
-from numpy.core.numerictypes import typecodes
+from numpy._core.numerictypes import typecodes
+
 from .test import is_pos_def
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy!=1.24.0
+numpy>=2.0.0
 scipy
 scikit-learn>=0.24
 joblib

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     platforms="any",
     python_requires=">=3.9",
     install_requires=[
-        "numpy!=1.24.0",
+        "numpy>=2.0.0",
         "scipy",
         "scikit-learn>=0.24",
         "joblib",


### PR DESCRIPTION
This PR updates NumPy version and removes the following warning:

```
pyriemann\utils\base.py:4: DeprecationWarning: numpy.core.numerictypes is deprecated and has been renamed to numpy._core.numerictypes.
The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release.
In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API.
If that is the case, use the public NumPy API. If not, you are using NumPy internals.
If you would still like to access an internal attribute, use numpy._core.numerictypes.typecodes.
    from numpy.core.numerictypes import typecodes
```