### PR TITLE
Speedup of the mean_alm

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -28,6 +28,8 @@ v0.10.dev
 
 - Enhance :class:`pyriemann.tangentspace.TangentSpace` to support HPD matrices. :pr:`394` by :user:`qbarthelemy`
 
+- Speedup of the ALM mean :func:`pyriemann.utils.mean.mean_alm`. :pr:`398` by :user:`qbarthelemy`
+
 v0.9 (July 2025)
 ----------------
 
@@ -234,7 +236,7 @@ v0.3 (July 2022)
 
 - Deprecate ``pyriemann.utils.viz.plot_confusion_matrix`` as sklearn integrate its own version. :pr:`135` by :user:`sylvchev`
 
-- Add Ando-Li-Mathias mean estimation in :func:`pyriemann.utils.mean.mean_covariance`. :pr:`56` by :user:`sylvchev`
+- Add Ando-Li-Mathias (ALM) mean in :func:`pyriemann.utils.mean.mean_alm`. :pr:`56` by :user:`sylvchev`
 
 - Add Schaefer-Strimmer covariance estimator in :func:`pyriemann.utils.covariance.covariances`, and an example to compare estimators :pr:`59` by :user:`sylvchev`
 

--- a/tests/test_utils_median.py
+++ b/tests/test_utils_median.py
@@ -60,10 +60,11 @@ def test_median_euclid_scalars(n_values, rndstate):
     assert np_med == approx(py_med)
 
 
+@pytest.mark.parametrize("n_dim1, n_dim2", [(4, 5), (5, 4)])
 @pytest.mark.parametrize("kind", ["real", "comp"])
-def test_median_euclid(kind, get_mats):
+def test_median_euclid(n_dim1, n_dim2, kind, get_mats):
     """Euclidean median for non-square matrices"""
-    n_matrices, n_dim1, n_dim2 = 10, 3, 4
+    n_matrices = 10
     X = get_mats(n_matrices, [n_dim1, n_dim2], kind)
     assert median_euclid(X).shape == (n_dim1, n_dim2)
 


### PR DESCRIPTION
Speedup of the `mean_alm` added in #56, replacing `copy.deepcoy()` by `ndarray.copy()`.

<img width="640" height="480" alt="pr_398_6mats" src="https://github.com/user-attachments/assets/437acf8c-0b96-4432-8c55-1db3164152c5" />

Also, complete tests for means and medians.