### PR TITLE
Avoid duplicating code when using joblib

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,8 @@ v0.9.dev
 
 - Enhance :func:`pyriemann.utils.distance.pairwise_distance` to support HPD matrices for "euclid", "harmonic", "logchol" and "logeuclid" metrics. :pr:`350` by :user:`qbarthelemy`
 
+- Avoid duplicating code when using joblib. :pr:`359` by :user:`qbarthelemy`
+
 v0.8 (February 2025)
 --------------------
 

--- a/pyriemann/channelselection.py
+++ b/pyriemann/channelselection.py
@@ -27,7 +27,7 @@ class ElectrodeSelection(TransformerMixin, BaseEstimator):
         The metric can be a dict with two keys, "mean" and "distance"
         in order to pass different metrics.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        Number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel.
         If -1 all CPUs are used. If 1 is given, no parallel computing code is
         used at all, which is useful for debugging. For n_jobs below -1,

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -108,7 +108,7 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
         centroid seeds. The final results will be the best output of
         n_init consecutive runs in terms of inertia.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        Number of jobs to use for the computation. This works by computing
         each of the n_init runs in parallel.
         If -1 all CPUs are used. If 1 is given, no parallel computing code is
         used at all, which is useful for debugging. For n_jobs below -1,
@@ -187,36 +187,20 @@ class Kmeans(SpdClassifMixin, ClusterMixin, TransformerMixin, BaseEstimator):
                 size=self.n_init,
             )
 
-            if self.n_jobs == 1:
-                res = []
-                for i in range(self.n_init):
-                    res.append(_fit_single(
-                        X,
-                        y,
-                        n_clusters=self.n_clusters,
-                        init=self.init,
-                        random_state=seeds[i],
-                        metric=self.metric,
-                        max_iter=self.max_iter,
-                        tol=self.tol,
-                    ))
-                labels, inertia, mdm = zip(*res)
-
-            else:
-                res = Parallel(n_jobs=self.n_jobs, verbose=0)(
-                    delayed(_fit_single)(
-                        X,
-                        y,
-                        n_clusters=self.n_clusters,
-                        init=self.init,
-                        random_state=seed,
-                        metric=self.metric,
-                        max_iter=self.max_iter,
-                        tol=self.tol,
-                        n_jobs=1,
-                    ) for seed in seeds
-                )
-                labels, inertia, mdm = zip(*res)
+            res = Parallel(n_jobs=self.n_jobs)(
+                delayed(_fit_single)(
+                    X,
+                    y,
+                    n_clusters=self.n_clusters,
+                    init=self.init,
+                    random_state=seed,
+                    metric=self.metric,
+                    max_iter=self.max_iter,
+                    tol=self.tol,
+                    n_jobs=1,
+                ) for seed in seeds
+            )
+            labels, inertia, mdm = zip(*res)
 
             best = np.argmin(inertia)
             mdm = mdm[best]

--- a/pyriemann/datasets/sampling.py
+++ b/pyriemann/datasets/sampling.py
@@ -265,7 +265,7 @@ def _slice_sampling(ptarget, n_samples, x0, n_burnin=20, thin=10,
     random_state : int | RandomState instance | None, default=None
         Pass an int for reproducible output across multiple function calls.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        Number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
 
     Returns
@@ -320,7 +320,7 @@ def _sample_parameter_r(n_samples, n_dim, sigma,
     random_state : int | RandomState instance | None, default=None
         Pass an int for reproducible output across multiple function calls.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        Number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : {"auto", "slice", "rejection"}, default="auto"
         Method used to sample parameter r: "auto", "slice" or "rejection".
@@ -418,7 +418,7 @@ def _sample_gaussian_spd_centered(n_matrices, n_dim, sigma, random_state=None,
     random_state : int | RandomState instance | None, default=None
         Pass an int for reproducible output across multiple function calls.
     n_jobs : int, default=1
-        The number of jobs to use for the computation. This works by computing
+        Number of jobs to use for the computation. This works by computing
         each of the class centroid in parallel. If -1 all CPUs are used.
     sampling_method : {"auto", "slice", "rejection"}, default="auto"
         Method used to sample parameter r: "auto", "slice" or "rejection".

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -924,7 +924,7 @@ class Kernels(TransformerMixin, BaseEstimator):
         The metric to use when computing kernel function between channels [2]_:
         "linear", "poly", "polynomial", "rbf", "laplacian", "cosine".
     n_jobs : int, default=None
-        The number of jobs to use for the computation [2]_. This works by
+        Number of jobs to use for the computation [2]_. This works by
         breaking down the pairwise matrix into n_jobs even slices and computing
         them in parallel.
     **kwds : dict

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -573,7 +573,7 @@ class TLRotate(TransformerMixin, BaseEstimator):
     metric : {"euclid", "riemann"}, default="euclid"
         For inputs in manifold, distance to minimize between class means.
     n_jobs : int, default=1
-        For inputs in manifold, the number of jobs to use for the computation.
+        For inputs in manifold, number of jobs to use for the computation.
         This works by computing the rotation matrix for each source domain in
         parallel. If -1 all CPUs are used.
     expl_var : float, default=0.999


### PR DESCRIPTION
This PR avoids duplicating code when using `joblib`, removing conditions `if n_jobs == 1`.