### PR TITLE
force matplotlib backend for tests

### DIFF
--- a/tests/test_utils_viz.py
+++ b/tests/test_utils_viz.py
@@ -1,3 +1,4 @@
+import matplotlib
 import numpy as np
 import pytest
 
@@ -8,6 +9,8 @@ from pyriemann.utils.viz import (
     plot_waveforms
 )
 
+matplotlib.use('Agg')
+
 
 @requires_matplotlib
 def test_embedding(get_mats):
@@ -15,7 +18,7 @@ def test_embedding(get_mats):
     n_matrices, n_channels = 5, 3
     mats = get_mats(n_matrices, n_channels, "spd")
     plot_embedding(mats, y=None, metric="euclid")
-    y = np.ones(mats.shape[0])
+    y = np.ones(n_matrices)
     plot_embedding(mats, y=y, metric="euclid")
 
 


### PR DESCRIPTION

On Windows, it is very frequent for tests using matplotlib to crash due to tkinter

```
FAILED tests/test_utils_viz.py::test_plot_waveforms[mean] - _tkinter.TclError: Can't find a usable init.tcl in the following directories:
{C:\hostedtoolcache\windows\Python\3.10.11\x64\tcl\tcl8.6}
```
or
```
FAILED tests/test_utils_viz.py::test_embedding - _tkinter.TclError: Can't find a usable init.tcl in the following directories:
{C:\hostedtoolcache\windows\Python\3.10.11\x64\tcl\tcl8.6}
```
The solution is to force backend to Agg