### PR TITLE
Fix sklearn error "This Pipeline instance is not fitted yet"

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -37,6 +37,8 @@ v0.10.dev
 - Add Thompson metric: :func:`pyriemann.utils.distance.distance_thompson`, :func:`pyriemann.utils.geodesic.geodesic_thompson`,
   and :func:`pyriemann.utils.mean.mean_thompson`. :pr:`401` by :user:`qbarthelemy`
 
+- Fix sklearn error ``This Pipeline instance is not fitted yet``. :pr:`406` by :user:`qbarthelemy`
+
 v0.9 (July 2025)
 ----------------
 
@@ -52,7 +54,7 @@ v0.9 (July 2025)
 
 - Avoid duplicating code when using joblib. :pr:`359` by :user:`qbarthelemy`
 
-- Fix sklearn warning. :pr:`358` by :user:`qbarthelemy`
+- Fix sklearn warning ``This Pipeline instance is not fitted yet``. :pr:`358` by :user:`qbarthelemy`
 
 - Add :func:`pyriemann.utils.tangentspace.log_map` and :func:`pyriemann.utils.tangentspace.exp_map`. :pr:`363` by :user:`qbarthelemy`
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -938,7 +938,11 @@ class TLEstimator(BaseEstimator):
         else:
             self.estimator.fit(X_dec, y_dec, sample_weight=weights)
 
+        self._is_fitted = True
         return self
+
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "_is_fitted") and self._is_fitted
 
     def predict(self, X):
         """Get the predictions.


### PR DESCRIPTION
Running examples in `transfer` with sklearn 1.8 raises the following error
```
NotFittedError: This Pipeline instance is not fitted yet.
Call 'fit' with appropriate arguments before using this estimator.
```
see 
https://github.com/pyRiemann/pyRiemann/actions/runs/20267944727/job/58195870456#step:5:1131

Related to 
https://github.com/pyRiemann/pyRiemann/pull/358