### PR TITLE
Changed mirror for hyperspectral

### DIFF
--- a/examples/image-radar/helpers/datasets_helpers.py
+++ b/examples/image-radar/helpers/datasets_helpers.py
@@ -23,26 +23,27 @@ def download_salinas(data_path: str):
         Path to the data folder to download the data.
     """
     urls = [
-        "https://www.ehu.eus/ccwintco/uploads/f/f1/Salinas.mat",
-        "https://www.ehu.eus/ccwintco/uploads/a/a3/Salinas_corrected.mat",
-        "https://www.ehu.eus/ccwintco/uploads/f/fa/Salinas_gt.mat",
+        "https://zenodo.org/records/15771735/files/Salinas.mat?download=1",
+        "https://zenodo.org/records/15771735/files/Salinas_corrected.mat?download=1",
+        "https://zenodo.org/records/15771735/files/Salinas_gt.mat?download=1",
     ]
-    filenames = [os.path.basename(url) for url in urls]
+    filenames = [os.path.basename(url).split("?")[0] for url in urls]
     if not os.path.exists(data_path):
         os.makedirs(data_path, exist_ok=True)
-    if not all([os.path.exists(os.path.join(data_path, filename))
-                for filename in filenames]):
+    if not all(
+        [os.path.exists(os.path.join(data_path, filename)) for filename in filenames]
+    ):
         print("Downloading Salinas dataset...")
-        for url in urls:
-            urllib.request.urlretrieve(url, os.path.join(data_path,
-                                       os.path.basename(url)))
+        for url, filename in zip(urls, filenames):
+            urllib.request.urlretrieve(url, os.path.join(data_path, filename))
         print("Done.")
     else:
         print("Salinas dataset already downloaded.")
 
 
-def read_salinas(data_path: str, version: str = "corrected") -> \
-        Tuple[ArrayLike, ArrayLike, Dict[int, str]]:
+def read_salinas(
+    data_path: str, version: str = "corrected"
+) -> Tuple[ArrayLike, ArrayLike, Dict[int, str]]:
     """Read Salinas hyperspectral data.
 
     Parameters


### PR DESCRIPTION
Update hyperspectral dataset links to reliable Zenodo mirror for improved download reliability. This redistribution is fully compliant with NASA data policies, as NASA content including AVIRIS hyperspectral data is "generally not subject to copyright in the United States" and "may be reproduced and distributed without further permission from NASA" according to [NASA's official media guidelines](https://www.nasa.gov/nasa-brand-center/images-and-media/) and [Earthdata policy](https://www.earthdata.nasa.gov/learn/use-data/data-use-policy), with proper attribution to NASA/JPL maintained in the Zenodo repository.