### PR TITLE
Complete doc of methods

### DIFF
--- a/pyriemann/channelselection.py
+++ b/pyriemann/channelselection.py
@@ -6,7 +6,7 @@ from .utils.distance import distance
 from .classification import MDM
 
 
-class ElectrodeSelection(BaseEstimator, TransformerMixin):
+class ElectrodeSelection(TransformerMixin, BaseEstimator):
 
     """Channel selection based on a Riemannian geometry criterion.
 
@@ -125,8 +125,27 @@ class ElectrodeSelection(BaseEstimator, TransformerMixin):
         """
         return X[:, self.subelec_, :][:, :, self.subelec_]
 
+    def fit_transform(self, X, y=None, sample_weight=None):
+        """Fit and transform in a single function.
 
-class FlatChannelRemover(BaseEstimator, TransformerMixin):
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+        y : None | ndarray, shape (n_matrices,), default=None
+            Labels for each matrix.
+        sample_weight : None | ndarray, shape (n_matrices,), default=None
+            Weights for each matrix. If None, it uses equal weights.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_elec, n_elec)
+            Set of SPD matrices after reduction of the number of channels.
+        """
+        return self.fit(X, y, sample_weight=sample_weight).transform(X)
+
+
+class FlatChannelRemover(TransformerMixin, BaseEstimator):
     """Flat channel removal.
 
     Attributes
@@ -170,7 +189,7 @@ class FlatChannelRemover(BaseEstimator, TransformerMixin):
         return X[:, self.channels_, :]
 
     def fit_transform(self, X, y=None):
-        """Find and remove flat channels.
+        """Fit and transform in a single function.
 
         Parameters
         ----------
@@ -184,5 +203,4 @@ class FlatChannelRemover(BaseEstimator, TransformerMixin):
         X_new : ndarray, shape (n_matrices, n_good_channels, n_times)
             Multi-channel time-series without flat channels.
         """
-        self.fit(X, y)
-        return self.transform(X)
+        return self.fit(X, y).transform(X)

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -407,9 +407,9 @@ class FgMDM(SpdClassifMixin, TransformerMixin, BaseEstimator):
 class TSClassifier(SpdClassifMixin, BaseEstimator):
     """Classification in the tangent space.
 
-    Project data in the tangent space and apply a classifier on the projected
-    data. This is a simple helper to pipeline the tangent space projection and
-    a classifier. Default classifier is LogisticRegression.
+    Project SPD matrices in the tangent space and apply a classifier.
+    This is a simple helper to pipeline the tangent space projection and
+    a classifier.
 
     Parameters
     ----------
@@ -530,7 +530,7 @@ class TSclassifier(TSClassifier):
 class KNearestNeighbor(MDM):
     """Classification by k-nearest neighbors.
 
-    Classification by k-nearest neighbors (k-NN). For each point of the test
+    Classification by k-nearest neighbors (k-NN). For each matrix of the test
     set, the pairwise distance to each element of the training set is
     estimated. The class is affected according to the majority class of the
     k-nearest neighbors.
@@ -659,12 +659,14 @@ class SVC(sklearnSVC):
     metric : string, default="riemann"
         Metric for kernel matrix computation. For the list of supported metrics
         see :func:`pyriemann.utils.kernel.kernel`.
-    Cref : None | callable | ndarray, shape (n_channels, n_channels)
-        Reference point for kernel matrix computation.
-        If None, the mean of the training data according to the metric is used.
-        If callable, the function is called on the training data to calculate
-        Cref.
-    kernel_fct : None | "precomputed" | callable
+    Cref : None | callable | ndarray, shape (n_channels, n_channels), \
+            default=None
+        Reference matrix for kernel matrix computation.
+        If None, the mean of the training matrices according to the metric is
+        used.
+        If callable, the function is called on the training matrices to
+        calculate Cref.
+    kernel_fct : None | "precomputed" | callable, default=None
         If None or "precomputed", the kernel matrix for datasets X and Y is
         estimated according to `pyriemann.utils.kernel(X, Y, Cref, metric)`.
         If callable, the callable is passed as the kernel parameter to

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -687,7 +687,7 @@ class SVC(sklearnSVC):
         Tolerance for stopping criterion.
     cache_size : float, default=200
         Specify the size of the kernel cache (in MB).
-    class_weight : dict or "balanced", default=None
+    class_weight : None | dict | "balanced", default=None
         Set the parameter C of class i to class_weight[i]*C for SVC. If not
         given, all classes are supposed to have weight one.
         The "balanced" mode uses the values of y to automatically adjust
@@ -713,7 +713,7 @@ class SVC(sklearnSVC):
         `decision_function`; otherwise the first class among the tied
         classes is returned. Please note that breaking ties comes at a
         relatively high computational cost compared to a simple predict.
-    random_state : int, RandomState instance or None, default=None
+    random_state : None | int | RandomState instance, default=None
         Controls the pseudo random number generation for shuffling the data for
         probability estimates. Ignored when `probability` is False.
         Pass an int for reproducible output across multiple function calls.

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -390,7 +390,7 @@ class FgMDM(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD/HPD matrices.
+            Set of SPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels for each matrix.
         sample_weight : None | ndarray, shape (n_matrices,), default=None
@@ -581,7 +581,7 @@ class KNearestNeighbor(MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels for each matrix.
         sample_weight : None
@@ -605,7 +605,7 @@ class KNearestNeighbor(MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -623,7 +623,7 @@ class KNearestNeighbor(MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -871,8 +871,13 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Brain-Computer Interface Conference, Sep 2019, Graz, Austria.
     """
 
-    def __init__(self, power_list=[-1, 0, 1], method_label="sum_means",
-                 metric="riemann", n_jobs=1):
+    def __init__(
+        self,
+        power_list=[-1, 0, 1],
+        method_label="sum_means",
+        metric="riemann",
+        n_jobs=1,
+    ):
         """Init."""
         self.power_list = power_list
         self.method_label = method_label
@@ -885,7 +890,7 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels for each matrix.
         sample_weight : None | ndarray shape (n_matrices,), default=None
@@ -942,7 +947,7 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -981,7 +986,7 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -1003,7 +1008,7 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels for each matrix.
         sample_weight : None | ndarray shape (n_matrices,), default=None
@@ -1022,7 +1027,7 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -1034,10 +1039,10 @@ class MeanField(SpdClassifMixin, TransformerMixin, BaseEstimator):
 
 def class_distinctiveness(X, y, exponent=1, metric="riemann",
                           return_num_denom=False):
-    r"""Measure class distinctiveness between classes of SPD matrices.
+    r"""Measure class distinctiveness between classes of SPD/HPD matrices.
 
     For two class problem, the class distinctiveness between class :math:`K_1`
-    and :math:`K_2` on the manifold of SPD matrices is quantified as [1]_:
+    and :math:`K_2` on the manifold of SPD/HPD matrices is quantified as [1]_:
 
     .. math::
         \mathrm{classDis}(K_1, K_2, p) =
@@ -1069,7 +1074,7 @@ def class_distinctiveness(X, y, exponent=1, metric="riemann",
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of SPD matrices.
+        Set of SPD/HPD matrices.
     y : ndarray, shape (n_matrices,)
         Labels for each matrix.
     exponent : int, default=1

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -93,7 +93,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         (see :func:`pyriemann.utils.distance.distance`).
         The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
-    random_state : integer or np.RandomState, optional
+    random_state : None | integer | np.RandomState, default=None
         The generator used to initialize the centroids. If an integer is
         given, it fixes the seed. Defaults to the global numpy random
         number generator.

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -72,10 +72,10 @@ def _fit_single(X, y=None, n_clusters=2, init="random", random_state=None,
 
 
 class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
-    """Clustering by k-means with SPD matrices as inputs.
+    """Clustering by k-means with SPD/HPD matrices as inputs.
 
     The k-means is a clustering method used to find clusters that minimize the
-    sum of squared distances between centroids and SPD matrices [1]_.
+    sum of squared distances between centroids and SPD/HPD matrices [1]_.
 
     Then, for each new matrix, the class is affected according to the nearest
     centroid.
@@ -171,7 +171,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None
             Not used, here for compatibility with sklearn API.
 
@@ -249,7 +249,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -264,7 +264,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None
             Not used, here for compatibility with sklearn API.
 
@@ -281,7 +281,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -296,7 +296,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None
             Not used, here for compatibility with sklearn API.
 
@@ -319,7 +319,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
 
 
 class KmeansPerClassTransform(TransformerMixin, BaseEstimator):
-    """Clustering by k-means for each class with SPD matrices as inputs.
+    """Clustering by k-means for each class with SPD/HPD matrices as inputs.
 
     Parameters
     ----------
@@ -350,7 +350,7 @@ class KmeansPerClassTransform(TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels corresponding to each matrix.
 
@@ -374,7 +374,7 @@ class KmeansPerClassTransform(TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -392,7 +392,7 @@ class KmeansPerClassTransform(TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Labels corresponding to each matrix.
 
@@ -408,7 +408,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
     """Artifact detection with the Riemannian Potato.
 
     The Riemannian Potato [1]_ is a clustering method used to detect artifact
-    in multichannel signals. Processing SPD matrices,
+    in multichannel signals. Processing SPD/HPD matrices,
     the algorithm iteratively estimates the centroid of clean
     matrices by rejecting every matrix that is too far from it.
 
@@ -459,8 +459,14 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Electrical and Electronics Engineers, 2019, 27 (2), pp.244-255
     """
 
-    def __init__(self, metric="riemann", threshold=3, n_iter_max=100,
-                 pos_label=1, neg_label=0):
+    def __init__(
+        self,
+        metric="riemann",
+        threshold=3,
+        n_iter_max=100,
+        pos_label=1,
+        neg_label=0,
+    ):
         """Init."""
         self.metric = metric
         self.threshold = threshold
@@ -469,15 +475,15 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         self.neg_label = neg_label
 
     def fit(self, X, y=None, sample_weight=None):
-        """Fit the potato from SPD matrices.
+        """Fit the potato.
 
-        Fit the potato from SPD matrices, with an iterative outlier
+        Fit the potato from SPD/HPD matrices, with an iterative outlier
         removal to obtain a reliable potato.
 
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
             label corresponds to a clean (resp. artifact) matrix.
@@ -522,7 +528,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         return self
 
     def partial_fit(self, X, y=None, *, sample_weight=None, alpha=0.1):
-        """Partially fit the potato from SPD matrices.
+        """Partially fit the potato.
 
         This partial fit can be used to update dynamic or semi-dymanic online
         potatoes with clean matrices.
@@ -530,7 +536,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
             label corresponds to a clean (resp. artifact) matrix.
@@ -595,7 +601,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -612,7 +618,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
             label corresponds to a clean (resp. artifact) matrix.
@@ -633,7 +639,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -656,7 +662,7 @@ class Potato(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -713,7 +719,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
     """Artifact detection with the Riemannian Potato Field.
 
     The Riemannian Potato Field [1]_ is a clustering method used to detect
-    artifact in multichannel signals. Processing SPD matrices,
+    artifact in multichannel signals. Processing SPD/HPD matrices,
     the algorithm combines several potatoes of low dimension,
     each one being designed to capture specific artifact typically
     affecting specific subsets of channels and/or specific frequency bands.
@@ -760,8 +766,16 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         Electrical and Electronics Engineers, 2019, 27 (2), pp.244-255
     """
 
-    def __init__(self, n_potatoes=1, p_threshold=0.01, z_threshold=3,
-                 metric="riemann", n_iter_max=10, pos_label=1, neg_label=0):
+    def __init__(
+        self,
+        n_potatoes=1,
+        p_threshold=0.01,
+        z_threshold=3,
+        metric="riemann",
+        n_iter_max=10,
+        pos_label=1,
+        neg_label=0,
+    ):
         """Init."""
         self.n_potatoes = int(n_potatoes)
         self.p_threshold = p_threshold
@@ -772,9 +786,9 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         self.neg_label = neg_label
 
     def fit(self, X, y=None, sample_weight=None):
-        """Fit the potato field from SPD matrices.
+        """Fit the potato field.
 
-        Fit the potato field from SPD matrices, with iterative
+        Fit the potato field from SPD/HPD matrices, with iterative
         outlier removal to obtain reliable potatoes.
 
         Parameters
@@ -782,7 +796,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
@@ -819,7 +833,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         return self
 
     def partial_fit(self, X, y=None, *, sample_weight=None, alpha=0.1):
-        """Partially fit the potato field from SPD matrices.
+        """Partially fit the potato field.
 
         This partial fit can be used to update dynamic or semi-dymanic online
         potatoes with clean matrices.
@@ -829,7 +843,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
@@ -874,7 +888,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
 
         Returns
@@ -899,7 +913,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
         y : None | ndarray, shape (n_matrices,), default=None
             Labels corresponding to each matrix: positive (resp. negative)
@@ -923,7 +937,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
 
         Returns
@@ -949,7 +963,7 @@ class PotatoField(TransformerMixin, SpdClassifMixin, BaseEstimator):
         X : list of n_potatoes ndarrays of shape (n_matrices, n_channels, \
                 n_channels) with same n_matrices but potentially different \
                 n_channels
-            List of sets of SPD matrices, each corresponding to a different
+            List of sets of SPD/HPD matrices, each corresponding to a different
             subset of channels and/or filtering with a specific frequency band.
 
         Returns

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -13,13 +13,14 @@ from .utils.kernel import kernel as kernel_fct
 
 
 class SpectralEmbedding(BaseEstimator):
-    """Spectral embedding of SPD matrices into an Euclidean space.
+    """Spectral embedding of SPD/HPD matrices into an Euclidean space.
 
-    It uses Laplacian Eigenmaps [1]_ to embed SPD matrices into an Euclidean
-    space of smaller dimension. The basic hypothesis is that high-dimensional
+    It uses Laplacian Eigenmaps [1]_ to embed SPD/HPD matrices into an
+    Euclidean space of smaller dimension.
+    The basic hypothesis is that high-dimensional
     data live in a low-dimensional manifold, whose intrinsic geometry can be
     described via the Laplacian matrix of a graph. The vertices of this graph
-    are the SPD matrices and the weights of the links are determined by the
+    are the SPD/HPD matrices and the weights of the links are determined by the
     Riemannian distance between each pair of them.
 
     Parameters
@@ -75,12 +76,12 @@ class SpectralEmbedding(BaseEstimator):
         return kernel_n
 
     def fit(self, X, y=None):
-        """Fit the model from data in X.
+        """Fit the spectral embedding.
 
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None
             Not used, here for compatibility with sklearn API.
 
@@ -110,7 +111,7 @@ class SpectralEmbedding(BaseEstimator):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : None
             Not used, here for compatibility with sklearn API.
 
@@ -129,14 +130,12 @@ class LocallyLinearEmbedding(TransformerMixin, BaseEstimator):
 
     As proposed in [1]_, Locally Linear Embedding (LLE) is a non-linear,
     neighborhood-preserving dimensionality reduction algorithm which
-    consists of three main steps. For each matrix X[i],
+    consists of three main steps. For each SPD matrix X[i] [2]_:
 
     1.  find its k-nearest neighbors k-NN(X[i]),
     2.  calculate the best reconstruction of X[i] based on its k-NN,
     3.  calculate a low-dimensional embedding for all matrices based on
         the weights in step 2.
-
-    This implementation using SPD matrices is based on [2]_.
 
     Parameters
     ----------
@@ -357,7 +356,7 @@ def locally_linear_embedding(
 
     Locally Linear Embedding (LLE) is a non-linear,
     neighborhood-preserving dimensionality reduction algorithm which consists
-    of three main steps [1]_. For each matrix X[i],
+    of three main steps [1]_. For each SPD matrix X[i]:
 
     1.  find its k-nearest neighbors k-NN(X[i]),
     2.  calculate the best reconstruction of X[i] based on its

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -124,7 +124,7 @@ class SpectralEmbedding(BaseEstimator):
         return self.embedding_
 
 
-class LocallyLinearEmbedding(BaseEstimator, TransformerMixin):
+class LocallyLinearEmbedding(TransformerMixin, BaseEstimator):
     """Locally Linear Embedding (LLE) of SPD matrices.
 
     As proposed in [1]_, Locally Linear Embedding (LLE) is a non-linear,

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -17,14 +17,14 @@ def _nextpow2(i):
     return n
 
 
-class Covariances(BaseEstimator, TransformerMixin):
+class Covariances(TransformerMixin, BaseEstimator):
     """Estimation of covariance matrices.
 
     Perform a simple covariance matrix estimation for each given input.
 
     Parameters
     ----------
-    estimator : string, default='scm'
+    estimator : string, default="scm"
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
     **kwds : dict
@@ -36,7 +36,7 @@ class Covariances(BaseEstimator, TransformerMixin):
     XdawnCovariances
     """
 
-    def __init__(self, estimator='scm', **kwds):
+    def __init__(self, estimator="scm", **kwds):
         """Init."""
         self.estimator = estimator
         self.kwds = kwds
@@ -70,14 +70,31 @@ class Covariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_channels, n_channels)
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
             Covariance matrices.
         """
         covmats = covariances(X, estimator=self.estimator, **self.kwds)
         return covmats
 
+    def fit_transform(self, X, y=None):
+        """Fit and transform in a single function.
 
-class ERPCovariances(BaseEstimator, TransformerMixin):
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : None
+            Not used, here for compatibility with sklearn API.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
+            Covariance matrices.
+        """
+        return self.fit(X, y).transform(X)
+
+
+class ERPCovariances(TransformerMixin, BaseEstimator):
     r"""Estimate special form covariance matrices for ERP.
 
     Estimation of special form covariance matrix dedicated to event-related
@@ -104,7 +121,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
     classes : list of int | None, default=None
         List of classes to take into account for prototype estimation.
         If None, all classes will be accounted.
-    estimator : string, default='scm'
+    estimator : string, default="scm"
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
     svd : int | None, default=None
@@ -141,7 +158,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         GRETSI, 2013.
     """
 
-    def __init__(self, classes=None, estimator='scm', svd=None, **kwds):
+    def __init__(self, classes=None, estimator="scm", svd=None, **kwds):
         """Init."""
         self.classes = classes
         self.estimator = estimator
@@ -167,7 +184,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         """
         if self.svd is not None:
             if not isinstance(self.svd, int):
-                raise TypeError('svd must be None or int')
+                raise TypeError("svd must be None or int")
         if self.classes is not None:
             classes = self.classes
         else:
@@ -198,7 +215,7 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_components, n_components)
+        X_new : ndarray, shape (n_matrices, n_components, n_components)
             Covariance matrices for ERP, where the size of matrices
             `n_components` is equal to `(1 + n_classes) x n_channels` if `svd`
             is None, and to `n_channels + n_classes x min(svd, n_channels)`
@@ -212,8 +229,28 @@ class ERPCovariances(BaseEstimator, TransformerMixin):
         )
         return covmats
 
+    def fit_transform(self, X, y):
+        """Fit and transform in a single function.
 
-class XdawnCovariances(BaseEstimator, TransformerMixin):
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : ndarray, shape (n_matrices,)
+            Labels for each matrix.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_components, n_components)
+            Covariance matrices for ERP, where the size of matrices
+            `n_components` is equal to `(1 + n_classes) x n_channels` if `svd`
+            is None, and to `n_channels + n_classes x min(svd, n_channels)`
+            otherwise.
+        """
+        return self.fit(X, y).transform(X)
+
+
+class XdawnCovariances(TransformerMixin, BaseEstimator):
     """Estimate special form covariance matrices for ERP combined with Xdawn.
 
     Estimation of special form covariance matrix dedicated to ERP processing
@@ -239,12 +276,12 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     classes : list of int | None, default=None
         list of classes to take into account for prototype estimation.
         If None, all classes will be accounted.
-    estimator : string, default='scm'
+    estimator : string, default="scm"
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
-    xdawn_estimator : string, default='scm'
+    xdawn_estimator : string, default="scm"
         Covariance matrix estimator for `Xdawn` spatial filtering.
-        Should be regularized using 'lwf' or 'oas', see
+        Should be regularized using "lwf" or "oas", see
         :func:`pyriemann.utils.covariance.covariances`.
     baseline_cov : array, shape (n_channels, n_channels) | None, default=None
         Baseline covariance for `Xdawn` spatial filtering,
@@ -271,14 +308,16 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         challenge.
     """
 
-    def __init__(self,
-                 nfilter=4,
-                 applyfilters=True,
-                 classes=None,
-                 estimator='scm',
-                 xdawn_estimator='scm',
-                 baseline_cov=None,
-                 **kwds):
+    def __init__(
+        self,
+        nfilter=4,
+        applyfilters=True,
+        classes=None,
+        estimator="scm",
+        xdawn_estimator="scm",
+        baseline_cov=None,
+        **kwds
+    ):
         """Init."""
         self.applyfilters = applyfilters
         self.estimator = estimator
@@ -291,7 +330,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
     def fit(self, X, y):
         """Fit.
 
-        Estimate spatial filters and prototyped response for each classes.
+        Estimate spatial filters and prototyped response for each class.
 
         Parameters
         ----------
@@ -325,7 +364,7 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_components, n_components)
+        X_new : ndarray, shape (n_matrices, n_components, n_components)
             Covariance matrices filtered by Xdawn, where n_components is equal
             to `2 x n_classes x min(n_channels, nfilter)` if `applyfilters` is
             True, and to `n_channels + n_classes x min(n_channels, nfilter)`
@@ -342,8 +381,28 @@ class XdawnCovariances(BaseEstimator, TransformerMixin):
         )
         return covmats
 
+    def fit_transform(self, X, y):
+        """Fit and transform in a single function.
 
-class BlockCovariances(BaseEstimator, TransformerMixin):
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : ndarray, shape (n_matrices,)
+            Labels for each matrix.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_components, n_components)
+            Covariance matrices filtered by Xdawn, where n_components is equal
+            to `2 x n_classes x min(n_channels, nfilter)` if `applyfilters` is
+            True, and to `n_channels + n_classes x min(n_channels, nfilter)`
+            otherwise.
+        """
+        return self.fit(X, y).transform(X)
+
+
+class BlockCovariances(Covariances):
     """Estimation of block covariance matrices.
 
     Perform a block covariance estimation for each given matrix. The
@@ -357,7 +416,7 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    block_size : int | list of int
+    block_size : int | array-like of int
         Sizes of individual blocks given as int for same-size block, or list
         for varying block sizes.
     estimator : string, default="scm"
@@ -381,25 +440,6 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
         self.block_size = block_size
         self.kwds = kwds
 
-    def fit(self, X, y=None):
-        """Fit.
-
-        Do nothing. For compatibility purpose.
-
-        Parameters
-        ----------
-        X : ndarray, shape (n_matrices, n_channels, n_times)
-            Multi-channel time-series.
-        y : None
-            Not used, here for compatibility with sklearn API.
-
-        Returns
-        -------
-        self : BlockCovariances instance
-            The BlockCovariances instance.
-        """
-        return self
-
     def transform(self, X):
         """Estimate block covariance matrices.
 
@@ -410,7 +450,7 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_channels, n_channels)
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
             Covariance matrices.
         """
         n_matrices, n_channels, n_times = X.shape
@@ -448,7 +488,7 @@ class BlockCovariances(BaseEstimator, TransformerMixin):
 ###############################################################################
 
 
-class CrossSpectra(BaseEstimator, TransformerMixin):
+class CrossSpectra(TransformerMixin, BaseEstimator):
     """Estimation of cross-spectral matrices.
 
     Complex cross-spectral matrices are HPD matrices estimated as the spectrum
@@ -489,8 +529,14 @@ class CrossSpectra(BaseEstimator, TransformerMixin):
     .. [1] https://en.wikipedia.org/wiki/Cross-spectrum
     """
 
-    def __init__(self, window=128, overlap=0.75, fmin=None, fmax=None,
-                 fs=None):
+    def __init__(
+        self,
+        window=128,
+        overlap=0.75,
+        fmin=None,
+        fmax=None,
+        fs=None,
+    ):
         """Init."""
         self.window = _nextpow2(window)
         self.overlap = overlap
@@ -539,11 +585,29 @@ class CrossSpectra(BaseEstimator, TransformerMixin):
                 overlap=self.overlap,
                 fmin=self.fmin,
                 fmax=self.fmax,
-                fs=self.fs)
+                fs=self.fs,
+            )
             X_new.append(S)
         self.freqs_ = freqs
 
         return np.array(X_new)
+
+    def fit_transform(self, X, y=None):
+        """Fit and transform in a single function.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : None
+            Not used, here for compatibility with sklearn API.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels, n_freqs)
+            Cross-spectral matrices for each input and for each frequency bin.
+        """
+        return self.fit(X, y).transform(X)
 
 
 class CoSpectra(CrossSpectra):
@@ -615,20 +679,20 @@ class Coherences(CoSpectra):
         The maximal frequency to be returned.
     fs : float | None, default=None
         The sampling frequency of the signal.
-    coh : {'ordinary', 'instantaneous', 'lagged', 'imaginary'}, \
-            default='ordinary'
+    coh : {"ordinary", "instantaneous", "lagged", "imaginary"}, \
+            default="ordinary"
         The coherence type:
 
-        * 'ordinary' for the ordinary coherence, defined in Eq.(22) of [1]_;
+        * "ordinary" for the ordinary coherence, defined in Eq.(22) of [1]_;
           this normalization of cross-spectral matrices captures both in-phase
           and out-of-phase correlations. However it is inflated by the
           artificial in-phase (zero-lag) correlation engendered by volume
           conduction.
-        * 'instantaneous' for the instantaneous coherence, Eq.(26) of [1]_,
+        * "instantaneous" for the instantaneous coherence, Eq.(26) of [1]_,
           capturing only in-phase correlation.
-        * 'lagged' for the lagged-coherence, Eq.(28) of [1]_, capturing only
+        * "lagged" for the lagged-coherence, Eq.(28) of [1]_, capturing only
           out-of-phase correlation (not defined for DC and Nyquist bins).
-        * 'imaginary' for the imaginary coherence [2]_, Eq.(0.16) of [3]_,
+        * "imaginary" for the imaginary coherence [2]_, Eq.(0.16) of [3]_,
           capturing out-of-phase correlation but still affected by in-phase
           correlation.
 
@@ -666,8 +730,15 @@ class Coherences(CoSpectra):
         M. Congedo. Technical Report, 2018.
     """
 
-    def __init__(self, window=128, overlap=0.75, fmin=None, fmax=None,
-                 fs=None, coh='ordinary'):
+    def __init__(
+        self,
+        window=128,
+        overlap=0.75,
+        fmin=None,
+        fmax=None,
+        fs=None,
+        coh="ordinary",
+    ):
         """Init."""
         self.window = _nextpow2(window)
         self.overlap = overlap
@@ -686,7 +757,7 @@ class Coherences(CoSpectra):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_channels, n_channels, n_freqs)
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels, n_freqs)
             Squared coherence matrices for each input and for each frequency
             bin.
         """
@@ -700,14 +771,15 @@ class Coherences(CoSpectra):
                 fmin=self.fmin,
                 fmax=self.fmax,
                 fs=self.fs,
-                coh=self.coh)
+                coh=self.coh,
+            )
             out.append(S)
         self.freqs_ = freqs
 
         return np.array(out)
 
 
-class TimeDelayCovariances(BaseEstimator, TransformerMixin):
+class TimeDelayCovariances(TransformerMixin, BaseEstimator):
     """Estimation of covariance matrices with time delay matrices.
 
     Time delay covariance matrices are useful to catch spectral dynamics of
@@ -719,7 +791,7 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
     delays : int | list of int, default=4
         The delays to apply for the Hankel matrices. If `int`, it use a range
         of delays up to the given value. A list of int can be given.
-    estimator : string, default='scm'
+    estimator : string, default="scm"
         Covariance matrix estimator, see
         :func:`pyriemann.utils.covariance.covariances`.
     **kwds : dict
@@ -746,7 +818,7 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
         Biomedical Engineering 52(9), 1541-1548, 2005.
     """
 
-    def __init__(self, delays=4, estimator='scm', **kwds):
+    def __init__(self, delays=4, estimator="scm", **kwds):
         """Init."""
         self.delays = delays
         self.estimator = estimator
@@ -781,7 +853,7 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        covmats : ndarray, shape (n_matrices, n_channels x n_delays, \
+        X_new : ndarray, shape (n_matrices, n_channels x n_delays, \
                 n_channels x n_delays)
             Time delay covariance matrices, where `n_delays` is equal to:
             `delays` when it is a int, and `1 + len(delays)` when it is a list.
@@ -792,7 +864,7 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
         elif isinstance(self.delays, list):
             delays = self.delays
         else:
-            raise ValueError('delays must be an integer or a list')
+            raise ValueError("delays must be an integer or a list")
 
         Xtd = [X]
         for d in delays:
@@ -801,6 +873,25 @@ class TimeDelayCovariances(BaseEstimator, TransformerMixin):
 
         covmats = covariances(self.Xtd_, estimator=self.estimator, **self.kwds)
         return covmats
+
+    def fit_transform(self, X, y=None):
+        """Fit and transform in a single function.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : None
+            Not used, here for compatibility with sklearn API.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_channels x n_delays, \
+                n_channels x n_delays)
+            Time delay covariance matrices, where `n_delays` is equal to:
+            `delays` when it is a int, and `1 + len(delays)` when it is a list.
+        """
+        return self.fit(X, y).transform(X)
 
 
 ###############################################################################
@@ -811,7 +902,7 @@ ker_est_functions = [
 ]
 
 
-class Kernels(BaseEstimator, TransformerMixin):
+class Kernels(TransformerMixin, BaseEstimator):
     r"""Estimation of kernel matrices between channels of time series.
 
     Perform a kernel matrix estimation for each given time series, evaluating a
@@ -893,7 +984,7 @@ class Kernels(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        K : ndarray, shape (n_matrices, n_channels, n_channels)
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
             Kernel matrices.
         """
         if self.metric not in ker_est_functions:
@@ -911,11 +1002,30 @@ class Kernels(BaseEstimator, TransformerMixin):
 
         return np.asarray(K)
 
+    def fit_transform(self, X, y=None):
+        """Fit and transform in a single function.
+
+        Estimate kernel matrices from time series.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_times)
+            Multi-channel time-series.
+        y : None
+            Not used, here for compatibility with sklearn API.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
+            Kernel matrices.
+        """
+        return self.fit(X, y).transform(X)
+
 
 ###############################################################################
 
 
-class Shrinkage(BaseEstimator, TransformerMixin):
+class Shrinkage(TransformerMixin, BaseEstimator):
     """Regularization of SPD/HPD matrices by shrinkage.
 
     This transformer applies a shrinkage regularization to SPD/HPD matrices.
@@ -978,3 +1088,20 @@ class Shrinkage(BaseEstimator, TransformerMixin):
             Xnew[i].real = shrunk_covariance(x.real, self.shrinkage)
 
         return Xnew
+
+    def fit_transform(self, X, y=None):
+        """Fit and transform in a single function.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD/HPD matrices.
+        y : None
+            Not used, here for compatibility with sklearn API.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of shrunk SPD/HPD matrices.
+        """
+        return self.fit(X, y).transform(X)

--- a/pyriemann/preprocessing.py
+++ b/pyriemann/preprocessing.py
@@ -10,7 +10,7 @@ from .utils.geodesic import geodesic
 from .utils.mean import mean_covariance
 
 
-class Whitening(BaseEstimator, TransformerMixin):
+class Whitening(TransformerMixin, BaseEstimator):
     """Whitening, and optional unsupervised dimension reduction.
 
     Implementation of the whitening, and an optional unsupervised dimension
@@ -252,6 +252,26 @@ class Whitening(BaseEstimator, TransformerMixin):
             Set of whitened, and optionally reduced, SPD matrices.
         """
         return self.filters_.T @ X @ self.filters_
+
+    def fit_transform(self, X, y=None, sample_weight=None):
+        """Fit and transform in a single function.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+        y : None
+            Ignored as unsupervised.
+        sample_weight : None | ndarray, shape (n_matrices,), default=None
+            Weight of each matrix, to compute the weighted mean matrix used for
+            whitening and dimension reduction. If None, it uses equal weights.
+
+        Returns
+        -------
+        X_new : ndarray, shape (n_matrices, n_components, n_components)
+            Set of whitened, and optionally reduced, SPD matrices.
+        """
+        return self.fit(X, y, sample_weight=sample_weight).transform(X)
 
     def inverse_transform(self, X):
         """Apply inverse whitening spatial filters.

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -29,7 +29,7 @@ class SVR(sklearnSVR):
         Reference matrix for kernel matrix computation.
         If None, the mean of the training matrices according to the metric is
         used.
-    kernel_fct : "precomputed" | callable, default=None
+    kernel_fct : None | "precomputed" | callable, default=None
         If "precomputed", the kernel matrix for datasets X and Y is estimated
         according to `pyriemann.utils.kernel(X, Y, Cref, metric)`.
         If callable, the callable is passed as the kernel parameter to

--- a/pyriemann/regression.py
+++ b/pyriemann/regression.py
@@ -25,10 +25,11 @@ class SVR(sklearnSVR):
     metric : string, default="riemann"
         Metric for kernel matrix computation. For the list of supported metrics
         see :func:`pyriemann.utils.kernel.kernel`.
-    Cref : None | ndarray, shape (n_channels, n_channels)
-        Reference point for kernel matrix computation. If None, the mean of
-        the training data according to the metric is used.
-    kernel_fct : "precomputed" | callable
+    Cref : None | ndarray, shape (n_channels, n_channels), default=None
+        Reference matrix for kernel matrix computation.
+        If None, the mean of the training matrices according to the metric is
+        used.
+    kernel_fct : "precomputed" | callable, default=None
         If "precomputed", the kernel matrix for datasets X and Y is estimated
         according to `pyriemann.utils.kernel(X, Y, Cref, metric)`.
         If callable, the callable is passed as the kernel parameter to
@@ -59,7 +60,7 @@ class SVR(sklearnSVR):
     Attributes
     ----------
     data_ : ndarray, shape (n_matrices, n_channels, n_channels)
-        If fitted, training data.
+        If fitted, training matrices.
 
     Notes
     -----
@@ -187,7 +188,7 @@ class KNearestNeighborRegressor(RegressorMixin, MDM):
     values_ : ndarray, shape (n_matrices,)
         Training target values.
     covmeans_ : ndarray, shape (n_matrices, n_channels, n_channels)
-        Training set of SPD matrices.
+        Training matrices.
 
     Notes
     -----
@@ -206,7 +207,7 @@ class KNearestNeighborRegressor(RegressorMixin, MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             Target values for each matrix.
         sample_weight : None
@@ -229,7 +230,7 @@ class KNearestNeighborRegressor(RegressorMixin, MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Set of SPD matrices.
+            Set of SPD/HPD matrices.
 
         Returns
         -------
@@ -251,7 +252,7 @@ class KNearestNeighborRegressor(RegressorMixin, MDM):
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels)
-            Test set of SPD matrices.
+            Test set of SPD/HPD matrices.
         y : ndarray, shape (n_matrices,)
             True values for each matrix.
 

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -147,7 +147,7 @@ class Xdawn(TransformerMixin, BaseEstimator):
         -------
         X_new : ndarray, shape (n_trials, n_classes x min(n_channels, \
                 n_filters), n_times)
-            Set of spatialy filtered trials.
+            Set of spatially filtered trials.
         """
         return self.filters_ @ X
 
@@ -165,7 +165,7 @@ class Xdawn(TransformerMixin, BaseEstimator):
         -------
         X_new : ndarray, shape (n_trials, n_classes x min(n_channels, \
                 n_filters), n_times)
-            Set of spatialy filtered trials.
+            Set of spatially filtered trials.
         """
         return self.fit(X, y, sample_weight=sample_weight).transform(X)
 
@@ -240,7 +240,7 @@ class BilinearFilter(TransformerMixin, BaseEstimator):
         -------
         X_new : ndarray, shape (n_trials, n_filters) or \
                 ndarray, shape (n_trials, n_filters, n_filters)
-            Set of spatialy filtered log-variance or covariance, depending on
+            Set of spatially filtered log-variance or covariance, depending on
             the `log` input parameter.
         """
         if not isinstance(X, (np.ndarray, list)):
@@ -259,7 +259,7 @@ class BilinearFilter(TransformerMixin, BaseEstimator):
         else:
             return X_new
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y):
         """Fit and transform in a single function.
 
         Parameters
@@ -271,8 +271,10 @@ class BilinearFilter(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        X_new : ndarray, shape (n_matrices, n_elec, n_elec)
-            Set of SPD matrices after reduction of the number of channels.
+        X_new : ndarray, shape (n_trials, n_filters) or \
+                ndarray, shape (n_trials, n_filters, n_filters)
+            Set of spatially filtered log-variance or covariance, depending on
+            the `log` input parameter.
         """
         return self.fit(X, y).transform(X)
 

--- a/pyriemann/tangentspace.py
+++ b/pyriemann/tangentspace.py
@@ -8,7 +8,7 @@ from .utils.tangentspace import tangent_space, untangent_space
 from .utils.utils import check_metric
 
 
-class TangentSpace(BaseEstimator, TransformerMixin):
+class TangentSpace(TransformerMixin, BaseEstimator):
 
     """Tangent space projection.
 
@@ -211,7 +211,7 @@ class TangentSpace(BaseEstimator, TransformerMixin):
         return untangent_space(X, self.reference_, metric=self.metric_map)
 
 
-class FGDA(BaseEstimator, TransformerMixin):
+class FGDA(TransformerMixin, BaseEstimator):
 
     """Fisher geodesic discriminant analysis.
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -1273,5 +1273,4 @@ class MDWM(MDM):
             Mean accuracy of clf.predict(X) wrt. y_enc.
         """
         _, y_true, _ = decode_domains(X, y_enc)
-        y_pred = self.predict(X)
-        return accuracy_score(y_true, y_pred)
+        return super().score(X, y_true, sample_weight)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -73,8 +73,6 @@ def test_classifier(n_classes, classif, get_mats, get_labels, get_weights):
     clf_predict_proba(classif, mats, labels)
     clf_score(classif, mats, labels)
     clf_populate_classes(classif, mats, labels)
-    if classif in (MDM, KNearestNeighbor, MeanField):
-        clf_fitpredict(classif, mats, labels)
     if classif in (MDM, FgMDM, MeanField):
         clf_transform(classif, mats, labels)
         clf_fittransform(classif, mats, labels)
@@ -88,6 +86,7 @@ def clf_fit(classif, mats, labels, weights):
     n_classes = len(np.unique(labels))
     clf = classif().fit(mats, labels)
     assert clf.classes_.shape == (n_classes,)
+    assert_array_equal(clf.classes_, np.unique(labels))
 
     clf.fit(mats, labels, sample_weight=weights)
 
@@ -107,12 +106,6 @@ def clf_predict_proba(classif, mats, labels):
     proba = clf.fit(mats, labels).predict_proba(mats)
     assert proba.shape == (n_matrices, n_classes)
     assert proba.sum(axis=1) == approx(np.ones(n_matrices))
-
-
-def clf_fitpredict(classif, mats, labels):
-    clf = classif()
-    clf.fit_predict(mats, labels)
-    assert_array_equal(clf.classes_, np.unique(labels))
 
 
 def clf_score(classif, mats, labels):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -23,7 +23,7 @@ from pyriemann.classification import (
     class_distinctiveness,
 )
 
-rclf = [MDM, FgMDM, KNearestNeighbor, TSClassifier, SVC, MeanField]
+clfs = [MDM, FgMDM, KNearestNeighbor, TSClassifier, SVC, MeanField]
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ def test_mode(X, axis, expected):
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("n_classes", [2, 3])
-@pytest.mark.parametrize("classif", rclf)
+@pytest.mark.parametrize("classif", clfs)
 def test_classifier(kind, n_classes, classif,
                     get_mats, get_labels, get_weights):
     if kind == "hpd" and classif in [FgMDM, TSClassifier, SVC]:
@@ -155,7 +155,7 @@ def clf_tsupdate(classif, mats, labels):
     clf.fit(mats, labels).predict(mats)
 
 
-@pytest.mark.parametrize("classif", rclf)
+@pytest.mark.parametrize("classif", clfs)
 @pytest.mark.parametrize("mean", ["faulty", 42])
 @pytest.mark.parametrize("dist", ["not_real", 27])
 def test_metric_dict_error(classif, mean, dist, get_mats, get_labels):
@@ -167,7 +167,7 @@ def test_metric_dict_error(classif, mean, dist, get_mats, get_labels):
         clf.fit(mats, labels).predict(mats)
 
 
-@pytest.mark.parametrize("classif", rclf)
+@pytest.mark.parametrize("classif", clfs)
 @pytest.mark.parametrize("metric", [42, "faulty", {"foo": "bar"}])
 def test_metric_errors(classif, metric, get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
@@ -178,7 +178,7 @@ def test_metric_errors(classif, metric, get_mats, get_labels):
         clf.fit(mats, labels).predict(mats)
 
 
-@pytest.mark.parametrize("classif", rclf)
+@pytest.mark.parametrize("classif", clfs)
 @pytest.mark.parametrize("metric", get_metrics())
 def test_metric_str(classif, metric, get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -55,15 +55,19 @@ def test_mode(X, axis, expected):
         assert_array_equal(actual, sp.ravel())
 
 
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("n_classes", [2, 3])
 @pytest.mark.parametrize("classif", rclf)
-def test_classifier(n_classes, classif, get_mats, get_labels, get_weights):
+def test_classifier(kind, n_classes, classif,
+                    get_mats, get_labels, get_weights):
+    if kind == "hpd" and classif in [FgMDM, TSClassifier, SVC]:
+        pytest.skip()
     if n_classes == 2:
         n_matrices, n_channels = 6, 3
     else:
         assert n_classes == 3
         n_matrices, n_channels = 9, 3
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     labels = get_labels(n_matrices, n_classes)
     weights = get_weights(n_matrices)
 
@@ -431,16 +435,18 @@ def test_meanfield(get_mats, get_labels, power_list, method_label, metric):
     assert transf.shape == (n_matrices, n_classes)
 
 
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("n_classes", [1, 2, 3])
 @pytest.mark.parametrize("metric_mean", get_means())
 @pytest.mark.parametrize("metric_dist", get_distances())
 @pytest.mark.parametrize("exponent", [1, 2])
-def test_class_distinctiveness(n_classes, metric_mean, metric_dist, exponent,
-                               get_mats, get_labels):
+def test_class_distinctiveness(kind, n_classes, metric_mean, metric_dist,
+                               exponent, get_mats, get_labels):
     """Test function for class distinctiveness measure for two class problem"""
     n_matrices, n_channels = 6, 3
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     labels = get_labels(n_matrices, n_classes)
+
     if n_classes == 1:
         with pytest.raises(ValueError):
             class_distinctiveness(mats, labels)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -10,13 +10,15 @@ from pyriemann.clustering import (
     PotatoField,
 )
 
+clts = [Kmeans, KmeansPerClassTransform, Potato, PotatoField]
 
-@pytest.mark.parametrize(
-    "clust", [Kmeans, KmeansPerClassTransform, Potato, PotatoField]
-)
-def test_clustering_two_clusters(clust, get_mats, get_labels, get_weights):
+
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+@pytest.mark.parametrize("clust", clts)
+def test_clustering_two_clusters(kind, clust,
+                                 get_mats, get_labels, get_weights):
     n_clusters, n_matrices, n_channels = 2, 6, 4
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     weights = get_weights(n_matrices)
 
     if clust is Kmeans:
@@ -45,9 +47,9 @@ def test_clustering_two_clusters(clust, get_mats, get_labels, get_weights):
 
     if clust is PotatoField:
         n_potatoes = 3
-        mats = [get_mats(n_matrices, n_channels, "spd"),
-                get_mats(n_matrices, n_channels + 2, "spd"),
-                get_mats(n_matrices, n_channels + 1, "spd")]
+        mats = [get_mats(n_matrices, n_channels, kind),
+                get_mats(n_matrices, n_channels + 2, kind),
+                get_mats(n_matrices, n_channels + 1, kind)]
         clf_fit(clust, mats, weights)
         clf_transform(clust, mats, n_potatoes)
         clf_predict(clust, mats, n_potatoes)
@@ -56,12 +58,11 @@ def test_clustering_two_clusters(clust, get_mats, get_labels, get_weights):
         clf_fit_independence(clust, mats, n_potatoes)
 
 
-@pytest.mark.parametrize(
-    "clust", [Kmeans, KmeansPerClassTransform, Potato, PotatoField]
-)
-def test_clustering_three_clusters(clust, get_mats, get_labels):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+@pytest.mark.parametrize("clust", clts)
+def test_clustering_three_clusters(kind, clust, get_mats, get_labels):
     n_clusters, n_matrices, n_channels = 3, 6, 2
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
 
     if clust is Kmeans:
         clf_predict(clust, mats, n_clusters)
@@ -273,14 +274,14 @@ def test_potato_fit_error(y_fail, get_mats):
         Potato().fit(mats, y=y_fail)
 
 
-def test_potato_partial_fit_not_fitted(get_mats):
+def test_potato_partialfit_not_fitted(get_mats):
     n_matrices, n_channels = 6, 3
     mats = get_mats(n_matrices, n_channels, "spd")
     with pytest.raises(ValueError):  # potato not fitted
         Potato().partial_fit(mats)
 
 
-def test_potato_partial_fit_diff_channels(get_mats, get_labels):
+def test_potato_partialfit_diff_channels(get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
     mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
@@ -289,7 +290,7 @@ def test_potato_partial_fit_diff_channels(get_mats, get_labels):
         pt.partial_fit(get_mats(2, n_channels + 1, "spd"))
 
 
-def test_potato_partial_fit_no_poslabel(get_mats, get_labels):
+def test_potato_partialfit_no_poslabel(get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
     mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
@@ -299,7 +300,7 @@ def test_potato_partial_fit_no_poslabel(get_mats, get_labels):
 
 
 @pytest.mark.parametrize("alpha", [-0.1, 1.1])
-def test_potato_partial_fit_alpha(alpha, get_mats, get_labels):
+def test_potato_partialfit_alpha(alpha, get_mats, get_labels):
     n_matrices, n_channels, n_classes = 6, 3, 2
     mats = get_mats(n_matrices, n_channels, "spd")
     labels = get_labels(n_matrices, n_classes)
@@ -335,7 +336,7 @@ def test_potato_specific_labels(get_mats):
     pt.fit(mats, y=[2] * n_matrices)
 
 
-def test_potato_field_fit(get_mats):
+def test_potatofield_fit(get_mats):
     n_potatoes, n_matrices, n_channels = 2, 6, 3
     mats1 = get_mats(n_matrices, n_channels, "spd")
     mats2 = get_mats(n_matrices, n_channels + 1, "spd")
@@ -356,7 +357,7 @@ def test_potato_field_fit(get_mats):
 @pytest.mark.parametrize(
     "method", ["partial_fit", "transform", "predict_proba"]
 )
-def test_potato_field_method(get_mats, method):
+def test_potatofield_method(get_mats, method):
     n_potatoes, n_matrices, n_channels = 2, 6, 3
     mats1 = get_mats(n_matrices, n_channels, "spd")
     mats2 = get_mats(n_matrices, n_channels + 1, "spd")

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -20,6 +20,7 @@ def test_clustering_two_clusters(clust, get_mats, get_labels, get_weights):
     weights = get_weights(n_matrices)
 
     if clust is Kmeans:
+        clf_fit(clust, mats, weights)
         clf_predict(clust, mats, n_clusters)
         clf_transform(clust, mats, n_clusters)
         clf_jobs(clust, mats, n_clusters)
@@ -40,6 +41,7 @@ def test_clustering_two_clusters(clust, get_mats, get_labels, get_weights):
         clf_predict_proba(clust, mats)
         clf_partial_fit(clust, mats)
         clf_fit_independence(clust, mats)
+        clf_fittransform(clust, mats)
 
     if clust is PotatoField:
         n_potatoes = 3
@@ -87,7 +89,8 @@ def clf_fit(clust, mats, weights):
         n_channels = mats.shape[-1]
         assert clf.covmean_.shape == (n_channels, n_channels)
 
-    clf.fit(mats, sample_weight=weights)
+    if clust is not Kmeans:
+        clf.fit(mats, sample_weight=weights)
 
 
 def clf_transform(clust, mats, n_clusters=None):
@@ -193,6 +196,13 @@ def clf_fit_labels_independence(clust, mats, labels):
     # retraining with different size should erase previous fit
     new_mats = mats[:, :-1, :-1]
     clf.fit(new_mats, labels).transform(new_mats)
+
+
+def clf_fittransform(clust, mats):
+    clf = clust()
+    transf = clf.fit_transform(mats)
+    transf2 = clf.fit(mats).transform(mats)
+    assert_array_equal(transf, transf2)
 
 
 @pytest.mark.parametrize("clust", [Kmeans, KmeansPerClassTransform])

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -12,13 +12,16 @@ from pyriemann.embedding import (
 )
 from pyriemann.utils.kernel import kernel, kernel_functions
 
-rembd = [SpectralEmbedding, LocallyLinearEmbedding]
+embds = [SpectralEmbedding, LocallyLinearEmbedding]
 
 
-@pytest.mark.parametrize("embd", rembd)
-def test_embedding(embd, get_mats):
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
+@pytest.mark.parametrize("embd", embds)
+def test_embedding(kind, embd, get_mats):
+    if kind == "hpd" and embd is LocallyLinearEmbedding:
+        pytest.skip()
     n_matrices, n_channels, n_comp = 8, 3, 4
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
 
     embd_fit(embd, mats, n_comp)
     embd_fit_transform(embd, mats, n_comp)
@@ -103,7 +106,7 @@ def test_spectral_embedding_parameters(metric, eps, get_mats):
 
 
 @pytest.mark.parametrize("n_components", [2, 4, 100])
-@pytest.mark.parametrize("embd", rembd)
+@pytest.mark.parametrize("embd", embds)
 def test_embd_n_comp(n_components, embd, get_mats):
     n_matrices, n_channels = 8, 3
     mats = get_mats(n_matrices, n_channels, "spd")

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -12,10 +12,13 @@ from pyriemann.utils.mean import mean_covariance
 regs = [SVR, KNearestNeighborRegressor]
 
 
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("regres", regs)
-def test_regression(regres, get_mats, get_targets, get_weights):
+def test_regression(kind, regres, get_mats, get_targets, get_weights):
+    if kind == "hpd" and regres is SVR:
+        pytest.skip()
     n_matrices, n_channels = 6, 3
-    mats = get_mats(n_matrices, n_channels, "spd")
+    mats = get_mats(n_matrices, n_channels, kind)
     targets = get_targets(n_matrices)
     weights = get_weights(n_matrices)
 


### PR DESCRIPTION
Inheriting from sklearn classes and mixins, documentation of methods is not always adapted to pyRiemann data, and sometimes makes reference to `samples`  and `features`, instead of `matrices`  and `channels`.

For example, `fit_transform()` method of the `Covariance` class is documented as:
```
    Parameters:
        X : array-like of shape (n_samples, n_features)
            Input samples.
        y : array-like of shape (n_samples,) or (n_samples, n_outputs), default=None
            Target values (None for unsupervised transformations).
```
see https://pyriemann.readthedocs.io/en/latest/generated/pyriemann.estimation.Covariances.html#pyriemann.estimation.Covariances.fit_transform

This PR:
- completes documentation, especially for `fit_transform` methods;
- uses a specific mixin for the classifiers of SPD matrices, to share the doc of `score` method;
- completes tests and update doc for classification/clustering/regression/embedding classes supporting HPD matrices, continuing #204;
- deprecates `fit_predict` method for classifiers.