### PR TITLE
Enhance nearest_sym_pos_def

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,7 +110,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyRiemann'
-copyright = u'2015-2024, pyRiemann Contributors'
+copyright = u'2015-2025, pyRiemann Contributors'
 author = u'Alexandre Barachant'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8'
+__version__ = '0.9.dev'


### PR DESCRIPTION
This PR enhances the code of `nearest_sym_pos_def`, removing redundancy, removing the matrix multiplication by a diagonal matrix, and correcting the documentation.