### PR TITLE
Add innerproduct_wasserstein for Hermitian matrices

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -815,6 +815,7 @@ Tangent Space
     innerproduct_logchol
     innerproduct_logeuclid
     innerproduct_riemann
+    innerproduct_wasserstein
     norm
     transport
     transport_euclid

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -13,6 +13,9 @@ v0.13.dev
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
   :pr:`462` by :user:`qbarthelemy`
 
+- Add Wasserstein inner product for Hermitian matrices :func:`pyriemann.geometry.tangentspace.innerproduct_wasserstein`.
+  :pr:`455` by :user:`qbarthelemy`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/geometry/distance.py
+++ b/pyriemann/geometry/distance.py
@@ -612,13 +612,15 @@ def distance_wasserstein(A, B, squared=False):
 
     References
     ----------
-    .. [1] `Optimal transport: old and new
-        <https://link.springer.com/book/10.1007/978-3-540-71050-9>`_
-        C. Villani. Springer Science & Business Media, 2008, vol. 338
-    .. [2] `An extension of Kakutani's theorem on infinite product measures to
+    .. [1] `An extension of Kakutani's theorem on infinite product measures to
         the tensor product of semifinite w*-algebras
         <https://www.ams.org/journals/tran/1969-135-00/S0002-9947-1969-0236719-2/S0002-9947-1969-0236719-2.pdf>`_
         D. Bures. Trans Am Math Soc, 1969, 135, pp. 199-212
+    .. [2] `On the Bures–Wasserstein distance between positive definite
+        matrices
+        <https://www.sciencedirect.com/science/article/pii/S0723086918300021>`_
+        R. Bhatia, T. Jain, Y. Lim. Expositiones mathematicae, 2019, 37,
+        pp. 165-191.
     """  # noqa
     xp = check_matrix_pair(A, B)
     B12 = sqrtm(B)

--- a/pyriemann/geometry/geodesic.py
+++ b/pyriemann/geometry/geodesic.py
@@ -362,7 +362,7 @@ def geodesic_wasserstein(A, B, alpha=0.5):
 
     The matrix at position :math:`\alpha` on the Wasserstein geodesic between
     two SPD/HPD matrices :math:`\mathbf{A}` and :math:`\mathbf{B}` is
-    given in [1]_:
+    given in Proposition 4 of [1]_:
 
     .. math::
         \mathbf{C} = (1-\alpha)^2\mathbf{A} + \alpha^2\mathbf{B} +

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -237,16 +237,8 @@ def exp_map_wasserstein(X, Cref, **kwargs):
         pp. 137–179.
     """
     xp = check_matrix_pair(X, Cref, require_square=True)
-    d, V = xp.linalg.eigh(Cref)
-    Vh = ctranspose(V)
-    C = 1 / (d[:, None] + d[None, :])
-
-    X_rotated = Vh @ X @ V
-    X_tmp = C * X_rotated
-    X_tmp = X_tmp @ (d[..., None] * X_tmp)
-    X_tmp = V @ X_tmp @ Vh
-
-    return Cref + X + X_tmp
+    LX = xp.asarray(solve_continuous_lyapunov(Cref, X))
+    return Cref + X + LX @ Cref @ LX
 
 
 exp_map_functions = {
@@ -955,7 +947,7 @@ def innerproduct_wasserstein(X, Y, Cref):
 
     Wasserstein inner product :math:`\mathbf{g}` between
     symmetric/Hermitian matrices in tangent space :math:`\mathbf{X}`
-    and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in Eq(6)
+    and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in Eq.(7)
     of [1]_. See also [2]_.
 
     Parameters

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -949,6 +949,66 @@ def innerproduct_riemann(X, Y, Cref):
     return _apply_inner_product(X_, Y_)
 
 
+def innerproduct_wasserstein(X, Y, Cref):
+    r"""Wasserstein inner product.
+
+    Wasserstein inner product :math:`\mathbf{g}` between
+    symmetric/Hermitian matrices in tangent space :math:`\mathbf{X}`
+    and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in [1]_.
+    Implementation comes from Eq.(32) in [2]_.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        First symmetric/Hermitian matrices in tangent space at Cref.
+    Y : ndarray, shape (..., n, n) | None
+        Second symmetric/Hermitian matrices in tangent space at Cref.
+        If None, Y is set to X, giving the squared norm of X.
+    Cref : ndarray, shape (n, n)
+        Reference SPD/HPD matrix.
+
+    Returns
+    -------
+    G : float or ndarray, shape (...,)
+        Wasserstein inner product between X and Y.
+
+    Notes
+    -----
+    .. versionadded:: 0.12
+
+    See Also
+    --------
+    innerproduct
+
+    References
+    ----------
+    .. [1] `Wasserstein Riemannian geometry of Gaussian densities
+        <https://link.springer.com/article/10.1007/s41884-018-0014-4>`_
+        L. Malagò, L. Montrucchio, G. Pistone. Information Geometry, 2018, 1,
+        pp. 137–179.
+    .. [2] `On the Bures–Wasserstein distance between positive definite
+        matrices
+        <https://www.sciencedirect.com/science/article/pii/S0723086918300021>`_
+        R. Bhatia, T. Jain, Y. Lim. Expositiones mathematicae, 2019, 37,
+        pp. 165-191.
+    """
+    xp = check_matrix_pair(X, Cref, require_square=True)
+    eigvals, eigvecs = xp.linalg.eigh(Cref)
+
+    if Y is None:
+        Y = X
+
+    alpha = eigvals[:, None] / (eigvals[:, None] + eigvals[None, :]) ** 2
+    X_ = eigvecs.T @ xp.conj(X) @ eigvecs
+    Y_ = eigvecs.T @ Y @ eigvecs
+    G = xp.einsum("ij,...ij,...ji->...", alpha, X_, Y_).real
+
+    if is_numpy_namespace(xp) and G.ndim == 0:
+        return float(G)
+    else:
+        return G
+
+
 def _apply_inner_product(X, Y):
     # product G = trace(X^H @ Y)
     xp = get_namespace(X, Y)
@@ -965,6 +1025,7 @@ innerproduct_functions = {
     "logchol": innerproduct_logchol,
     "logeuclid": innerproduct_logeuclid,
     "riemann": innerproduct_riemann,
+    "wasserstein": innerproduct_wasserstein,
 }
 
 
@@ -986,7 +1047,8 @@ def innerproduct(X, Y, Cref, metric="riemann"):
         Reference matrix.
     metric : string | callable, default="riemann"
         Metric used for inner product, can be:
-        "euclid", "logchol", "logeuclid", "riemann", or a callable function.
+        "euclid", "logchol", "logeuclid", "riemann", "wasserstein",
+        or a callable function.
 
     Returns
     -------
@@ -1005,6 +1067,7 @@ def innerproduct(X, Y, Cref, metric="riemann"):
     innerproduct_logchol
     innerproduct_logeuclid
     innerproduct_riemann
+    innerproduct_wasserstein
     """
     innerproduct_function = check_function(metric, innerproduct_functions)
     return innerproduct_function(X, Y, Cref)

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -967,7 +967,7 @@ def innerproduct_wasserstein(X, Y, Cref):
 
     Notes
     -----
-    .. versionadded:: 0.12
+    .. versionadded:: 0.13
 
     See Also
     --------

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -7,6 +7,7 @@ from array_api_compat import (
     device as xpd,
     is_numpy_namespace,
 )
+from scipy.linalg import solve_continuous_lyapunov
 
 from ._backend import diag_indices, tril_indices, triu_indices
 from ._check import check_function, check_matrix_pair
@@ -954,8 +955,8 @@ def innerproduct_wasserstein(X, Y, Cref):
 
     Wasserstein inner product :math:`\mathbf{g}` between
     symmetric/Hermitian matrices in tangent space :math:`\mathbf{X}`
-    and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in [1]_.
-    Implementation comes from Eq.(32) in [2]_.
+    and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in Eq(6)
+    of [1]_. See also [2]_.
 
     Parameters
     ----------
@@ -993,16 +994,14 @@ def innerproduct_wasserstein(X, Y, Cref):
         pp. 165-191.
     """
     xp = check_matrix_pair(X, Cref, require_square=True)
-    eigvals, eigvecs = xp.linalg.eigh(Cref)
-
+    LX = xp.asarray(solve_continuous_lyapunov(Cref, xp.conj(X)))
     if Y is None:
         Y = X
+    G = 0.5 * xp.einsum("...ij,...ij->...", LX, Y).real
+    return _prepare_output(G, xp)
 
-    alpha = eigvals[:, None] / (eigvals[:, None] + eigvals[None, :]) ** 2
-    X_ = eigvecs.T @ xp.conj(X) @ eigvecs
-    Y_ = eigvecs.T @ Y @ eigvecs
-    G = xp.einsum("ij,...ij,...ji->...", alpha, X_, Y_).real
 
+def _prepare_output(G, xp):
     if is_numpy_namespace(xp) and G.ndim == 0:
         return float(G)
     else:
@@ -1013,11 +1012,7 @@ def _apply_inner_product(X, Y):
     # product G = trace(X^H @ Y)
     xp = get_namespace(X, Y)
     G = xp.einsum("...nm,...nm->...", xp.conj(X), Y).real
-
-    if is_numpy_namespace(xp) and G.ndim == 0:
-        return float(G)
-    else:
-        return G
+    return _prepare_output(G, xp)
 
 
 innerproduct_functions = {
@@ -1087,8 +1082,8 @@ def norm(X, Cref, metric="riemann"):
     Cref : ndarray, shape (n, n) | None
         Reference matrix.
     metric : string | callable, default="riemann"
-        Metric used for norm, can be:
-        "euclid", "logeuclid", "riemann", or a callable function.
+        Metric used for norm, see
+        :func:`pyriemann.geometry.tangentspace.innerproduct`.
 
     Returns
     -------

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -29,6 +29,7 @@ from pyriemann.geometry.tangentspace import (
     innerproduct_logchol,
     innerproduct_logeuclid,
     innerproduct_riemann,
+    innerproduct_wasserstein,
     norm,
     transport,
     transport_euclid,
@@ -223,7 +224,7 @@ def test_tangent_and_untangent_space(kind, metric, get_mats):
 
 ###############################################################################
 
-metrics = ["euclid", "logchol", "logeuclid", "riemann"]
+metrics = ["euclid", "logchol", "logeuclid", "riemann", "wasserstein"]
 
 
 @pytest.mark.parametrize("metric", metrics)
@@ -292,6 +293,7 @@ def test_innerproduct_x_y(kindX, kindC, metric, get_mats):
         innerproduct_logchol,
         innerproduct_logeuclid,
         innerproduct_riemann,
+        innerproduct_wasserstein,
     ],
 )
 def test_innerproduct_broadcasting(finnerproduct, backend, get_mats):

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -315,8 +315,10 @@ def test_innerproduct_broadcasting(finnerproduct, backend, get_mats):
 @pytest.mark.parametrize("metric", metrics)
 def test_innerproduct_property_distance(kindX, kindC, metric, get_mats):
     """Test d(C,exp_C(X))^2 = g_C(X,X) locally"""
+    if kindC == "hpd" and metric == "wasserstein":
+        pytest.skip()
     n_matrices, n_channels = 5, 3
-    X = get_mats(n_matrices, n_channels, kindX)
+    X = 0.1 * get_mats(n_matrices, n_channels, kindX)
     Cref = get_mats(1, n_channels, kindC)[0]
     G = innerproduct(X, X, Cref, metric=metric)
 

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -2,6 +2,7 @@ from array_api_compat import array_namespace as get_namespace
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
+from scipy.linalg import solve_continuous_lyapunov
 
 from conftest import approx, to_numpy
 from pyriemann.geometry.distance import distance, distance_riemann
@@ -268,6 +269,15 @@ def test_innerproduct_x_x(kindX, kindC, metric, get_mats):
     G1 = innerproduct(X, None, Cref, metric=metric)
     assert_array_equal(G, G1)
 
+
+@pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])
+@pytest.mark.parametrize("metric", metrics)
+def test_innerproduct_distance(kindX, kindC, metric, get_mats):
+    n_matrices, n_channels = 3, 2
+    X = get_mats(n_matrices, n_channels, kindX)
+    Cref = get_mats(1, n_channels, kindC)[0]
+    G = innerproduct(X, X, Cref, metric=metric)
+
     Xexp = exp_map(X, Cref, metric=metric, Cm12=True)
     G2 = distance(Xexp, Cref, metric=metric, squared=True)
     assert_array_almost_equal(G, G2.flatten())
@@ -393,6 +403,20 @@ def test_innerproduct_riemann(kindX, kindC, get_mats):
 
     # Eq(2.6) in [Moakher2005]
     G1 = np.trace(np.linalg.solve(Cref, X) @ np.linalg.solve(Cref, Y))
+    assert_array_almost_equal(G, G1)
+
+
+def test_innerproduct_wasserstein(get_mats):
+    n_channels = 4
+    X, Y = get_mats(2, n_channels, "sym")
+    Cref = get_mats(1, n_channels, "spd")[0]
+    G = innerproduct_wasserstein(X, Y, Cref)
+    xp = get_namespace(X)
+
+    # Eq(6) in [Malago2018]
+    LX = xp.asarray(solve_continuous_lyapunov(Cref, X))
+    LY = xp.asarray(solve_continuous_lyapunov(Cref, Y))
+    G1 = xp.trace(LX @ Cref @ LY)
     assert_array_almost_equal(G, G1)
 
 

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -272,19 +272,6 @@ def test_innerproduct_x_x(kindX, kindC, metric, get_mats):
 
 @pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])
 @pytest.mark.parametrize("metric", metrics)
-def test_innerproduct_distance(kindX, kindC, metric, get_mats):
-    n_matrices, n_channels = 3, 2
-    X = get_mats(n_matrices, n_channels, kindX)
-    Cref = get_mats(1, n_channels, kindC)[0]
-    G = innerproduct(X, X, Cref, metric=metric)
-
-    Xexp = exp_map(X, Cref, metric=metric, Cm12=True)
-    G2 = distance(Xexp, Cref, metric=metric, squared=True)
-    assert_array_almost_equal(G, G2.flatten())
-
-
-@pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])
-@pytest.mark.parametrize("metric", metrics)
 def test_innerproduct_x_y(kindX, kindC, metric, get_mats):
     """Test innerproduct for different X and Y"""
     n_matrices, n_channels = 4, 3
@@ -322,6 +309,20 @@ def test_innerproduct_broadcasting(finnerproduct, backend, get_mats):
     C = xp.stack([A for _ in range(n_sets)])
     D = xp.stack([B for _ in range(n_sets)])
     assert finnerproduct(C, D, Cref).shape == (n_sets, n_matrices)  # 4D arrays
+
+
+@pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])
+@pytest.mark.parametrize("metric", metrics)
+def test_innerproduct_property_distance(kindX, kindC, metric, get_mats):
+    """Test d(C,exp_C(X))^2 = g_C(X,X) locally"""
+    n_matrices, n_channels = 5, 3
+    X = get_mats(n_matrices, n_channels, kindX)
+    Cref = get_mats(1, n_channels, kindC)[0]
+    G = innerproduct(X, X, Cref, metric=metric)
+
+    Xexp = exp_map(X, Cref, metric=metric, Cm12=True)
+    G2 = distance(Xexp, Cref, metric=metric, squared=True)
+    assert_array_almost_equal(G, G2.flatten())
 
 
 @pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -321,8 +321,8 @@ def test_innerproduct_property_distance(kindX, kindC, metric, get_mats):
     G = innerproduct(X, X, Cref, metric=metric)
 
     Xexp = exp_map(X, Cref, metric=metric, Cm12=True)
-    G2 = distance(Xexp, Cref, metric=metric, squared=True)
-    assert_array_almost_equal(G, G2.flatten())
+    D2 = distance(Xexp, Cref, metric=metric, squared=True)
+    assert_array_almost_equal(D2.flatten(), G)
 
 
 @pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])


### PR DESCRIPTION
Add `innerproduct_wasserstein` for Hermitian matrices,
following [Malago2018, Wasserstein Riemannian geometry of Gaussian densities](https://arxiv.org/pdf/1801.09269)
and [Bathia2019, On the Bures–Wasserstein distance between positive definite matrices](https://www.sciencedirect.com/science/article/pii/S0723086918300021)

Tests `test_innerproduct_property_distance` are KO.