### PR TITLE
Enhance pairwise_distance

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,8 +12,9 @@ v0.9.dev
 
 - Add conjugate transpose operator :func:`pyriemann.utils.base.ctranspose` for real- and complex-valued ndarrays. :pr:`348` by :user:`qbarthelemy`
 
-- Add :class:`pyriemann.embedding.TSNE`, a Riemannian t-SNE implementation
-  and update example comparing embeddings. :pr:`347` by :user:`thibaultdesurrel`
+- Add :class:`pyriemann.embedding.TSNE`, a Riemannian t-SNE implementation and update example comparing embeddings. :pr:`347` by :user:`thibaultdesurrel`
+
+- Enhance :func:`pyriemann.utils.distance.pairwise_distance` to support HPD matrices for "euclid", "harmonic", "logchol" and "logeuclid" metrics. :pr:`350` by :user:`qbarthelemy`
 
 v0.8 (February 2025)
 --------------------

--- a/pyriemann/embedding.py
+++ b/pyriemann/embedding.py
@@ -556,14 +556,13 @@ def _compute_condprob_gaussian(X, metric, perplexity):
     r"""Conditional probabilities using a Gaussian distribution.
 
     ..math::
-        p_{j|i} = \frac{\exp(-\delta(X_i, X_j)^2/2\sigma_i^2)}{\
-        \sum_{k\neq i}\exp(-\delta(X_i, X_k)^2/2\sigma_i^2)}
-
+        p_{j|i} = \frac{\exp(-\delta(X_i, X_j)^2/2\sigma_i^2)}
+        {\sum_{k\neq i}\exp(-\delta(X_i, X_k)^2/2\sigma_i^2)}
 
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of SPD matrices.
+        Set of SPD/HPD matrices.
 
     Returns
     -------
@@ -590,7 +589,7 @@ def _compute_jointprob_student(X, metric):
     Parameters
     ----------
     X : ndarray, shape (n_matrices, n_channels, n_channels)
-        Set of SPD matrices.
+        Set of SPD/HPD matrices.
 
     Returns
     -------

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -22,8 +22,6 @@ embds = [SpectralEmbedding, LocallyLinearEmbedding, TSNE]
 def test_embedding(kind, embd, metric, get_mats):
     if kind == "hpd" and embd is LocallyLinearEmbedding:
         pytest.skip()
-    if kind == "hpd" and metric in ["euclid", "logeuclid"]:
-        pytest.skip()  # sklearn.euclidean_dist does not support complex data
     n_matrices, n_channels, n_comp = 8, 3, 4
     mats = get_mats(n_matrices, n_channels, kind)
 

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -262,17 +262,18 @@ def test_distance_wrapper_between_set_and_matrix(dist, get_mats):
         distance(mats_4d, mats, metric=dist)
 
 
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("dist", get_distances())
 @pytest.mark.parametrize("Y", [None, True])
 @pytest.mark.parametrize("squared", [False, True])
-def test_pairwise_distance_matrix(get_mats, dist, Y, squared):
+def test_pairwise_distance_matrix(kind, dist, Y, squared, get_mats):
     n_matrices_X, n_matrices_Y, n_channels = 6, 4, 5
-    X = get_mats(n_matrices_X, n_channels, "spd")
+    X = get_mats(n_matrices_X, n_channels, kind)
     if Y is None:
         n_matrices_Y = n_matrices_X
         Y_ = X
     else:
-        Y = get_mats(n_matrices_Y, n_channels, "spd")
+        Y = get_mats(n_matrices_Y, n_channels, kind)
         Y_ = Y
 
     pdist = pairwise_distance(X, Y, metric=dist, squared=squared)


### PR DESCRIPTION
`pairwise_distance` used with metric = "euclid", "harmonic", "logchol", "logeuclid" on HPD matrices raises
`ValueError: Complex data not supported`
because `euclidean_distances` of `sklearn` does not support complex-valued arrays.

Related to #204

@thibaultdesurrel 