### PR TITLE
Improve kernels

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,7 +35,7 @@ v0.8.dev
   one-to-one to many-to-one domain adaptation in tangent space. :pr:`337` by :user:`qbarthelemy`
 
 - Enhance :func:`pyriemann.utils.kernel.kernel_logeuclid` adding ``Cref`` parameter,
-  and correct :func:`pyriemann.utils.kernel.kernel_riemann` when ``Y`` is different from ``X`` and ``Cref`` is None. :pr:`338` by :user:`qbarthelemy`
+  and correct :func:`pyriemann.utils.kernel.kernel_riemann` when ``Y`` is different from ``X`` and ``Cref`` is None. :pr:`340` by :user:`qbarthelemy`
 
 v0.7 (October 2024)
 -------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,6 +34,9 @@ v0.8.dev
 - Enhance TSA, adding weights to transformers, and generalizing :class:`pyriemann.classification.TLRotate` from
   one-to-one to many-to-one domain adaptation in tangent space. :pr:`337` by :user:`qbarthelemy`
 
+- Enhance :func:`pyriemann.utils.kernel.kernel_logeuclid` adding ``Cref`` parameter,
+  and correct :func:`pyriemann.utils.kernel.kernel_riemann` when ``Y`` is different from ``X`` and ``Cref`` is None. :pr:`338` by :user:`qbarthelemy`
+
 v0.7 (October 2024)
 -------------------
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,7 +34,7 @@ v0.8.dev
 - Enhance TSA, adding weights to transformers, and generalizing :class:`pyriemann.classification.TLRotate` from
   one-to-one to many-to-one domain adaptation in tangent space. :pr:`337` by :user:`qbarthelemy`
 
-- Enhance :func:`pyriemann.utils.kernel.kernel_logeuclid` adding ``Cref`` parameter,
+- Enhance :func:`pyriemann.utils.kernel.kernel_euclid` and :func:`pyriemann.utils.kernel.kernel_logeuclid` adding ``Cref`` parameter,
   and correct :func:`pyriemann.utils.kernel.kernel_riemann` when ``Y`` is different from ``X`` and ``Cref`` is None. :pr:`340` by :user:`qbarthelemy`
 
 v0.7 (October 2024)

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -110,7 +110,7 @@ def kernel_logeuclid(X, Y=None, *, Cref=None, reg=1e-10):
     """
     def kernelfct(X, Cref):
         if Cref is None:
-            return logm(X), np.eye(X.shape[-1])
+            return logm(X), Cref
         else:
             return logm(X) - logm(Cref), Cref
 

--- a/pyriemann/utils/kernel.py
+++ b/pyriemann/utils/kernel.py
@@ -10,9 +10,9 @@ from .utils import check_function
 def kernel_euclid(X, Y=None, *, reg=1e-10, **kwargs):
     r"""Euclidean kernel between two sets of matrices.
 
-    Calculates the Euclidean kernel matrix :math:`\mathbf{K}` of inner products
-    of two sets :math:`\mathbf{X}` and :math:`\mathbf{Y}` of matrices in
-    :math:`\mathbb{R}^{n \times m}` by calculating pairwise products:
+    Euclidean kernel matrix :math:`\mathbf{K}` of two sets
+    :math:`\mathbf{X}` and :math:`\mathbf{Y}` of matrices in
+    :math:`\mathbb{R}^{n \times m}` is calculated with pairwise inner products:
 
     .. math::
         \mathbf{K}_{i,j} = \text{tr}(\mathbf{X}_i^T \mathbf{Y}_j)
@@ -41,18 +41,27 @@ def kernel_euclid(X, Y=None, *, reg=1e-10, **kwargs):
     kernel
     """
     def kernelfct(X, Cref):
-        return X
+        return X, Cref
 
     return _apply_matrix_kernel(kernelfct, X, Y, reg=reg)
 
 
-def kernel_logeuclid(X, Y=None, *, reg=1e-10, **kwargs):
+def kernel_logeuclid(X, Y=None, *, Cref=None, reg=1e-10):
     r"""Log-Euclidean kernel between two sets of SPD matrices.
 
-    Calculates the log-Euclidean kernel matrix :math:`\mathbf{K}` of inner
-    products of two sets :math:`\mathbf{X}` and :math:`\mathbf{Y}` of SPD
-    matrices in :math:`\mathbb{R}^{n \times n}` by calculating pairwise
-    products [1]_:
+    Log-Euclidean kernel matrix :math:`\mathbf{K}` of two sets
+    :math:`\mathbf{X}` and :math:`\mathbf{Y}` of SPD matrices in
+    :math:`\mathbb{R}^{n \times n}` on tangent space at
+    :math:`\mathbf{C}_\text{ref}` is calculated with pairwise inner products
+    [1]_:
+
+    .. math::
+        \mathbf{K}_{i,j} = \text{tr}(
+        (\log(\mathbf{X}_i) - \log(\mathbf{C}_\text{ref}))
+        (\log(\mathbf{Y}_j) - \log(\mathbf{C}_\text{ref}))
+        )
+
+    If :math:`\mathbf{C}_\text{ref}` is None [2]_:
 
     .. math::
         \mathbf{K}_{i,j} = \text{tr}(\log(\mathbf{X}_i) \log(\mathbf{Y}_j))
@@ -63,6 +72,11 @@ def kernel_logeuclid(X, Y=None, *, reg=1e-10, **kwargs):
         First set of SPD matrices.
     Y : None | ndarray, shape (n_matrices_Y, n, n), default=None
         Second set of SPD matrices. If None, Y is set to X.
+    Cref : None | ndarray, shape (n, n), default=None
+        Reference SPD matrix.
+        If None, Cref is defined as identity matrix.
+
+        .. versionadded:: 0.8
     reg : float, default=1e-10
         Regularization parameter to mitigate numerical errors in kernel
         matrix estimation.
@@ -75,6 +89,8 @@ def kernel_logeuclid(X, Y=None, *, reg=1e-10, **kwargs):
     Notes
     -----
     .. versionadded:: 0.3
+    .. versionchanged:: 0.8
+        Add parameter Cref to use a reference matrix.
 
     See Also
     --------
@@ -82,28 +98,37 @@ def kernel_logeuclid(X, Y=None, *, reg=1e-10, **kwargs):
 
     References
     ----------
-    .. [1] `Classification of covariance matrices using a Riemannian-based
-        kernel for BCI applications
-        <https://hal.archives-ouvertes.fr/hal-00820475/>`_
-        A. Barachant, S. Bonnet, M. Congedo and C. Jutten. Neurocomputing,
-        Elsevier, 2013, 112, pp.172-178.
+    .. [1] `A New Canonical Log-Euclidean Kernel for Symmetric Positive
+        Definite Matrices for EEG Analysis
+        <https://ieeexplore.ieee.org/iel8/10/4359967/10735221.pdf>`_
+        G. L. W. vom Berg, V. Rohr, D. Platt and B. Blankertz.
+        IEEE Transactions on Biomedical Engineering, 2024
+    .. [2] `Factor analysis based spatial correlation modeling for speaker
+        verification
+        <https://ieeexplore.ieee.org/abstract/document/5684490>`_
+        E. Wang, W. Guo, L. Dai, K. Lee, B. Ma and H. Li. IEEE ISCSLP, 2010
     """
     def kernelfct(X, Cref):
-        return logm(X)
+        if Cref is None:
+            return logm(X), np.eye(X.shape[-1])
+        else:
+            return logm(X) - logm(Cref), Cref
 
-    return _apply_matrix_kernel(kernelfct, X, Y, reg=reg)
+    return _apply_matrix_kernel(kernelfct, X, Y, Cref=Cref, reg=reg)
 
 
 def kernel_riemann(X, Y=None, *, Cref=None, reg=1e-10):
     r"""Affine-invariant Riemannian kernel between two sets of SPD matrices.
 
-    Calculates the affine-invariant Riemannian kernel matrix :math:`\mathbf{K}`
-    of inner products of two sets :math:`\mathbf{X}` and :math:`\mathbf{Y}` of
-    SPD matrices in :math:`\mathbb{R}^{n \times n}` on tangent space at
-    :math:`\mathbf{C}_\text{ref}` by calculating pairwise products [1]_:
+    Affine-invariant Riemannian kernel matrix :math:`\mathbf{K}` of two sets
+    :math:`\mathbf{X}` and :math:`\mathbf{Y}` of SPD matrices in
+    :math:`\mathbb{R}^{n \times n}` on tangent space at
+    :math:`\mathbf{C}_\text{ref}` is calculated with pairwise inner products
+    [1]_:
 
     .. math::
-        \mathbf{K}_{i,j} = \text{tr}( \log( \mathbf{C}_\text{ref}^{-1/2}
+        \mathbf{K}_{i,j} = \text{tr}(
+        \log( \mathbf{C}_\text{ref}^{-1/2}
         \mathbf{X}_i \mathbf{C}_\text{ref}^{-1/2} )
         \log( \mathbf{C}_\text{ref}^{-1/2} \mathbf{Y}_j
         \mathbf{C}_\text{ref}^{-1/2}) )
@@ -115,8 +140,9 @@ def kernel_riemann(X, Y=None, *, Cref=None, reg=1e-10):
     Y : None | ndarray, shape (n_matrices_Y, n, n), default=None
         Second set of SPD matrices. If None, Y is set to X.
     Cref : None | ndarray, shape (n, n), default=None
-        Reference point for the tangent space and inner product calculation.
-        If None, Cref is calculated as the Riemannian mean of X.
+        Reference SPD matrix.
+        If None, Cref is calculated as the Riemannian mean of X, see
+        :func:`pyriemann.utils.mean.mean_riemann`.
     reg : float, default=1e-10
         Regularization parameter to mitigate numerical errors in kernel
         matrix estimation.
@@ -148,7 +174,7 @@ def kernel_riemann(X, Y=None, *, Cref=None, reg=1e-10):
 
         C_invsq = invsqrtm(Cref)
         X_ = logm(C_invsq @ X @ C_invsq)
-        return X_
+        return X_, Cref
 
     return _apply_matrix_kernel(kernelfct, X, Y, Cref=Cref, reg=reg)
 
@@ -159,14 +185,14 @@ def kernel_riemann(X, Y=None, *, Cref=None, reg=1e-10):
 def _check_dimensions(X, Y, Cref):
     """Check for matching dimensions in X, Y and Cref."""
     if not isinstance(Y, type(None)):
-        assert Y.shape[1:] == X.shape[1:], f"Dimension of matrices in Y must "\
-                                           f"match dimension of matrices in " \
+        assert Y.shape[1:] == X.shape[1:], "Dimension of matrices in Y must "\
+                                           "match dimension of matrices in " \
                                            f"X. Expected {X.shape[1:]}, got " \
                                            f"{Y.shape[1:]}."
 
     if not isinstance(Cref, type(None)):
-        assert Cref.shape == X.shape[1:], f"Dimension of Cref must match " \
-                                          f"dimension of matrices in X. " \
+        assert Cref.shape == X.shape[1:], "Dimension of Cref must match " \
+                                          "dimension of matrices in X. " \
                                           f"Expected {X.shape[1:]}, got " \
                                           f"{Cref.shape}."
 
@@ -176,12 +202,12 @@ def _apply_matrix_kernel(kernel_fct, X, Y=None, *, Cref=None, reg=1e-10):
     _check_dimensions(X, Y, Cref)
     n_matrices_X, n, n = X.shape
 
-    X_ = kernel_fct(X, Cref)
+    X_, Cref = kernel_fct(X, Cref)
 
-    if isinstance(Y, type(None)) or np.array_equal(X, Y):
+    if Y is None or np.array_equal(X, Y):
         Y_ = X_
     else:
-        Y_ = kernel_fct(Y, Cref)
+        Y_, _ = kernel_fct(Y, Cref)
 
     # calculate scalar products: K[i,j] = np.trace(X_[i]^T @ Y_[j])
     X_T = X_.transpose((0, 2, 1))
@@ -202,10 +228,12 @@ kernel_functions = {
 
 
 def kernel(X, Y=None, *, Cref=None, metric="riemann", reg=1e-10):
-    """Kernel matrix between matrices according to a specified metric.
+    r"""Kernel matrix between matrices according to a specified metric.
 
-    Calculates the kernel matrix K of inner products of two sets X and Y of
-    matrices on the tangent space at Cref according to a specified metric.
+    It calculates the kernel matrix :math:`\mathbf{K}` of pairwise inner
+    products of two sets :math:`\mathbf{X}` and :math:`\mathbf{Y}`
+    of matrices on the tangent space at :math:`\mathbf{C}_\text{ref}`,
+    according to a specified metric.
 
     Parameters
     ----------
@@ -214,8 +242,7 @@ def kernel(X, Y=None, *, Cref=None, metric="riemann", reg=1e-10):
     Y : None | ndarray, shape (n_matrices_Y, n, n), default=None
         Second set of matrices. If None, Y is set to X.
     Cref : None | ndarray, shape (n, n), default=None
-        Reference point for the tangent space and inner product
-        calculation. Only used if metric="riemann".
+        Reference matrix. Used for "logeuclid" or "riemann" metrics.
     metric : string | callable, default="riemann"
         Metric used for tangent space and mean estimation, can be:
         "euclid", "logeuclid", "riemann", or a callable function.

--- a/tests/test_utils_kernel.py
+++ b/tests/test_utils_kernel.py
@@ -1,5 +1,9 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import (
+    assert_array_equal,
+    assert_array_almost_equal,
+    assert_raises,
+)
 import pytest
 
 from pyriemann.utils.base import logm
@@ -13,35 +17,23 @@ from pyriemann.utils.mean import mean_covariance
 from pyriemann.utils.test import is_sym_pos_semi_def as is_spsd
 
 rker_str = ["euclid", "logeuclid", "riemann"]
-rker_fct = [kernel_euclid, kernel_logeuclid, kernel_riemann]
-
-
-@pytest.mark.parametrize("ker", rker_fct)
-def test_kernel_x_x(ker, get_mats):
-    """Test kernel build"""
-    n_matrices, n_channels = 7, 3
-    X = get_mats(n_matrices, n_channels, "spd")
-    K = ker(X, X)
-    assert K.shape == (n_matrices, n_matrices)
-    assert is_spsd(K)
-    assert_array_almost_equal(K, ker(X))
 
 
 @pytest.mark.parametrize("ker", rker_str)
-def test_kernel_cref(ker, get_mats):
-    """Test kernel reference"""
+def test_kernel_x_x(ker, get_mats):
+    """Test kernel build"""
     n_matrices, n_channels = 5, 3
     X = get_mats(n_matrices, n_channels, "spd")
-    cref = mean_covariance(X, metric=ker)
     K = kernel(X, X, metric=ker)
-    K1 = kernel(X, X, Cref=cref, metric=ker)
-    assert_array_equal(K, K1)
+    assert K.shape == (n_matrices, n_matrices)
+    assert is_spsd(K)
+    assert_array_almost_equal(K, globals()[f"kernel_{ker}"](X))
 
 
 @pytest.mark.parametrize("ker", rker_str)
 def test_kernel_x_y(ker, get_mats):
     """Test kernel for different X and Y"""
-    n_matrices_X, n_matrices_Y, n_channels = 6, 5, 3
+    n_matrices_X, n_matrices_Y, n_channels = 4, 5, 3
     X = get_mats(n_matrices_X, n_channels, "spd")
     Y = get_mats(n_matrices_Y, n_channels, "spd")
     K = kernel(X, Y, metric=ker)
@@ -73,11 +65,33 @@ def test_input_dimension_error(ker, get_mats):
     X = get_mats(n_matrices, n_channels, "spd")
     Y = get_mats(n_matrices, n_channels + 1, "spd")
     cref = get_mats(1, n_channels + 1, "spd")[0]
-    if ker == "riemann":
+    if ker in ["logeuclid", "riemann"]:
         with pytest.raises(AssertionError):
             kernel(X, Cref=cref, metric=ker)
     with pytest.raises(AssertionError):
         kernel(X, Y, metric=ker)
+
+
+@pytest.mark.parametrize("n_channels", [4, 5, 6])
+@pytest.mark.parametrize("ker", rker_str)
+def test_cref(n_channels, ker, get_mats):
+    n_matrices_X, n_matrices_Y = 7, 4
+    X = get_mats(n_matrices_X, n_channels, "spd")
+    Y = get_mats(n_matrices_Y, n_channels, "spd")
+    K = kernel(X, Y, metric=ker)
+
+    if ker == "logeuclid":
+        Cref = np.eye(n_channels)
+    elif ker == "riemann":
+        Cref = mean_covariance(X)
+    else:
+        return
+
+    K1 = kernel(X, Y, Cref=Cref, metric=ker)
+    assert_array_equal(K, K1)
+
+    K2 = kernel(X, Y, Cref=X[0], metric=ker)
+    assert_raises(AssertionError, assert_array_equal, K, K2)
 
 
 @pytest.mark.parametrize("n_dim0, n_dim1", [(4, 4), (4, 5), (5, 4)])
@@ -87,7 +101,6 @@ def test_euclid(n_dim0, n_dim1, rndstate):
     X = rndstate.randn(n_matrices_X, n_dim0, n_dim1)
     Y = rndstate.randn(n_matrices_Y, n_dim0, n_dim1)
     K = kernel_euclid(X, Y)
-    assert K.shape == (n_matrices_X, n_matrices_Y)
 
     K1 = np.empty((n_matrices_X, n_matrices_Y))
     K2 = np.empty((n_matrices_X, n_matrices_Y))
@@ -97,6 +110,12 @@ def test_euclid(n_dim0, n_dim1, rndstate):
             K2[i, j] = np.dot(X[i].flatten(), Y[j].flatten())
     assert_array_almost_equal(K, K1)
     assert_array_almost_equal(K, K2)
+
+
+def test_logeuclid(get_mats):
+    n_matrices, n_channels = 5, 3
+    X = get_mats(n_matrices, n_channels, "spd")
+    kernel_logeuclid(X)
 
 
 def test_riemann_correctness(get_mats):


### PR DESCRIPTION
This PR:

- [X] adds parameter Cref for log-Euclidean kernel, following the recent article [A New Canonical Log-Euclidean Kernel for Symmetric Positive Definite Matrices for EEG Analysis](https://ieeexplore.ieee.org/iel8/10/4359967/10735221.pdf), and updates documentation;
- [x] adds parameter Cref for Euclidean kernel and updates documentation;
- [X] corrects Riemannian kernel: when Y is different from X and Cref is None, previous code re-computed Cref when calling `Y_ = kernel_fct(Y)` which was different from that computed when calling `X_ = kernel_fct(X)`;
- [X] completes tests for kernel module.