### PR TITLE
Add comparaison of clustering algorithms

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,7 +8,9 @@ What's new in the package
 A catalog of new features, improvements, and bug-fixes in each release.
 
 v0.10.dev
---------
+---------
+
+- Add example in gallery to compare clustering algorithms on synthetic datasets. :pr:`374` by :user:`qbarthelemy`
 
 v0.9 (July 2025)
 ----------------

--- a/examples/biosignal-ssvep/plot_classify_ssvep_pga.py
+++ b/examples/biosignal-ssvep/plot_classify_ssvep_pga.py
@@ -56,7 +56,7 @@ freq_band = 0.1
 events_id = {"13 Hz": 2, "17 Hz": 4, "21 Hz": 3, "resting-state": 1}
 
 duration = 2.5    # duration of epochs
-interval = 0.25   # interval between successive epochs for online processing
+interval = 0.5   # interval between successive epochs for online processing
 
 # Subject 12: first 4 sessions for training, last session for test
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -13,7 +13,6 @@ these examples does not necessarily carry over to real datasets.
 The 3D plots show training matrices in solid colors and testing matrices
 semi-transparent. The lower right shows the classification accuracy on the test
 set.
-
 """
 # Authors: Quentin Barthélemy
 #
@@ -48,11 +47,13 @@ def get_proba(cov_00, cov_01, cov_11, clf):
 
 def plot_classifiers(metric):
     figure = plt.figure(figsize=(12, 10))
-    figure.suptitle(f"Compare classifiers with metric='{metric}'", fontsize=16)
+    figure.suptitle(f"Classifiers with metric='{metric}'", fontsize=16)
     i = 1
 
     # iterate over datasets
-    for ds_cnt, (X, y) in enumerate(datasets):
+    for i_dataset, (X, y) in enumerate(datasets):
+        print(f"Dataset n°{i_dataset+1}")
+
         # split dataset into training and test part
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=0.4, random_state=42
@@ -64,9 +65,9 @@ def plot_classifiers(metric):
 
         # just plot the dataset first
         ax = plt.subplot(n_datasets, n_classifs + 1, i, projection="3d")
-        if ds_cnt == 0:
-            ax.set_title("Input data")
-        # Plot the training points
+        if i_dataset == 0:
+            ax.set_title("Input matrices")
+        # plot the training matrices
         ax.scatter(
             X_train[:, 0, 0],
             X_train[:, 0, 1],
@@ -75,7 +76,7 @@ def plot_classifiers(metric):
             cmap=cm_bright,
             edgecolors="k"
         )
-        # Plot the testing points
+        # plot the testing matrices
         ax.scatter(
             X_test[:, 0, 0],
             X_test[:, 0, 1],
@@ -97,26 +98,23 @@ def plot_classifiers(metric):
         ry = np.arange(y_min, y_max, (y_max - y_min) / 50)
         rz = np.arange(z_min, z_max, (z_max - z_min) / 50)
 
-        print(f"Dataset n°{ds_cnt+1}")
-
         # iterate over classifiers
-        for name, clf in zip(names, classifiers):
-            ax = plt.subplot(n_datasets, n_classifs + 1, i, projection="3d")
-
+        for name, clf in zip(names, classifs):
             clf.set_params(**{"metric": metric})
+
             t0 = time()
             clf.fit(X_train, y_train)
             t1 = time() - t0
-
             t0 = time()
             score = clf.score(X_test, y_test)
             t2 = time() - t0
-
             print(
                 f" {name}:\n  training time={t1:.5f}\n  test time    ={t2:.5f}"
             )
 
-            # Plot the decision boundaries for horizontal 2D planes going
+            ax = plt.subplot(n_datasets, n_classifs + 1, i, projection="3d")
+
+            # plot the decision boundaries for horizontal 2D planes going
             # through the mean value of the third coordinates
             xx, yy = np.meshgrid(rx, ry)
             zz = get_proba(xx, yy, X[:, 1, 1].mean()*np.ones_like(xx), clf=clf)
@@ -133,7 +131,7 @@ def plot_classifiers(metric):
             xx = np.ma.masked_where(~np.isfinite(xx), xx)
             ax.contourf(xx, yy, zz, zdir="x", offset=x_min, cmap=cm, alpha=0.5)
 
-            # Plot the training points
+            # plot the training matrices
             ax.scatter(
                 X_train[:, 0, 0],
                 X_train[:, 0, 1],
@@ -142,7 +140,7 @@ def plot_classifiers(metric):
                 cmap=cm_bright,
                 edgecolors="k"
             )
-            # Plot the testing points
+            # plot the testing matrices
             ax.scatter(
                 X_test[:, 0, 0],
                 X_test[:, 0, 1],
@@ -153,7 +151,7 @@ def plot_classifiers(metric):
                 alpha=0.6
             )
 
-            if ds_cnt == 0:
+            if i_dataset == 0:
                 ax.set_title(name)
             ax.text(
                 1.3 * x_max,
@@ -185,12 +183,12 @@ names = [
     "k-NN",
     "SVC",
 ]
-classifiers = [
+classifs = [
     MDM(),
     KNearestNeighbor(n_neighbors=3),
     SVC(probability=True),
 ]
-n_classifs = len(classifiers)
+n_classifs = len(classifs)
 
 rs = np.random.RandomState(2022)
 n_matrices, n_channels = 50, 2
@@ -235,17 +233,10 @@ cm_bright = ListedColormap(["#FF0000", "#0000FF"])
 
 
 ###############################################################################
-# Classifiers with Riemannian metric
-# ----------------------------------
+# Classifiers with affine-invariant Riemannian metric
+# ---------------------------------------------------
 
 plot_classifiers("riemann")
-
-
-###############################################################################
-# Classifiers with Log-Euclidean metric
-# -------------------------------------
-
-plot_classifiers("logeuclid")
 
 
 ###############################################################################

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -46,8 +46,8 @@ def get_proba(cov_00, cov_01, cov_11, clf):
 
 
 def plot_classifiers(metric):
-    figure = plt.figure(figsize=(12, 10))
-    figure.suptitle(f"Classifiers with metric='{metric}'", fontsize=16)
+    fig = plt.figure(figsize=(12, 10))
+    fig.suptitle(f"Classifiers with metric='{metric}'", fontsize=16)
     i = 1
 
     # iterate over datasets

--- a/examples/simulated/plot_clusterer_comparison.py
+++ b/examples/simulated/plot_clusterer_comparison.py
@@ -31,9 +31,8 @@ from pyriemann.datasets import make_matrices, make_gaussian_blobs
 
 
 def plot_clusterers(metric):
-    figure = plt.figure(figsize=(12, 10))
-    figure.suptitle(f"Clustering algorithms with metric='{metric}'",
-                    fontsize=16)
+    fig = plt.figure(figsize=(12, 10))
+    fig.suptitle(f"Clustering algorithms with metric='{metric}'", fontsize=16)
     i = 1
 
     # iterate over datasets

--- a/examples/simulated/plot_clusterer_comparison.py
+++ b/examples/simulated/plot_clusterer_comparison.py
@@ -1,0 +1,192 @@
+"""
+===============================================================================
+Clustering algorithm comparison
+===============================================================================
+
+A comparison of several clustering algorithms on low-dimensional synthetic
+datasets, adapted to SPD matrices from [1]_.
+The point of this example is to illustrate the nature of clustering
+of different algorithms, used with different metrics [2]_.
+This should be taken with a grain of salt, as the intuition conveyed by
+these examples does not necessarily carry over to real datasets.
+"""
+# Authors: Quentin Barthélemy
+#
+# License: BSD (3-clause)
+
+from itertools import cycle, islice
+from time import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pyriemann.clustering import (
+    Kmeans,
+    MeanShift,
+)
+from pyriemann.datasets import make_matrices, make_gaussian_blobs
+
+
+###############################################################################
+
+
+def plot_clusterers(metric):
+    figure = plt.figure(figsize=(12, 10))
+    figure.suptitle(f"Clustering algorithms with metric='{metric}'",
+                    fontsize=16)
+    i = 1
+
+    # iterate over datasets
+    for i_dataset, X in enumerate(datasets):
+        print(f"Dataset n°{i_dataset+1}")
+
+        x_min, x_max = X[:, 0, 0].min(), X[:, 0, 0].max()
+        y_min, y_max = X[:, 0, 1].min(), X[:, 0, 1].max()
+        z_min, z_max = X[:, 1, 1].min(), X[:, 1, 1].max()
+
+        # iterate over clusterers
+        for name, clt in zip(names, clusts):
+            clt.set_params(**{"metric": metric})
+
+            t0 = time()
+            clt.fit(X)
+            t1 = time() - t0
+            if hasattr(clt, "labels_"):
+                y_pred = clt.labels_.astype(int)
+            else:
+                y_pred = clt.predict(X)
+            print(f" {name}:\n  training time={t1:.5f}")
+
+            colors = np.array(
+                list(
+                    islice(
+                        cycle(
+                            [
+                                "#377eb8",
+                                "#ff7f00",
+                                "#4daf4a",
+                                "#f781bf",
+                                "#a65628",
+                                "#984ea3",
+                                "#999999",
+                                "#e41a1c",
+                                "#dede00",
+                            ]
+                        ),
+                        int(max(y_pred) + 1),
+                    )
+                )
+            )
+            colors = np.append(colors, ["#000000"])
+
+            # plot
+            ax = plt.subplot(n_datasets, n_clusts, i, projection="3d")
+            ax.scatter(
+                X[:, 0, 0],
+                X[:, 0, 1],
+                X[:, 1, 1],
+                color=colors[y_pred]
+            )
+
+            if i_dataset == 0:
+                ax.set_title(name)
+            ax.set_xlim(x_min, x_max)
+            ax.set_ylim(y_min, y_max)
+            ax.set_zlim(z_min, z_max)
+            ax.set_xticks(())
+            ax.set_yticks(())
+            ax.set_zticks(())
+            if i_dataset <= 1:
+                ax.view_init(azim=-110)
+            if i_dataset == 2:
+                ax.view_init(elev=20, azim=40)
+            if i_dataset == 3:
+                ax.view_init(elev=5, azim=100, roll=0)
+
+            i += 1
+
+    plt.show()
+
+
+###############################################################################
+# Clustering and Datasets
+# -----------------------
+
+names = [
+    "k-means, 2 clusters",
+    "k-means, 3 clusters",
+    "mean shift, uniform kernel",
+    "mean shift, normal kernel",
+]
+n_jobs = 4
+clusts = [
+    Kmeans(n_clusters=2, n_jobs=n_jobs),
+    Kmeans(n_clusters=3, n_jobs=n_jobs),
+    MeanShift(kernel="uniform", n_jobs=n_jobs),
+    MeanShift(kernel="normal", n_jobs=n_jobs),
+]
+n_clusts = len(clusts)
+
+rs = np.random.RandomState(2025)
+n_matrices, n_channels = 50, 2
+
+datasets = [
+    np.concatenate([
+        make_matrices(
+            n_matrices, n_channels, "spd", rs,
+            evals_low=10, evals_high=14, eigvecs_mean=0.0, eigvecs_std=1.0,
+        ),
+        make_matrices(
+            n_matrices, n_channels, "spd", rs,
+            evals_low=14, evals_high=18, eigvecs_mean=5.0, eigvecs_std=2.0,
+        )
+    ]),
+    np.concatenate([
+        make_matrices(
+            n_matrices, n_channels, "spd", rs,
+            evals_low=4, evals_high=8, eigvecs_mean=0.0, eigvecs_std=0.5,
+        ),
+        make_matrices(
+            n_matrices, n_channels, "spd", rs,
+            evals_low=9, evals_high=13, eigvecs_mean=2.0, eigvecs_std=1.0,
+        ),
+        make_matrices(
+            n_matrices, n_channels, "spd", rs,
+            evals_low=14, evals_high=18, eigvecs_mean=5.0, eigvecs_std=2.0,
+        )
+    ]),
+    make_gaussian_blobs(
+        2*n_matrices, n_channels, random_state=rs, n_jobs=4,
+        class_sep=5., class_disp=.5,
+    )[0],
+    make_gaussian_blobs(
+        2*n_matrices, n_channels, random_state=rs, n_jobs=4,
+        class_sep=2., class_disp=.5,
+    )[0]
+]
+n_datasets = len(datasets)
+
+
+###############################################################################
+# Clustering with affine-invariant Riemannian metric
+# --------------------------------------------------
+
+plot_clusterers("riemann")
+
+
+###############################################################################
+# Clustering with Euclidean metric
+# --------------------------------
+
+plot_clusterers("euclid")
+
+
+###############################################################################
+# References
+# ----------
+# .. [1] https://scikit-learn.org/stable/auto_examples/cluster/plot_cluster_comparison.html  # noqa
+# .. [2] `Review of Riemannian distances and divergences, applied to
+#    SSVEP-based BCI
+#    <https://hal.archives-ouvertes.fr/LISV/hal-03015762v1>`_
+#    S. Chevallier, E. K. Kalunga, Q. Barthélemy, E. Monacelli.
+#    Neuroinformatics, Springer, 2021, 19 (1), pp.93-106

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.9'
+__version__ = '0.10.dev'

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -185,7 +185,7 @@ class Kmeans(SpdClassifMixin, SpdClustMixin, TransformerMixin, BaseEstimator):
         self.metric = metric
         self.n_clusters = n_clusters
         self.max_iter = max_iter
-        self.seed = random_state
+        self.random_state = random_state
         self.init = init
         self.n_init = n_init
         self.tol = tol
@@ -207,7 +207,7 @@ class Kmeans(SpdClassifMixin, SpdClustMixin, TransformerMixin, BaseEstimator):
             The Kmeans instance.
         """
         if isinstance(self.init, str) and self.init == "random":
-            np.random.seed(self.seed)
+            np.random.seed(self.random_state)
             seeds = np.random.randint(
                 np.iinfo(np.int32).max,
                 size=self.n_init,
@@ -240,7 +240,7 @@ class Kmeans(SpdClassifMixin, SpdClustMixin, TransformerMixin, BaseEstimator):
                 y,
                 n_clusters=self.n_clusters,
                 init=self.init,
-                random_state=self.seed,
+                random_state=self.random_state,
                 metric=self.metric,
                 max_iter=self.max_iter,
                 tol=self.tol,


### PR DESCRIPTION
This PR adds an example in gallery to compare clustering algorithms on synthetic datasets.

`Kmeans` is updated, because `clt.set_params(**{"metric": metric})` raises this error
```
Traceback (most recent call last):
  File "pyRiemann\examples\simulated\plot_clusterer_comparison.py", line 174, in <module>
    plot_clusterers("riemann")
  File "pyRiemann\examples\simulated\plot_clusterer_comparison.py", line 49, in plot_clusterers
    clt.set_params(**{"metric": metric})
  File "anaconda3\envs\env_pyriemann\Lib\site-packages\sklearn\base.py", line 276, in set_params
    valid_params = self.get_params(deep=True)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "anaconda3\envs\env_pyriemann\Lib\site-packages\sklearn\base.py", line 248, in get_params
    value = getattr(self, key)
            ^^^^^^^^^^^^^^^^^^
AttributeError: 'Kmeans' object has no attribute 'random_state'
```
The log-Euclidean metric is removed from the classification example to reduce documentation build time.

Inspired by scikit-learn example,
https://scikit-learn.org/stable/auto_examples/cluster/plot_cluster_comparison.html,
it could be great to integrate new functions to add new synthetic datasets, like https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_circles.html or https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_moons.html, but adapted to the manifold of SPD/HPD matrices.