### PR TITLE
Speedup of 2×2 SPD/HPD matrix operations using Sylvester's formula

### DIFF
--- a/pyriemann/utils/base.py
+++ b/pyriemann/utils/base.py
@@ -87,9 +87,41 @@ def _matrix_operator(X, operator):
             "You should add regularization to avoid this error."
         )
 
-    eigvals, eigvecs = np.linalg.eigh(X)
-    eigvals = operator(eigvals)
-    X_new = eigvecs @ (np.expand_dims(eigvals, -1) * ctranspose(eigvecs))
+    if X.shape[-1] == 2:
+        # Fast computation for 2x2 matrices
+        # Start by computing the eigenvalues using a
+        # stable closed-form solution
+        a, b, c = X[..., 0, 0], X[..., 0, 1], X[..., 1, 1]
+        trace = a + c
+        det = a * c - np.abs(b)**2
+
+        disc = np.sqrt((a - c)**2 + 4 * np.abs(b)**2)
+        lam1 = (trace + disc) / 2
+        # Stable small eigenvalue: uses lam1*lam2 = det to avoid cancellation
+        # in (trace - disc) when trace ≈ disc (near-singular matrices).
+        with np.errstate(invalid="ignore", divide="ignore"):
+            lam2 = np.where(disc > 0, det / lam1, lam1)
+        eigvals = np.array([lam1, lam2])
+
+        # Apply the operator to the eigenvalues,
+        # handling degeneracy (lam1 ≈ lam2)
+        diff = eigvals[0] - eigvals[1]
+        degenerate = np.isclose(eigvals[0], eigvals[1])
+        with np.errstate(invalid="ignore", divide="ignore"):
+            alpha_1 = (operator(eigvals[0]) - operator(eigvals[1])) / diff
+            alpha_2 = (
+                eigvals[0] * operator(eigvals[1])
+                - eigvals[1] * operator(eigvals[0])
+            ) / diff
+        alpha_1 = np.where(degenerate, 0, alpha_1)
+        alpha_2 = np.where(degenerate, operator(eigvals[0]), alpha_2)
+        alpha_1 = np.asarray(alpha_1)[..., np.newaxis, np.newaxis]
+        alpha_2 = np.asarray(alpha_2)[..., np.newaxis, np.newaxis]
+        X_new = alpha_1 * X + alpha_2 * np.eye(2)
+    else:
+        eigvals, eigvecs = np.linalg.eigh(X)
+        eigvals = operator(eigvals)
+        X_new = eigvecs @ (np.expand_dims(eigvals, -1) * ctranspose(eigvecs))
     return X_new
 
 


### PR DESCRIPTION
Hello everybody,

I've recently been working on speeding up the [Riemannian t-SNE](https://pyriemann.readthedocs.io/en/latest/generated/pyriemann.embedding.TSNE.html#pyriemann.embedding.TSNE) that I implemented in pyRiemann last year. The main bottleneck were the base operations done on the low-dimensional $2 \times 2$ SPD/HPD matrices.

In order to speed them up, I discovered [Sylvester's formula](https://en.wikipedia.org/wiki/Sylvester%27s_formula) that helps us compute $f(X)$ for any diagonalizable matrix. In the case of a $2 \times 2$ SPD matrix, this formula simplifies to

```math
f(X) = \alpha_1 X + \alpha_2 I_2
```

where

```math
\alpha_1 = \frac{f(\lambda_+) - f(\lambda_-)}{\lambda_+ - \lambda_-}, \qquad \alpha_2 = \frac{\lambda_+ f(\lambda_-) - \lambda_- f(\lambda_+)}{\lambda_+ - \lambda_-}
```

and $\lambda_+$, $\lambda_-$ are the eigenvalues of $X$. For a $2 \times 2$ SPD/HPD matrix $X = \begin{pmatrix}a & b \\ b & c\end{pmatrix}$, these eigenvalues can be computed efficiently as:

```math
\lambda_{\pm} = \frac{(a+c) \pm \sqrt{(a-c)^2 + 4|b|^2}}{2}
```

I implemented this in `pyriemann/utils/base.py` in `_matrix_operator` for the special case of `X.shape[-1] == 2`. I then did some benchmarking for `expm`, `logm`, `sqrtm` and `invsqrtm`. There is a major speedup when the number of matrices increases.
<img width="3300" height="2400" alt="benchmark_results" src="https://github.com/user-attachments/assets/24b409ca-4b71-42ee-a3a2-fc6e79311f0c" />

Happy to add the math to the docstring or a dedicated section of the docs if that's the convention.

I am also working on a similar improvement of `_pairwise_distance_riemann` but I am struggling to have a numerically stable version for both SPD and HPD matrices.

Cheers,


 ----

Derivation


### Sylvester's formula

Based on the formula on [Wikipedia](https://en.wikipedia.org/wiki/Sylvester%27s_formula), for $X$ an SPD/HPD matrix:

```math
f(X) = f(\lambda_+) X_+ + f(\lambda_-) X_-
```

with

```math
X_+ = \frac{1}{\lambda_+ - \lambda_-}(X - \lambda_- I_2), \qquad X_- = \frac{1}{\lambda_- - \lambda_+}(X - \lambda_+ I_2)
```

Expanding gives:

```math
f(X) = \underbrace{\frac{f(\lambda_+) - f(\lambda_-)}{\lambda_+ - \lambda_-}}_{\alpha_1} X + \underbrace{\frac{\lambda_+ f(\lambda_-) - \lambda_- f(\lambda_+)}{\lambda_+ - \lambda_-}}_{\alpha_2} I_2
```

### Eigenvalues of a 2×2 SPD/HPD matrix

For $X = \begin{pmatrix}a & b \\ b & c\end{pmatrix}$, using trace and determinant:

```math
\begin{cases} \lambda_+ + \lambda_- = a + c \\ \lambda_+ \lambda_- = ac - |b|^2 \end{cases}
```

Solving the characteristic polynomial $\lambda^2 - (a+c)\lambda + ac - |b|^2 = 0$ gives:

```math
\lambda_{\pm} = \frac{(a+c) \pm \sqrt{(a+c)^2 - 4(ac - |b|^2)}}{2} = \frac{(a+c) \pm \sqrt{(a-c)^2 + 4|b|^2}}{2}
```
