### PR TITLE
Generalize TSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and classifying them using the Riemannian geometry of SPD matrices [[1]](#1).
 
 For BCI applications, studied paradigms are motor imagery [[2]](#2) [[3]](#3),
 event-related potentials (ERP) [[4]](#4) and steady-state visually evoked potentials (SSVEP) [[5]](#5).
-Using extended labels, API allows transfer learning between sessions or subjects [[6]](#6).
+Using extended labels, API allows multisource transfer learning between sessions or subjects [[6]](#6).
 
 Another application is [remote sensing](https://en.wikipedia.org/wiki/Remote_sensing),
 estimating covariance matrices over spatial coordinates of radar images using a sliding window,

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -31,6 +31,9 @@ v0.8.dev
   and add parameters defining the normal distribution to draw eigen vectors.
   Deprecate ``generate_random_spd_matrix``. :pr:`339` by :user:`qbarthelemy`
 
+- Enhance TSA, adding weights to transformers, and generalizing :class:`pyriemann.classification.TLRotate` from
+  one-to-one to many-to-one domain adaptation in tangent space. :pr:`336` by :user:`qbarthelemy`
+
 v0.7 (October 2024)
 -------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -32,7 +32,7 @@ v0.8.dev
   Deprecate ``generate_random_spd_matrix``. :pr:`339` by :user:`qbarthelemy`
 
 - Enhance TSA, adding weights to transformers, and generalizing :class:`pyriemann.classification.TLRotate` from
-  one-to-one to many-to-one domain adaptation in tangent space. :pr:`336` by :user:`qbarthelemy`
+  one-to-one to many-to-one domain adaptation in tangent space. :pr:`337` by :user:`qbarthelemy`
 
 v0.7 (October 2024)
 -------------------

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -377,6 +377,8 @@ def make_classification_transfer(
     domain_names : list, default=["source_domain", "target_domain"]
         Names of domains, source and target.
 
+        .. versionadded:: 0.8
+
     Returns
     -------
     X_enc : ndarray, shape (4*n_matrices, 2, 2)
@@ -392,7 +394,6 @@ def make_classification_transfer(
     rs = check_random_state(random_state)
     seeds = rs.randint(100, size=4)
 
-    # the examples considered here are always for 2x2 matrices
     n_dim = 2
     if len(class_names) != 2:
         raise ValueError("class_names must contain 2 elements")

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -332,9 +332,17 @@ def make_outliers(n_matrices, mean, sigma, outlier_coeff=10,
     return outliers
 
 
-def make_classification_transfer(n_matrices, class_sep=3.0, class_disp=1.0,
-                                 domain_sep=5.0, theta=0.0, stretch=1.0,
-                                 random_state=None, class_names=[1, 2]):
+def make_classification_transfer(
+    n_matrices,
+    class_sep=3.0,
+    class_disp=1.0,
+    domain_sep=5.0,
+    theta=0.0,
+    stretch=1.0,
+    random_state=None,
+    class_names=[1, 2],
+    domain_names=["source_domain", "target_domain"],
+):
     """Generate 2x2 SPD matrices for two classes in source and target domains.
 
     Generate a set of 2x2 SPD matrices drawn from Riemannian Gaussian
@@ -366,6 +374,8 @@ def make_classification_transfer(n_matrices, class_sep=3.0, class_disp=1.0,
         Pass an int for reproducible output across multiple function calls.
     class_names : list, default=[1, 2]
         Names of classes.
+    domain_names : list, default=["source_domain", "target_domain"]
+        Names of domains, source and target.
 
     Returns
     -------
@@ -384,8 +394,10 @@ def make_classification_transfer(n_matrices, class_sep=3.0, class_disp=1.0,
 
     # the examples considered here are always for 2x2 matrices
     n_dim = 2
-    if len(class_names) != n_dim:
+    if len(class_names) != 2:
         raise ValueError("class_names must contain 2 elements")
+    if len(domain_names) != 2:
+        raise ValueError("domain_names must contain 2 elements")
 
     # create a source domain with two classes and global mean at identity
     M1_source = np.eye(n_dim)  # first class mean at Identity at first
@@ -455,7 +467,7 @@ def make_classification_transfer(n_matrices, class_sep=3.0, class_disp=1.0,
 
     # create array specifying the domain for each matrix
     domains = np.array(
-        len(X_source)*['source_domain'] + len(X_target)*['target_domain']
+        len(X_source) * [domain_names[0]] + len(X_target) * [domain_names[1]]
     )
 
     # encode the labels and domains together

--- a/pyriemann/datasets/simulated.py
+++ b/pyriemann/datasets/simulated.py
@@ -406,7 +406,8 @@ def make_classification_transfer(
         n_matrices=n_matrices,
         mean=M1_source,
         sigma=class_disp,
-        random_state=seeds[0])
+        random_state=seeds[0],
+    )
     y1_source = [class_names[0]] * n_matrices
     Pv = rs.randn(n_dim, n_dim)  # create random tangent vector
     Pv = (Pv + Pv.T)/2  # symmetrize
@@ -417,7 +418,8 @@ def make_classification_transfer(
         n_matrices=n_matrices,
         mean=M2_source,
         sigma=class_disp,
-        random_state=seeds[1])
+        random_state=seeds[1],
+    )
     y2_source = [class_names[1]] * n_matrices
     X_source = np.concatenate([X1_source, X2_source])
     M_source = mean_riemann(X_source)
@@ -431,12 +433,14 @@ def make_classification_transfer(
         n_matrices=n_matrices,
         mean=M1_source,
         sigma=class_disp,
-        random_state=seeds[2])
+        random_state=seeds[2],
+    )
     X2_target = sample_gaussian_spd(
         n_matrices=n_matrices,
         mean=M2_source,
         sigma=class_disp,
-        random_state=seeds[3])
+        random_state=seeds[3],
+    )
     X_target = np.concatenate([X1_target, X2_target])
     M_target = mean_riemann(X_target)
     M_target_invsqrt = invsqrtm(M_target)

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -566,7 +566,8 @@ class TLRotate(TransformerMixin, BaseEstimator):
     target_domain : str
         Domain to consider as target.
     weights : None | array, shape (n_classes,), default=None
-        Weights to assign for each class. If None, it uses equal weights.
+        For inputs in manifold, weights to assign for each class.
+        If None, it uses equal weights.
     metric : {"euclid", "riemann"}, default="euclid"
         For inputs in manifold, distance to minimize between class means.
     n_jobs : int, default=1

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -565,7 +565,7 @@ class TLRotate(TransformerMixin, BaseEstimator):
     ----------
     target_domain : str
         Domain to consider as target.
-    weights : None | array, shape (n_classes,), default=None
+    weights : None | ndarray, shape (n_classes,), default=None
         For inputs in manifold, weights to assign for each class.
         If None, it uses equal weights.
     metric : {"euclid", "riemann"}, default="euclid"
@@ -700,7 +700,7 @@ class TLRotate(TransformerMixin, BaseEstimator):
                     ) for label in np.unique(y_enc[domains == d])
                 ]),
                 M_target,
-                self.weights,
+                weights=self.weights,
                 metric=self.metric,
             ) for d in source_domains
         )

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -210,9 +210,11 @@ def _get_rotation_manifold(
         N. Boumal. To appear with Cambridge University Press. June, 2022
     """
     if X_source.shape[0] != X_target.shape[0]:
-        raise ValueError("Number of matrices in each domain doesn't match")
+        raise ValueError("Number of matrices in each domain doesn't match. "
+                         f"Got {X_source.shape[0]} and {X_target.shape[0]}.")
     if X_source.shape[1:] != X_target.shape[1:]:
-        raise ValueError("Number of channels in each domain doesn't match")
+        raise ValueError("Number of channels in each domain doesn't match. "
+                         f"Got {X_source.shape[1:]} and {X_target.shape[1:]}.")
     weights = check_weights(weights, len(X_source))
 
     # initialize the solution with an educated guess
@@ -297,7 +299,8 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
         2022
     """
     if X_source.shape != X_target.shape:
-        raise ValueError("Inputs shapes don't match")
+        raise ValueError("Inputs shapes don't match. "
+                         f"Got {X_source.shape} and {X_target.shape}.")
 
     C = X_source.T @ X_target
     u, s, vh = np.linalg.svd(C)

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -213,7 +213,6 @@ def _get_rotation_manifold(
         raise ValueError("Number of matrices in each domain doesn't match")
     if X_source.shape[1:] != X_target.shape[1:]:
         raise ValueError("Number of channels in each domain doesn't match")
-
     weights = check_weights(weights, len(X_source))
 
     # initialize the solution with an educated guess

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -177,7 +177,7 @@ def _get_rotation_manifold(
         Set of SPD matrices from the source domain.
     X_target : ndarray, shape (n_matrices, n, n)
         Set of SPD matrices from the target domain.
-    weights : None | array, shape (n_matrices,), default=None
+    weights : None | ndarray, shape (n_matrices,), default=None
         Weights for each pair of matrices. If None, it uses equal weights.
     metric : {"euclid", "riemann"}, default="euclid"
         Distance to minimize between SPD matrices.
@@ -209,11 +209,10 @@ def _get_rotation_manifold(
         <https://www.nicolasboumal.net/book/>`_
         N. Boumal. To appear with Cambridge University Press. June, 2022
     """
-
     if X_source.shape[0] != X_target.shape[0]:
-        raise ValueError("The number of matrices in each domain don't match")
+        raise ValueError("Number of matrices in each domain doesn't match")
     if X_source.shape[1:] != X_target.shape[1:]:
-        raise ValueError("The number of channels in each domain don't match")
+        raise ValueError("Number of channels in each domain doesn't match")
 
     weights = check_weights(weights, len(X_source))
 
@@ -298,6 +297,9 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
         A. Bleuzé, J. Mattout and M. Congedo, Frontiers in Human Neuroscience,
         2022
     """
+    if X_source.shape != X_target.shape:
+        raise ValueError("Inputs shapes don't match")
+
     C = X_source.T @ X_target
     u, s, vh = np.linalg.svd(C)
 

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -181,7 +181,7 @@ def _get_rotation_manifold(
         Weights for each pair of matrices. If None, it uses equal weights.
     metric : {"euclid", "riemann"}, default="euclid"
         Distance to minimize between SPD matrices.
-    tol_step : float, default 1e-9
+    tol_step : float, default=1e-9
         Stopping criterion based on the norm of the descent direction.
     maxiter : int, default=10_000
         Maximum number of iterations in the optimization procedure.

--- a/pyriemann/transfer/_rotate.py
+++ b/pyriemann/transfer/_rotate.py
@@ -263,15 +263,15 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
     matrix :math:`\mathbf{Q}` that minimizes:
 
     .. math::
-        || X^\text{source} Q -  X^\text{target} ||_F^2
+        || X^\text{source} Q - X^\text{target} ||_F^2
 
     From code provided by the authors [1]_.
 
     Parameters
     ----------
-    X_source : ndarray, shape (n_vectors, n_ts)
+    X_source : ndarray, shape (n_vectors, n)
         Set of tangent vectors from the source domain.
-    X_target : ndarray, shape (n_vectors, n_ts)
+    X_target : ndarray, shape (n_vectors, n)
         Set of tangent vectors from the target domain.
     expl_var : float
         Dimension reduction applied to the cross product matrix during
@@ -281,7 +281,7 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
 
     Returns
     -------
-    Q : ndarray, shape (n_ts, n_ts)
+    Q : ndarray, shape (n, n)
         Orthogonal matrix that minimizes the distance between the tangent
         vectors for the source and target domains.
 

--- a/pyriemann/transfer/_tools.py
+++ b/pyriemann/transfer/_tools.py
@@ -2,12 +2,12 @@ import numpy as np
 
 
 def encode_domains(X, y, domain):
-    r"""Encode the domains of the data in the labels.
+    """Encode the domains of the data in the labels.
 
     We handle the possibility of having different domains for the datasets by
     extending the labels of the data and including this information to them.
-    For instance, if we have a datum X with class `left_hand` on the
-    `domain_01` then its extended label will be `domain_01/left_hand`.
+    For instance, if we have a datum X with class ``left_hand`` on the
+    ``domain_01`` then its extended label will be ``domain_01/left_hand``.
     Note that if the classes were integers at first, they will be converted to
     strings.
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -43,21 +43,21 @@ rndstate = 1234
 ###############################################################################
 
 
-def make_classification_transfer_tangspace(rndstate, n_vectors_d=50, n_ts=10):
-    n_vectors = 2 * n_vectors_d
+def make_classification_transfer_tangspace(rndstate, domains,
+                                           n_vectors_d, n_ts):
+    n_vectors = n_vectors_d * len(domains)
     X = rndstate.randn(n_vectors, n_ts)
     y = rndstate.randint(0, 3, size=n_vectors)
-    domains = np.array(n_vectors_d * ["src"] + n_vectors_d * ["tgt"])
+    domains = np.repeat(domains, n_vectors_d)
     _, y_enc = encode_domains(X, y, domains)
     return X, y_enc
 
 
-def make_regression_transfer(rndstate, n_matrices, n_channels):
+def make_regression_transfer(rndstate, domains, n_matrices, n_channels):
     X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
     y = rndstate.randn(n_matrices)
-    domain = ["source_domain"] * (n_matrices // 2) \
-        + ["target_domain"] * (n_matrices // 2)
-    _, y_enc = encode_domains(X, y, domain)
+    domains = np.repeat(domains, n_matrices // len(domains))
+    _, y_enc = encode_domains(X, y, domains)
     return X, y_enc
 
 
@@ -92,7 +92,10 @@ def test_encode_decode_domains(rndstate):
 def test_tlsplitter(rndstate, cv):
     """Test wrapper for cross-validation"""
     X, y_enc = make_classification_transfer(
-        n_matrices=25, class_sep=5, class_disp=1.0, random_state=rndstate
+        n_matrices=25,
+        class_sep=5,
+        class_disp=1.0,
+        random_state=rndstate,
     )
 
     cv = TLSplitter(target_domain="target_domain", cv=cv)
@@ -109,7 +112,8 @@ def test_tlsplitter(rndstate, cv):
 @pytest.mark.parametrize("space", ["manifold", "tangentspace"])
 def test_tldummy(rndstate, space):
     X, y_enc = make_classification_transfer(
-        n_matrices=5, random_state=rndstate
+        n_matrices=5,
+        random_state=rndstate,
     )
     if space == "tangentspace":
         X = tangent_space(X, Cref=mean_riemann(X), metric="riemann")
@@ -127,7 +131,8 @@ def test_tlcenter_manifold(rndstate, get_weights,
                            metric, use_weight, target_domain):
     """Test centering matrices to identity"""
     X, y_enc = make_classification_transfer(
-        n_matrices=25, random_state=rndstate
+        n_matrices=25,
+        random_state=rndstate,
     )
     if use_weight:
         weights = get_weights(len(y_enc))
@@ -172,7 +177,8 @@ def test_tlcenter_manifold_fit_transf(rndstate, get_weights,
                                       metric, use_weight, target_domain):
     """Test .fit_transform() versus .fit().transform()"""
     X, y_enc = make_classification_transfer(
-        n_matrices=25, random_state=rndstate
+        n_matrices=25,
+        random_state=rndstate,
     )
     if use_weight:
         weights = get_weights(len(y_enc))
@@ -204,25 +210,34 @@ def test_tlcenter_manifold_fit_transf(rndstate, get_weights,
         assert Md == pytest.approx(np.eye(2))
 
 
-def test_tlcenter_tangentspace(rndstate):
+@pytest.mark.parametrize("use_weight", [True, False])
+def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
     """Test centering tangent vectors to origin"""
-    n_vectors_d, n_ts = 50, 10
+    n_ts = 10
     X, y_enc = make_classification_transfer_tangspace(
-        rndstate, n_vectors_d, n_ts
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_vectors_d=50,
+        n_ts=n_ts,
     )
+    if use_weight:
+        weights = get_weights(len(y_enc))
+    else:
+        weights = None
 
     _, _, domain = decode_domains(X, y_enc)
 
     tlctr = TLCenter(target_domain="tgt")
 
-    tlctr.fit(X, y_enc)
+    tlctr.fit(X, y_enc, sample_weight=weights)
 
     # Test if the mean of each domain is indeed zero
-    X_rct = tlctr.fit_transform(X, y_enc)
+    X_rct = tlctr.fit_transform(X, y_enc, sample_weight=weights)
     assert X_rct.shape == X.shape
     for d in np.unique(domain):
         idx = domain == d
-        md = np.mean(X_rct[idx], axis=0)
+        weights_d = weights[idx] if weights is not None else None
+        md = np.average(X_rct[idx], axis=0, weights=weights_d)
         assert_array_almost_equal(md, np.zeros((n_ts)))
 
     X_rct = tlctr.transform(X)
@@ -236,7 +251,9 @@ def test_tlscale_manifold(rndstate, get_weights,
                           use_centered_data, metric, use_weight):
     """Test scaling matrices to a target dispersion"""
     X, y_enc = make_classification_transfer(
-        n_matrices=25, class_disp=2.0, random_state=rndstate
+        n_matrices=25,
+        class_disp=2.0,
+        random_state=rndstate,
     )
     if use_weight:
         weights = get_weights(len(y_enc))
@@ -281,25 +298,36 @@ def test_tlscale_manifold(rndstate, get_weights,
         assert issubclass(w[-1].category, DeprecationWarning)
 
 
-def test_tlscale_tangentspace(rndstate):
+@pytest.mark.parametrize("use_weight", [True, False])
+def test_tlscale_tangentspace(rndstate, get_weights, use_weight):
     """Test scaling vectors to unit norm"""
-    n_vectors_d, n_ts = 50, 10
+    n_ts = 10
     X, y_enc = make_classification_transfer_tangspace(
-        rndstate, n_vectors_d, n_ts
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_vectors_d=50,
+        n_ts=n_ts,
     )
+    if use_weight:
+        weights = get_weights(len(y_enc))
+    else:
+        weights = None
 
     _, _, domain = decode_domains(X, y_enc)
 
     tlscl = TLScale(target_domain="tgt")
 
-    tlscl.fit(X, y_enc)
+    tlscl.fit(X, y_enc, sample_weight=weights)
 
     # Test if the mean of norms of each domain is indeed 1
-    X_scl = tlscl.fit_transform(X, y_enc)
+    X_scl = tlscl.fit_transform(X, y_enc, sample_weight=weights)
     assert X_scl.shape == X.shape
     for d in np.unique(domain):
         idx = domain == d
-        assert np.mean(np.linalg.norm(X_scl[idx], axis=1)) == pytest.approx(1)
+        weights_d = weights[idx] if weights is not None else None
+        assert np.average(
+            np.linalg.norm(X_scl[idx], axis=1), weights=weights_d
+        ) == pytest.approx(1)
 
     X_scl = tlscl.transform(X)
     assert X_scl.shape == X.shape
@@ -365,12 +393,21 @@ def test_tlrotate_manifold(rndstate, get_weights, metric, use_weight):
 
 @pytest.mark.parametrize("n_components", [1, 3, "max"])
 @pytest.mark.parametrize("n_clusters", [1, 2, 5])
-def test_tlrotate_tangentspace(rndstate, n_components, n_clusters):
+@pytest.mark.parametrize("use_weight", [True, False])
+def test_tlrotate_tangentspace(rndstate, get_weights,
+                               n_components, n_clusters, use_weight):
     """Test rotating vectors"""
-    n_vectors_d, n_ts = 50, 10
+    n_ts = 10
     X, y_enc = make_classification_transfer_tangspace(
-        rndstate, n_vectors_d, n_ts
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_vectors_d=50,
+        n_ts=n_ts,
     )
+    if use_weight:
+        weights = get_weights(len(y_enc))
+    else:
+        weights = None
 
     _, _, domain = decode_domains(X, y_enc)
 
@@ -380,10 +417,11 @@ def test_tlrotate_tangentspace(rndstate, n_components, n_clusters):
         n_clusters=n_clusters,
     )
 
-    tlrot.fit(X, y_enc)
-    assert tlrot.rotations_.shape == (n_ts, n_ts)
+    tlrot.fit(X, y_enc, sample_weight=weights)
+    for k in tlrot.rotations_.keys():
+        assert tlrot.rotations_[k].shape == (n_ts, n_ts)
 
-    X_rot = tlrot.fit_transform(X, y_enc)
+    X_rot = tlrot.fit_transform(X, y_enc, sample_weight=weights)
     assert X_rot.shape == X.shape
     assert_array_equal(
         X_rot[domain == "target_domain"],
@@ -405,14 +443,12 @@ def test_tlrotate_tangentspace(rndstate, n_components, n_clusters):
     ]
 )
 @pytest.mark.parametrize(
-    "source_weight, target_weight",
-    [(1.0, 0.0), (0.0, 1.0), (1.0, 1.0)],
+    "source_weight, target_weight", [(1, 0), (0, 1), (1, 1)],
 )
 def test_tlclassifier_mdm(rndstate, clf, source_weight, target_weight):
     """Test wrapper for MDM classifier"""
-    n_matrices = 40
     X, y_enc = make_classification_transfer(
-        n_matrices=n_matrices // 4,
+        n_matrices=10,
         class_sep=5,
         class_disp=1.0,
         random_state=rndstate,
@@ -466,44 +502,35 @@ def test_tlclassifier_mdm(rndstate, clf, source_weight, target_weight):
         make_pipeline(MeanField(metric="logeuclid")),
     ]
 )
-@pytest.mark.parametrize(
-    "source_weight, target_weight",
-    [(1.0, 0.0), (0.0, 1.0), (1.0, 1.0)],
-)
-def test_tlclassifier_manifold(rndstate, clf, source_weight, target_weight):
+@pytest.mark.parametrize("domains_weight", [(1, 0), (0, 1), (1, 1)])
+def test_tlclassifier_manifold(rndstate, clf, domains_weight):
     """Test wrapper for classifiers in manifold"""
-    n_matrices = 40
     X, y_enc = make_classification_transfer(
-        n_matrices=n_matrices // 4,
+        n_matrices=10,
         class_sep=5,
         class_disp=1.0,
         random_state=rndstate,
     )
 
-    tlclassifier(clf, X, y_enc, source_weight, target_weight)
+    tlclassifier(clf, X, y_enc, domains_weight)
 
 
 @pytest.mark.parametrize("clf", [LinearSVC(), LogisticRegression()])
-@pytest.mark.parametrize(
-    "source_weight, target_weight",
-    [(1.0, 0.0), (0.0, 1.0), (1.0, 1.0)],
-)
-def test_tlclassifier_tangentspace(rndstate,
-                                   clf, source_weight, target_weight):
+@pytest.mark.parametrize("domains_weight", [(1, 0), (0, 1), (1, 1)])
+def test_tlclassifier_tangentspace(rndstate, clf, domains_weight):
     """Test wrapper for classifiers in tangent space"""
-    n_matrices = 40
     X, y_enc = make_classification_transfer(
-        n_matrices=n_matrices // 4,
+        n_matrices=10,
         class_sep=5,
         class_disp=1.0,
         random_state=rndstate,
     )
     X = tangent_space(X, Cref=mean_riemann(X), metric="riemann")
 
-    tlclassifier(clf, X, y_enc, source_weight, target_weight)
+    tlclassifier(clf, X, y_enc, domains_weight)
 
 
-def tlclassifier(clf, X, y_enc, source_weight, target_weight, n_classes=2):
+def tlclassifier(clf, X, y_enc, domains_weight, n_classes=2):
     n_inputs = X.shape[0]
 
     if hasattr(clf, "probability"):
@@ -512,8 +539,8 @@ def tlclassifier(clf, X, y_enc, source_weight, target_weight, n_classes=2):
         target_domain="target_domain",
         estimator=clf,
         domain_weight={
-            "source_domain": source_weight,
-            "target_domain": target_weight,
+            "source_domain": domains_weight[0],
+            "target_domain": domains_weight[1],
         },
     )
 
@@ -543,46 +570,46 @@ def tlclassifier(clf, X, y_enc, source_weight, target_weight, n_classes=2):
         SVR(metric="riemann"),
     ]
 )
-@pytest.mark.parametrize(
-    "source_weight, target_weight",
-    [(1.0, 0.0), (0.0, 1.0), (1.0, 1.0)],
-)
-def test_tlregressor_manifold(rndstate, reg, source_weight, target_weight):
+@pytest.mark.parametrize("domains_weights", [(1, 0, 0), (0, 1, 1), (1, 1, 1)])
+def test_tlregressor_manifold(rndstate, reg, domains_weights):
     """Test wrapper for regressors in manifold"""
-    n_matrices, n_channels = 40, 2
     X, y_enc = make_regression_transfer(
-        rndstate, n_matrices=n_matrices, n_channels=n_channels
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_matrices=30,
+        n_channels=2,
     )
 
-    tlregressor(reg, X, y_enc, source_weight, target_weight)
+    tlregressor(reg, X, y_enc, domains_weights)
 
 
 @pytest.mark.parametrize("reg", [LinearSVR(), LinearRegression()])
-@pytest.mark.parametrize(
-    "source_weight, target_weight",
-    [(1.0, 0.0), (0.0, 1.0), (1.0, 1.0)],
-)
-def test_tlregressor_tangentspace(rndstate, reg, source_weight, target_weight):
+@pytest.mark.parametrize("domains_weights", [(1, 0, 0), (0, 1, 1), (1, 1, 1)])
+def test_tlregressor_tangentspace(rndstate, reg, domains_weights):
     """Test wrapper for regressors in tangent space"""
-    n_matrices, n_channels = 40, 2
     X, y_enc = make_regression_transfer(
-        rndstate, n_matrices=n_matrices, n_channels=n_channels
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_matrices=30,
+        n_channels=2,
     )
     X = tangent_space(X, Cref=mean_riemann(X), metric="riemann")
 
-    tlregressor(reg, X, y_enc, source_weight, target_weight)
+    tlregressor(reg, X, y_enc, domains_weights)
 
 
-def tlregressor(reg, X, y_enc, source_weight, target_weight):
+def tlregressor(reg, X, y_enc, domains_weights):
     n_inputs = X.shape[0]
+    _, _, domains = decode_domains(X, y_enc)
+    domains = np.unique(domains)
+    domain_weight = {}
+    for d, w in zip(domains, domains_weights):
+        domain_weight[d] = w
 
     tlreg = TLRegressor(
         target_domain="target_domain",
         estimator=reg,
-        domain_weight={
-            "source_domain": source_weight,
-            "target_domain": target_weight,
-        },
+        domain_weight=domain_weight,
     )
 
     # test fit
@@ -669,11 +696,13 @@ def test_mdwm_weights(rndstate, get_weights):
         class_disp=1.0,
         random_state=rndstate,
     )
-    weights = get_weights(n_matrices // n_classes)
 
     clf = MDWM(
         domain_tradeoff=0.4,
         target_domain="target_domain",
         metric="riemann",
     )
-    clf.fit(X, y_enc, sample_weight=weights)
+
+    clf.fit(X, y_enc, sample_weight=get_weights(n_matrices // n_classes))
+
+    clf.score(X, y_enc, sample_weight=get_weights(n_matrices))

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -365,7 +365,7 @@ def test_tlrotate_manifold(rndstate, get_weights, metric, use_weight):
         X_rot[domain == "target_domain"],
         X_rct[domain == "target_domain"],
     )
-    
+
     matrix_weight = check_weights(matrix_weight, len(y_enc))
 
     # check if the distance between the classes of each domain is reduced


### PR DESCRIPTION
This PR generalizes TSA:

- adding weights to transformers in tangent space,
- generalizing `TLRotate` for multiple source domains in tangent space, ie from one-to-one to many-to-one transfer learning.