### PR TITLE
Correct test on linearity of inner products and update doc of log-Cholesky inner product

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -60,7 +60,7 @@ v0.12 (July 2026)
   to generate HPD matrices from complex-typed mean for float ``sigma``.
   :issue:`413` by :user:`robrui`
 
-- Add log-Cholesky inner product for SPD matrices :func:`pyriemann.geometry.tangentspace.innerproduct_logchol`,
+- Add log-Cholesky inner product for Hermitian matrices :func:`pyriemann.geometry.tangentspace.innerproduct_logchol`,
   and improve other inner products.
   :pr:`450` by :user:`qbarthelemy`
 

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -782,18 +782,18 @@ def innerproduct_logchol(X, Y, Cref):
     r"""Log-Cholesky inner product.
 
     Log-Cholesky inner product :math:`\mathbf{g}` between
-    symmetric matrices in tangent space :math:`\mathbf{X}`
+    symmetric/Hermitian matrices in tangent space :math:`\mathbf{X}`
     and :math:`\mathbf{Y}` at :math:`\mathbf{C}_\text{ref}` is given in [1]_.
 
     Parameters
     ----------
     X : ndarray, shape (..., n, n)
-        First symmetric matrices in tangent space at Cref.
+        First symmetric/Hermitian matrices in tangent space at Cref.
     Y : ndarray, shape (..., n, n) | None
-        Second symmetric matrices in tangent space at Cref.
+        Second symmetric/Hermitian matrices in tangent space at Cref.
         If None, Y is set to X, giving the squared norm of X.
     Cref : ndarray, shape (n, n)
-        Reference SPD matrix.
+        Reference SPD/HPD matrix.
 
     Returns
     -------

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -328,27 +328,20 @@ def test_innerproduct_property_conjsymmetry(kindX, kindC, metric, get_mats):
 @pytest.mark.parametrize("metric", metrics)
 def test_innerproduct_property_linearity(kindX, kindC, metric,
                                          get_mats, rndstate):
-    if kindC == "hpd" and metric == "logchol":
-        pytest.skip()
     n_matrices, n_channels = 4, 3
     X = get_mats(n_matrices, n_channels, kindX)
     Y = get_mats(n_matrices, n_channels, kindX)
     Z = get_mats(n_matrices, n_channels, kindX)
     Cref = get_mats(1, n_channels, kindC)[0]
     a, b = rndstate.uniform(0.01, 0.99, size=2)
-    if kindX == "herm":
-        a_, b_ = rndstate.uniform(0.01, 0.99, size=2)
-        a += 1j * a_
-        b += 1j * b_
 
     Gxy = innerproduct(X, Y, Cref, metric=metric)
     Gxz = innerproduct(X, Z, Cref, metric=metric)
     Gyz = innerproduct(Y, Z, Cref, metric=metric)
 
     Gaxpbz = innerproduct(a * X + b * Y, Z, Cref, metric=metric)
-    aGxzpbGyz = a.conj() * Gxz + b.conj() * Gyz
+    aGxzpbGyz = a * Gxz + b * Gyz
     assert_array_almost_equal(Gaxpbz, aGxzpbGyz.real)
-
     Gxaypbz = innerproduct(X, a * Y + b * Z, Cref, metric=metric)
     aGxypbGxz = a * Gxy + b * Gxz
     assert_array_almost_equal(Gxaypbz, aGxypbGxz.real)

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -342,6 +342,7 @@ def test_innerproduct_property_linearity(kindX, kindC, metric,
     Gaxpbz = innerproduct(a * X + b * Y, Z, Cref, metric=metric)
     aGxzpbGyz = a * Gxz + b * Gyz
     assert_array_almost_equal(Gaxpbz, aGxzpbGyz.real)
+
     Gxaypbz = innerproduct(X, a * Y + b * Z, Cref, metric=metric)
     aGxypbGxz = a * Gxy + b * Gxz
     assert_array_almost_equal(Gxaypbz, aGxypbGxz.real)


### PR DESCRIPTION
Solves #454, because current code for log-Cholesky inner product already supports Hermitian matrices

As noticed here, https://github.com/pyRiemann/pyRiemann/pull/450#issuecomment-4847816538, `test_innerproduct_property_linearity` is false:
`a * X + b * Y` is Hermitian for `X` and `Y` Hermitian, and `a` and `b` real, not complex.