### PR TITLE
Make stateless transformers report as fitted (fix #456)

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,11 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.12.dev
 ---------
 
+- Add ``__sklearn_is_fitted__`` to stateless transformers, so they pass
+  scikit-learn's ``check_is_fitted`` after ``fit`` and can be used inside
+  ``Pipeline(transform_input=...)`` (introduced in scikit-learn 1.6).
+  :pr:`457` by :user:`bruAristimunha`
+
 - Deprecate ``covariances_X`` and ``cospectrum``.
   :pr:`442` by :user:`qbarthelemy`
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,11 +10,6 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.12.dev
 ---------
 
-- Add ``__sklearn_is_fitted__`` to stateless transformers, so they pass
-  scikit-learn's ``check_is_fitted`` after ``fit`` and can be used inside
-  ``Pipeline(transform_input=...)`` (introduced in scikit-learn 1.6).
-  :pr:`457` by :user:`bruAristimunha`
-
 - Deprecate ``covariances_X`` and ``cospectrum``.
   :pr:`442` by :user:`qbarthelemy`
 
@@ -65,6 +60,11 @@ v0.12.dev
 - Add log-Cholesky inner product for SPD matrices :func:`pyriemann.geometry.tangentspace.innerproduct_logchol`,
   and improve other inner products.
   :pr:`450` by :user:`qbarthelemy`
+
+- Add ``__sklearn_is_fitted__`` to stateless transformers, so they pass
+  scikit-learn's ``check_is_fitted`` after ``fit`` and can be used inside
+  ``Pipeline(transform_input=...)`` (introduced in scikit-learn 1.6).
+  :pr:`457` by :user:`bruAristimunha`
 
 v0.11 (April 2026)
 ------------------

--- a/pyriemann/estimation.py
+++ b/pyriemann/estimation.py
@@ -65,6 +65,9 @@ class Covariances(TransformerMixin, BaseEstimator):
         """
         return self
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def transform(self, X):
         """Estimate covariance matrices.
 
@@ -568,6 +571,9 @@ class CrossSpectra(TransformerMixin, BaseEstimator):
         """
         return self
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def transform(self, X):
         """Estimate cross-spectral matrices.
 
@@ -837,6 +843,9 @@ class TimeDelayCovariances(TransformerMixin, BaseEstimator):
         """
         return self
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def transform(self, X):
         """Estimate the time delay covariance matrices.
 
@@ -970,6 +979,9 @@ class Kernels(TransformerMixin, BaseEstimator):
         """
         return self
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def transform(self, X):
         """Estimate kernel matrices from time series.
 
@@ -1064,6 +1076,9 @@ class Shrinkage(TransformerMixin, BaseEstimator):
             The Shrinkage instance.
         """
         return self
+
+    def __sklearn_is_fitted__(self):
+        return True
 
     def transform(self, X):
         """Shrink the SPD/HPD matrices.

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -61,6 +61,9 @@ class TLDummy(TransformerMixin, BaseEstimator):
         """
         return self
 
+    def __sklearn_is_fitted__(self):
+        return True
+
     def transform(self, X):
         """Do nothing.
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -404,7 +404,7 @@ def test_shrinkage(shrinkage, kind, get_mats):
     ],
 )
 def test_stateless_check_is_fitted(estimator, n_dim, kind, get_mats):
-    """Stateless transformers report as fitted after ``fit`` (issue #456).
+    """Stateless transformers report as fitted after ``fit``.
 
     They have a no-op ``fit`` and set no fitted attribute, so without
     ``__sklearn_is_fitted__`` scikit-learn's ``check_is_fitted`` raised

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -5,6 +5,7 @@ from numpy.testing import (
     assert_raises,
 )
 from sklearn.covariance import shrunk_covariance
+from sklearn.utils.validation import check_is_fitted
 import pytest
 
 from pyriemann.estimation import (
@@ -387,3 +388,28 @@ def test_shrinkage(shrinkage, kind, get_mats):
 
     Xt2 = sh.fit_transform(X)
     assert_array_almost_equal(Xt, Xt2)
+
+
+@pytest.mark.parametrize(
+    "estimator, n_dim, kind",
+    [
+        (Covariances(), [3, 100], "real"),
+        (BlockCovariances(block_size=1), [3, 100], "real"),
+        (CrossSpectra(), [3, 100], "real"),
+        (CoSpectra(), [3, 100], "real"),
+        (Coherences(), [3, 100], "real"),
+        (TimeDelayCovariances(), [3, 100], "real"),
+        (Kernels(), [3, 100], "real"),
+        (Shrinkage(), 3, "spd"),
+    ],
+)
+def test_stateless_check_is_fitted(estimator, n_dim, kind, get_mats):
+    """Stateless transformers report as fitted after ``fit`` (issue #456).
+
+    They have a no-op ``fit`` and set no fitted attribute, so without
+    ``__sklearn_is_fitted__`` scikit-learn's ``check_is_fitted`` raised
+    ``NotFittedError`` (covers subclasses ``BlockCovariances``/``CoSpectra``/
+    ``Coherences`` via inheritance).
+    """
+    X = get_mats(2, n_dim, kind)
+    check_is_fitted(estimator.fit(X))

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -7,6 +7,7 @@ from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.model_selection import KFold, StratifiedShuffleSplit
 from sklearn.pipeline import make_pipeline, Pipeline
 from sklearn.svm import LinearSVC, LinearSVR
+from sklearn.utils.validation import check_is_fitted
 
 from pyriemann.datasets.simulated import (
     make_classification_transfer,
@@ -121,6 +122,7 @@ def test_tldummy(rndstate, space):
 
     dum = TLDummy()
     dum.fit(X, y_enc)
+    check_is_fitted(dum)  # issue #456: stateless step must report as fitted
     dum.fit_transform(X, y_enc)
     dum.transform(X)
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -122,7 +122,7 @@ def test_tldummy(rndstate, space):
 
     dum = TLDummy()
     dum.fit(X, y_enc)
-    check_is_fitted(dum)  # issue #456: stateless step must report as fitted
+    check_is_fitted(dum)
     dum.fit_transform(X, y_enc)
     dum.transform(X)
 


### PR DESCRIPTION
Closes #456.

## Problem

Stateless transformers (`Covariances`, `CrossSpectra`, `TimeDelayCovariances`, `Kernels`, `Shrinkage`, `TLDummy`, and their subclasses) have a no-op `fit` and define no fitted attribute nor `__sklearn_is_fitted__`. After `.fit(...)` they fail scikit-learn's `check_is_fitted`, raising `NotFittedError`.

This breaks scikit-learn ≥ 1.6's `Pipeline(transform_input=...)`, which transforms an auxiliary `fit` input through the fitted sub-pipeline (calling `transform` → `check_is_fitted`) before the consuming step — e.g. feeding an unlabeled target slice to a mid-pipeline alignment step (RPA after `Covariances`) in transfer-learning pipelines.

## Fix

Add `__sklearn_is_fitted__(self): return True` to each stateless base class (the maintainer-approved suggestion in the issue). Subclasses (`BlockCovariances`, `CoSpectra`, `Coherences`) inherit it via MRO.

## Tests

- `tests/test_estimation.py::test_stateless_check_is_fitted` — `check_is_fitted` passes after `fit` for all stateless estimation transformers and subclasses.
- `tests/test_transfer.py::test_tldummy` — extended with a `check_is_fitted` assertion for `TLDummy`.

Both reproducers from the issue (bare `check_is_fitted` and the `Pipeline(transform_input=...)` pattern) now pass. Full `test_estimation.py` and `test_transfer.py` suites are green.