### PR TITLE
ENH: expose tol_step and maxiter in TLRotate

### DIFF
--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -564,10 +564,10 @@ class TLRotate(TransformerMixin, BaseEstimator):
     n_clusters : int, default=3
         For inputs in tangent space, number of clusters used to split data.
     tol_step : float, default=1e-9
-        For inputs in manifold, stopping criterion based on the norm of 
+        For inputs in manifold, stopping criterion based on the norm of
         the descent direction.
     maxiter : int, default=10_000
-        For inputs in manifold, maximum number of iterations in the 
+        For inputs in manifold, maximum number of iterations in the
         optimization procedure.
 
     Attributes


### PR DESCRIPTION
**Changes**
- Added `tol_step`and `maxiter` as parameters for TLRotate and forwarded these to the `_get_rotation_manifold` function to allow users to adjust the stopping criteria for the manifold optimization. 

**Motivation**
- Makes TLRotate behavior easier to tune, especially for difficult optimization cases, without changing the default behavior.

**Implementation notes**
-  Defaults: `tol_step=1e-9`, `maxiter=10_000` (same values as defaults in the optimization)
- Added to class attributes so they are exposed in get_params() / set_params() like other sklearn-style estimators.

**Tests**
- Full pytest on local machine: 4400 passed, 16 skipped, 92 warnings.