### PR TITLE
deprecate covariances_X and cospectrum

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,7 +10,8 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.12.dev
 ---------
 
-- Deprecate ``covariances_X`` and ``cospectrum``. :pr:`442` by :user:`qbarthelemy`
+- Deprecate ``covariances_X`` and ``cospectrum``.
+  :pr:`442` by :user:`qbarthelemy`
 
 v0.11 (April 2026)
 ------------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,8 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.12.dev
 ---------
 
+- Deprecate ``covariances_X`` and ``cospectrum``. :pr:`442` by :user:`qbarthelemy`
+
 v0.11 (April 2026)
 ------------------
 

--- a/pyriemann/_version.py
+++ b/pyriemann/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.11'
+__version__ = '0.12.dev'

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.stats import chi2
 from sklearn.covariance import oas, ledoit_wolf, fast_mcd
 
+from . import deprecated
 from .base import ctranspose, _vectorize_nd
 from .distance import distance_mahalanobis
 from .test import is_square, is_real_type
@@ -469,6 +470,10 @@ def covariances_EP(X, P, estimator="cov", **kwds):
     return est(PX, **kwds)
 
 
+
+@deprecated(
+    "covariances_X() is deprecated and will be removed in 0.14.0."
+)
 def covariances_X(X, estimator="cov", alpha=0.2, **kwds):
     """Special form covariance matrix, embedding input X.
 
@@ -686,6 +691,10 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     return S, freqs
 
 
+@deprecated(
+    "cospectrum() is deprecated and will be removed in 0.14.0; "
+    "please use cross_spectrum() and take the real part of first output."
+)
 def cospectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     """Compute co-spectral matrices, the real part of cross-spectra.
 

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -600,7 +600,9 @@ def eegtocov(sig, window=128, overlapp=0.5, padding=True, estimator="cov"):
 
 
 def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
-    """Compute the complex cross-spectral matrices of a real signal X.
+    """Compute the complex cross-spectral matrices of a real signal.
+
+    Note that co-spectral matrices are the real part of cross-spectra.
 
     Parameters
     ----------

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -470,7 +470,6 @@ def covariances_EP(X, P, estimator="cov", **kwds):
     return est(PX, **kwds)
 
 
-
 @deprecated(
     "covariances_X() is deprecated and will be removed in 0.14.0."
 )

--- a/pyriemann/utils/covariance.py
+++ b/pyriemann/utils/covariance.py
@@ -624,6 +624,10 @@ def cross_spectrum(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None):
     freqs : ndarray, shape (n_freqs,)
         Frequencies associated to cross-spectra.
 
+    Notes
+    -----
+    .. versionadded:: 0.2.7
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Cross-spectrum
@@ -772,6 +776,12 @@ def coherence(X, window=128, overlap=0.75, fmin=None, fmax=None, fs=None,
         Squared coherence matrices, for each frequency bin.
     freqs : ndarray, shape (n_freqs,)
         Frequencies associated to coherence.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.4
+    .. versionchanged:: 0.3
+        Add support for lagged and imaginary coherences.
 
     References
     ----------


### PR DESCRIPTION
Deprecations to reduce the number of functions to maintain:
- `covariances_X ` is never used
- `cospectrum` is simply the real part of first output of `cross_spectrum`