### PR TITLE
Fix spatial filtering and update tests

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,8 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.9.dev
 --------
 
+- Fix :class:`pyriemann.spatialfilters.Xdawn` to remove the parameters ``sample_weight`` that is not used on the fit_transformation. :pr:`XXX` by :user:`baristimunha`
+
 - Add conjugate transpose operator :func:`pyriemann.utils.base.ctranspose` for real- and complex-valued ndarrays. :pr:`348` by :user:`qbarthelemy`
 
 - Add :class:`pyriemann.embedding.TSNE`, a Riemannian t-SNE implementation and update example comparing embeddings. :pr:`347` by :user:`thibaultdesurrel`

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -167,7 +167,7 @@ class Xdawn(TransformerMixin, BaseEstimator):
                 n_filters), n_times)
             Set of spatially filtered trials.
         """
-        return self.fit(X, y, sample_weight=sample_weight).transform(X)
+        return self.fit(X, y).transform(X)
 
 
 class BilinearFilter(TransformerMixin, BaseEstimator):

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -151,7 +151,7 @@ class Xdawn(TransformerMixin, BaseEstimator):
         """
         return self.filters_ @ X
 
-    def fit_transform(self, X, y=None, sample_weight=None):
+    def fit_transform(self, X, y=None):
         """Fit and transform in a single function.
 
         Parameters

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -94,6 +94,10 @@ def clf_transform(spfilt, X, labels, n_matrices, n_channels, n_times):
     else:
         Xtr = sf.fit(X, labels).transform(X)
 
+        Xtr1 = sf.fit_transform(X, labels)
+
+        assert_array_equal(Xtr, Xtr1)
+
     if spfilt is AJDC:
         assert Xtr.shape == (n_matrices, n_channels, n_times)
     elif spfilt is BilinearFilter:
@@ -104,6 +108,7 @@ def clf_transform(spfilt, X, labels, n_matrices, n_channels, n_times):
     else:
         n_components = min(n_channels, sf.nfilter)
         assert Xtr.shape == (n_matrices, n_components)
+
 
 
 def clf_transform_error(spfilt, X, labels, n_channels):


### PR DESCRIPTION
Remove unused `sample_weight` parameter from the `fit_transform` method and update related tests. Additionally, refresh the "What's New" file to reflect these changes.


closes #369