### PR TITLE
Add transductive re-estimation to TLCenter for LOSO transfer

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,7 +11,7 @@ v0.13.dev
 ---------
 
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
-:pr:`462` by :user:`qbarthelemy`
+  :pr:`462` by :user:`qbarthelemy`
 
 - Add ``"transductive"`` as a special value for ``target_domain`` in
   :class:`pyriemann.transfer.TLCenter`, so that ``transform()`` can recenter a

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,14 +10,14 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.13.dev
 ---------
 
+- Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
+:pr:`462` by :user:`qbarthelemy`
+
 - Add ``transductive`` parameter to :class:`pyriemann.transfer.TLCenter`, so
-  that ``transform()`` can recenter a batch to its own recomputed mean
+  that ``transform()`` can recenter a set of inputs to its own recomputed mean
   instead of a stored per-domain center. This supports leave-one-subject-out
   (or leave-one-session-out) evaluation, where the test domain is never seen
   during ``fit()``.
-
-- Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
-  :pr:`462` by :user:`qbarthelemy`
 
 v0.12 (July 2026)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -18,6 +18,9 @@ v0.13.dev
   set of inputs to its own recomputed mean instead of a stored per-domain
   center. This supports leave-one-subject-out (or leave-one-session-out)
   evaluation, where the test domain is never seen during ``fit()``.
+  Also add ``"last"`` as a clearer spelling for the existing "recenter to the
+  last fitted domain" behavior, deprecating the empty string ``""`` (which
+  had the same meaning); ``""`` will be removed in 0.14.0.
 
 v0.12 (July 2026)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,7 +20,7 @@ v0.13.dev
   evaluation, where the test domain is never seen during ``fit()``.
   Also add ``"last"`` as a clearer spelling for the existing "recenter to the
   last fitted domain" behavior, deprecating the empty string ``""`` (which
-  had the same meaning); ``""`` will be removed in 0.14.0.
+  had the same meaning).
 
 v0.12 (July 2026)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -13,11 +13,11 @@ v0.13.dev
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
 :pr:`462` by :user:`qbarthelemy`
 
-- Add ``transductive`` parameter to :class:`pyriemann.transfer.TLCenter`, so
-  that ``transform()`` can recenter a set of inputs to its own recomputed mean
-  instead of a stored per-domain center. This supports leave-one-subject-out
-  (or leave-one-session-out) evaluation, where the test domain is never seen
-  during ``fit()``.
+- Add ``"transductive"`` as a special value for ``target_domain`` in
+  :class:`pyriemann.transfer.TLCenter`, so that ``transform()`` can recenter a
+  set of inputs to its own recomputed mean instead of a stored per-domain
+  center. This supports leave-one-subject-out (or leave-one-session-out)
+  evaluation, where the test domain is never seen during ``fit()``.
 
 v0.12 (July 2026)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,12 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.13.dev
 ---------
 
+- Add ``transductive`` parameter to :class:`pyriemann.transfer.TLCenter`, so
+  that ``transform()`` can recenter a batch to its own recomputed mean
+  instead of a stored per-domain center. This supports leave-one-subject-out
+  (or leave-one-session-out) evaluation, where the test domain is never seen
+  during ``fit()``.
+
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
   :pr:`462` by :user:`qbarthelemy`
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -243,6 +243,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
           recentering all inputs in target domain;
           or in the last fitted domain when ``target_domain="last"``;
           or to their own mean when ``target_domain="transductive"``.
+
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels) or \

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -140,7 +140,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         If True, ``transform()`` ignores ``target_domain`` and ``centers_``,
         and instead recenters its input to its own mean, recomputed from the
         matrices or vectors passed to ``transform()``. This is useful at test
-        time in a leave-one-subject-out (or leave-one-session-out) setting,
+        time in a leave-one-subject/session-out setting,
         when the test domain was never seen during ``fit()`` and therefore
         has no stored center in ``centers_``. This unsupervised re-estimation
         of the reference point on unseen data was originally proposed, for

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -128,23 +128,37 @@ class TLCenter(TransformerMixin, BaseEstimator):
         * if not empty, ``transform()`` recenters matrices to the specified
           target domain;
         * else, ``transform()`` recenters matrices to the last fitted domain.
+
+        Ignored when ``transductive=True``.
     metric : str, default="riemann"
         For inputs in manifold,
         metric used for mean estimation. For the list of supported metrics,
         see :func:`pyriemann.geometry.mean.gmean`.
         Note, however, that only when using the "riemann" metric that we are
         ensured to re-center the matrices precisely to the identity.
+    transductive : bool, default=False
+        If True, ``transform()`` ignores ``target_domain`` and ``centers_``,
+        and instead recenters its input to its own mean, recomputed from the
+        matrices or vectors passed to ``transform()``. This is useful at test
+        time in a leave-one-subject-out (or leave-one-session-out) setting,
+        when the test domain was never seen during ``fit()`` and therefore
+        has no stored center in ``centers_``. This unsupervised re-estimation
+        of the reference point on unseen data was originally proposed, for
+        inter-session adaptation, in [3]_.
 
     Attributes
     ----------
     centers_ : dict
         Dictionary with key=domain_name and value=domain_center.
+        Not used by ``transform()`` when ``transductive=True``.
 
     Notes
     -----
     .. versionadded:: 0.4
     .. versionchanged:: 0.8
         Add support for tangent space centering.
+    .. versionchanged:: 0.13
+        Add ``transductive`` parameter.
 
     References
     ----------
@@ -157,12 +171,18 @@ class TLCenter(TransformerMixin, BaseEstimator):
         A Euclidean Space Data Alignment Approach
         <https://arxiv.org/abs/1808.05464>`_
         He He and Dongrui Wu, IEEE Transactions on Biomedical Engineering, 2019
+    .. [3] `Classification of covariance matrices using a Riemannian-based
+        kernel for BCI applications
+        <https://hal.science/hal-00820475>`_
+        A Barachant, S Bonnet, M Congedo, C Jutten, Neurocomputing, vol. 112,
+        pp. 172-178, 2013
     """
 
-    def __init__(self, target_domain, metric="riemann"):
+    def __init__(self, target_domain, metric="riemann", transductive=False):
         """Init"""
         self.target_domain = target_domain
         self.metric = metric
+        self.transductive = transductive
 
     def fit(self, X, y_enc, sample_weight=None):
         """Fit TLCenter.
@@ -216,7 +236,8 @@ class TLCenter(TransformerMixin, BaseEstimator):
         .. note::
            This method is designed for using at test time,
            recentering all inputs in target domain, or in the last fitted
-           domain.
+           domain. When ``transductive=True``, it instead recenters ``X`` to
+           its own mean, recomputed from ``X`` and ignoring ``centers_``.
 
         Parameters
         ----------
@@ -232,6 +253,11 @@ class TLCenter(TransformerMixin, BaseEstimator):
         """
         _check_inputs(X)
 
+        if self.transductive:
+            if X.ndim == 3:
+                return Whitening(metric=self.metric).fit_transform(X)
+            return X - np.mean(X, axis=0)
+
         # if target domain is specified, use it
         if self.target_domain != "":
             target_domain = self.target_domain
@@ -242,7 +268,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         if X.ndim == 3:
             X_new = self.centers_[target_domain].transform(X)
         else:
-            X_new = X - self.centers_[self.target_domain]
+            X_new = X - self.centers_[target_domain]
 
         return X_new
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -143,9 +143,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
             Add ``""`` as a special value.
         .. versionchanged:: 0.13
             Add ``"transductive"`` as a special value.
-            Add ``"last"`` as a special value, deprecating the empty string
-            ``""`` (which had the same meaning); ``""`` will be removed in
-            0.14.0.
+            Replace special value ``""`` by ``"last"``.
     metric : str, default="riemann"
         For inputs in manifold,
         metric used for mean estimation. For the list of supported metrics,

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -126,7 +126,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         Domain to consider as target in ``transform()`` function:
 
        * if ``"transductive"``, ``transform()`` ignores ``centers_`` and
-         instead recenters its input to its own mean, recomputed from the
+         instead recenters inputs to their own mean, recomputed from the
          matrices or vectors passed to ``transform()``. This is useful at
          test time in a leave-one-subject/session-out setting, when the
          test domain was never seen during ``fit()`` and therefore has no

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -141,6 +141,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         .. versionchanged:: 0.7
             Add ``""`` as a special value.
             Add ``""`` as a special value.
+            Add ``""`` as a special value.
         .. versionchanged:: 0.13
             Add ``"transductive"`` as a special value.
             Replace special value ``""`` by ``"last"``.

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -125,36 +125,37 @@ class TLCenter(TransformerMixin, BaseEstimator):
     target_domain : str
         Domain to consider as target in ``transform()`` function:
 
-       * if not empty, ``transform()`` recenters inputs to the specified
-         target domain;
-       * else, ``transform()`` recenters inputs to the last fitted domain.
-
-        Ignored when ``transductive=True``.
+       * if ``"transductive"``, ``transform()`` ignores ``centers_`` and
+         instead recenters its input to its own mean, recomputed from the
+         matrices or vectors passed to ``transform()``. This is useful at
+         test time in a leave-one-subject/session-out setting, when the
+         test domain was never seen during ``fit()`` and therefore has no
+         stored center in ``centers_``. This unsupervised re-estimation of
+         the center on unseen data was originally proposed for
+         inter-session adaptation [3]_.
+       * elif ``"last"``, ``transform()`` recenters inputs to the last
+         fitted domain;
+       * else, ``transform()`` recenters inputs to the specified target
+         domain.
 
         .. versionchanged:: 0.7
+        .. versionchanged:: 0.13
+            Add ``"transductive"`` as a special value.
+            Add ``"last"`` as a special value, deprecating the empty string
+            ``""`` (which had the same meaning); ``""`` will be removed in
+            0.14.0.
     metric : str, default="riemann"
         For inputs in manifold,
         metric used for mean estimation. For the list of supported metrics,
         see :func:`pyriemann.geometry.mean.gmean`.
         Note, however, that only when using the "riemann" metric that we are
         ensured to re-center the matrices precisely to the identity.
-    transductive : bool, default=False
-        If True, ``transform()`` ignores ``target_domain`` and ``centers_``,
-        and instead recenters its input to its own mean, recomputed from the
-        matrices or vectors passed to ``transform()``. This is useful at test
-        time in a leave-one-subject/session-out setting,
-        when the test domain was never seen during ``fit()`` and therefore
-        has no stored center in ``centers_``. This unsupervised re-estimation
-        of the center on unseen data was originally proposed for
-        inter-session adaptation [3]_.
-
-        .. versionadded:: 0.13
 
     Attributes
     ----------
     centers_ : dict
         Dictionary with key=domain_name and value=domain_center.
-        Not used by ``transform()`` when ``transductive=True``.
+        Not used by ``transform()`` when ``target_domain="transductive"``.
 
     Notes
     -----
@@ -164,7 +165,9 @@ class TLCenter(TransformerMixin, BaseEstimator):
     .. versionchanged:: 0.8
         Add support for tangent space centering.
     .. versionchanged:: 0.13
-        Add ``transductive`` parameter.
+        Add ``"transductive"`` and ``"last"`` as special values for
+        ``target_domain``; deprecate the empty string ``""``, which had the
+        same meaning as ``"last"``.
 
     References
     ----------
@@ -184,11 +187,10 @@ class TLCenter(TransformerMixin, BaseEstimator):
         pp. 172-178, 2013
     """
 
-    def __init__(self, target_domain, metric="riemann", transductive=False):
+    def __init__(self, target_domain, metric="riemann"):
         """Init"""
         self.target_domain = target_domain
         self.metric = metric
-        self.transductive = transductive
 
     def fit(self, X, y_enc, sample_weight=None):
         """Fit TLCenter.
@@ -243,8 +245,9 @@ class TLCenter(TransformerMixin, BaseEstimator):
            This method is designed for using at test time,
            recentering all inputs in target domain, or in the last fitted
            domain.
-           When ``transductive=True``, it instead recenters ``X`` to
-           its own mean, recomputed from ``X`` and ignoring ``centers_``.
+           When ``target_domain="transductive"``, it instead recenters
+           ``X`` to its own mean, recomputed from ``X`` and ignoring
+           ``centers_``.
 
         Parameters
         ----------
@@ -260,13 +263,21 @@ class TLCenter(TransformerMixin, BaseEstimator):
         """
         _check_inputs(X)
 
-        if self.transductive:
+        if self.target_domain == "transductive":
             if X.ndim == 3:
                 return Whitening(metric=self.metric).fit_transform(X)
             return X - np.mean(X, axis=0)
 
+        if self.target_domain == "":
+            warnings.warn(
+                "Empty string for target_domain is deprecated and will be "
+                "removed in 0.14.0; use target_domain=\"last\" instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # if target domain is specified, use it
-        if self.target_domain != "":
+        if self.target_domain not in ("", "last"):
             target_domain = self.target_domain
         # else, use last calibrated domain as target domain
         else:

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -159,6 +159,8 @@ class TLCenter(TransformerMixin, BaseEstimator):
     Notes
     -----
     .. versionadded:: 0.4
+    .. versionchanged:: 0.7
+        Add possibility for ``target_domain`` to be empty.
     .. versionchanged:: 0.8
         Add support for tangent space centering.
     .. versionchanged:: 0.13

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -130,6 +130,8 @@ class TLCenter(TransformerMixin, BaseEstimator):
         * else, ``transform()`` recenters matrices to the last fitted domain.
 
         Ignored when ``transductive=True``.
+
+        .. versionchanged:: 0.7
     metric : str, default="riemann"
         For inputs in manifold,
         metric used for mean estimation. For the list of supported metrics,

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -161,7 +161,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
     -----
     .. versionadded:: 0.4
     .. versionchanged:: 0.7
-        Add possibility for ``target_domain`` to be empty.
+        Add possibility to recenter inputs to the last fitted domain.
     .. versionchanged:: 0.8
         Add support for tangent space centering.
     .. versionchanged:: 0.13

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -238,7 +238,8 @@ class TLCenter(TransformerMixin, BaseEstimator):
         .. note::
            This method is designed for using at test time,
            recentering all inputs in target domain, or in the last fitted
-           domain. When ``transductive=True``, it instead recenters ``X`` to
+           domain.
+           When ``transductive=True``, it instead recenters ``X`` to
            its own mean, recomputed from ``X`` and ignoring ``centers_``.
 
         Parameters

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -144,7 +144,9 @@ class TLCenter(TransformerMixin, BaseEstimator):
         when the test domain was never seen during ``fit()`` and therefore
         has no stored center in ``centers_``. This unsupervised re-estimation
         of the reference point on unseen data was originally proposed, for
-        inter-session adaptation, in [3]_.
+        inter-session adaptation [3]_.
+
+        .. versionadded:: 0.13
 
     Attributes
     ----------

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -143,7 +143,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         time in a leave-one-subject/session-out setting,
         when the test domain was never seen during ``fit()`` and therefore
         has no stored center in ``centers_``. This unsupervised re-estimation
-        of the reference point on unseen data was originally proposed, for
+        of the center on unseen data was originally proposed for
         inter-session adaptation [3]_.
 
         .. versionadded:: 0.13

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -165,9 +165,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
     .. versionchanged:: 0.8
         Add support for tangent space centering.
     .. versionchanged:: 0.13
-        Add ``"transductive"`` and ``"last"`` as special values for
-        ``target_domain``; deprecate the empty string ``""``, which had the
-        same meaning as ``"last"``.
+        Add transductive estimation of centers.
 
     References
     ----------

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -139,6 +139,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
          domain.
 
         .. versionchanged:: 0.7
+            Add ``""`` as a special value.
         .. versionchanged:: 0.13
             Add ``"transductive"`` as a special value.
             Add ``"last"`` as a special value, deprecating the empty string

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -140,6 +140,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
 
         .. versionchanged:: 0.7
             Add ``""`` as a special value.
+            Add ``""`` as a special value.
         .. versionchanged:: 0.13
             Add ``"transductive"`` as a special value.
             Add ``"last"`` as a special value, deprecating the empty string

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -140,8 +140,6 @@ class TLCenter(TransformerMixin, BaseEstimator):
 
         .. versionchanged:: 0.7
             Add ``""`` as a special value.
-            Add ``""`` as a special value.
-            Add ``""`` as a special value.
         .. versionchanged:: 0.13
             Add ``"transductive"`` as a special value.
             Replace special value ``""`` by ``"last"``.

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -125,9 +125,9 @@ class TLCenter(TransformerMixin, BaseEstimator):
     target_domain : str
         Domain to consider as target in ``transform()`` function:
 
-        * if not empty, ``transform()`` recenters matrices to the specified
-          target domain;
-        * else, ``transform()`` recenters matrices to the last fitted domain.
+       * if not empty, ``transform()`` recenters inputs to the specified
+         target domain;
+       * else, ``transform()`` recenters inputs to the last fitted domain.
 
         Ignored when ``transductive=True``.
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -241,12 +241,9 @@ class TLCenter(TransformerMixin, BaseEstimator):
 
         .. note::
            This method is designed for using at test time,
-           recentering all inputs in target domain, or in the last fitted
-           domain.
-           When ``target_domain="transductive"``, it instead recenters
-           ``X`` to its own mean, recomputed from ``X`` and ignoring
-           ``centers_``.
-
+          recentering all inputs in target domain;
+          or in the last fitted domain when ``target_domain="last"``;
+          or to their own mean when ``target_domain="transductive"``.
         Parameters
         ----------
         X : ndarray, shape (n_matrices, n_channels, n_channels) or \

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -271,7 +271,7 @@ class TLCenter(TransformerMixin, BaseEstimator):
         if self.target_domain == "":
             warnings.warn(
                 "Empty string for target_domain is deprecated and will be "
-                "removed in 0.14.0; use target_domain=\"last\" instead.",
+                "removed in 0.15.0; use target_domain=\"last\" instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -164,14 +164,21 @@ def test_tlcenter_manifold(rndstate, get_weights,
         assert Md == pytest.approx(np.eye(2))
 
     # Test transform: "transductive" recenters the whole input to its own
-    # recomputed mean, while "target_domain"/"last" only guarantee that the
-    # target domain's own slice is centered
+    # recomputed (unweighted) mean, while "target_domain"/"last" only
+    # guarantee that the target domain's own slice is centered, weighted as
+    # it was when centers_ was fitted
     X_new = rct.transform(X)
     if target_domain == "transductive":
         assert gmean(X_new, metric=metric) == pytest.approx(np.eye(2))
     else:
         idx = domain == "target_domain"
-        assert gmean(X_new[idx], metric=metric) == pytest.approx(np.eye(2))
+        Xd = X_new[idx]
+        if use_weight:
+            weights_d = check_weights(weights[idx], np.sum(idx), like=Xd)
+            Md = gmean(Xd, metric=metric, sample_weight=weights_d)
+        else:
+            Md = gmean(Xd, metric=metric)
+        assert Md == pytest.approx(np.eye(2))
 
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -216,7 +216,7 @@ def test_tlcenter_manifold_transductive(rndstate, metric):
     heldout = domain == np.unique(domain)[0]
     X_fit, X_heldout = X[~heldout], X[heldout]
 
-    rct = TLCenter(target_domain="", metric=metric, transductive=True)
+    rct = TLCenter(target_domain="transductive", metric=metric)
     # fitted on domains that do NOT include the held-out one
     rct.fit(X_fit, y_enc[~heldout])
     assert np.unique(domain)[0] not in rct.centers_
@@ -275,7 +275,7 @@ def test_tlcenter_tangentspace_transductive(rndstate):
     heldout = domain == "tgt"
     X_fit, X_heldout = X[~heldout], X[heldout]
 
-    tlctr = TLCenter(target_domain="", transductive=True)
+    tlctr = TLCenter(target_domain="transductive")
     tlctr.fit(X_fit, y_enc[~heldout])
     assert "tgt" not in tlctr.centers_
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -129,7 +129,9 @@ def test_tldummy(rndstate, space):
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
 @pytest.mark.parametrize("use_weight", [True, False])
-@pytest.mark.parametrize("target_domain", ["target_domain", ""])
+@pytest.mark.parametrize(
+    "target_domain", ["target_domain", "last", "transductive"]
+)
 def test_tlcenter_manifold(rndstate, get_weights,
                            metric, use_weight, target_domain):
     """Test centering matrices to identity"""
@@ -161,13 +163,20 @@ def test_tlcenter_manifold(rndstate, get_weights,
             Md = gmean(Xd, metric=metric)
         assert Md == pytest.approx(np.eye(2))
 
-    # Test transform
-    rct.transform(X)
+    # Test transform: "transductive" recenters the whole input to its own
+    # recomputed mean, while "target_domain"/"last" only guarantee that the
+    # target domain's own slice is centered
+    X_new = rct.transform(X)
+    if target_domain == "transductive":
+        assert gmean(X_new, metric=metric) == pytest.approx(np.eye(2))
+    else:
+        idx = domain == "target_domain"
+        assert gmean(X_new[idx], metric=metric) == pytest.approx(np.eye(2))
 
 
 @pytest.mark.parametrize("metric", ["riemann", "euclid"])
 @pytest.mark.parametrize("use_weight", [True, False])
-@pytest.mark.parametrize("target_domain", ["target_domain", ""])
+@pytest.mark.parametrize("target_domain", ["target_domain", "last"])
 def test_tlcenter_manifold_fit_transf(rndstate, get_weights,
                                       metric, use_weight, target_domain):
     """Test .fit_transform() versus .fit().transform()"""
@@ -205,31 +214,10 @@ def test_tlcenter_manifold_fit_transf(rndstate, get_weights,
         assert Md == pytest.approx(np.eye(2))
 
 
-@pytest.mark.parametrize("metric", ["riemann", "euclid"])
-def test_tlcenter_manifold_transductive(rndstate, metric):
-    """Test transductive transform on an unseen domain"""
-    X, y_enc = make_classification_transfer(
-        n_matrices=25,
-        random_state=rndstate,
-    )
-    _, _, domain = decode_domains(X, y_enc)
-    heldout = domain == np.unique(domain)[0]
-    X_fit, X_heldout = X[~heldout], X[heldout]
-
-    rct = TLCenter(target_domain="transductive", metric=metric)
-    # fitted on domains that do NOT include the held-out one
-    rct.fit(X_fit, y_enc[~heldout])
-    assert np.unique(domain)[0] not in rct.centers_
-
-    # transform() must still work and recenter the held-out batch to its own
-    # mean, without ever looking up a stored center for it
-    X_new = rct.transform(X_heldout)
-    Md = gmean(X_new, metric=metric)
-    assert Md == pytest.approx(np.eye(2))
-
-
 @pytest.mark.parametrize("use_weight", [True, False])
-def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
+@pytest.mark.parametrize("target_domain", ["tgt", "last", "transductive"])
+def test_tlcenter_tangentspace(rndstate, get_weights, use_weight,
+                               target_domain):
     """Test centering tangent vectors to origin"""
     n_ts = 10
     X, y_enc = make_classification_transfer_tangspace(
@@ -245,7 +233,7 @@ def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
 
     _, _, domain = decode_domains(X, y_enc)
 
-    tlctr = TLCenter(target_domain="tgt")
+    tlctr = TLCenter(target_domain=target_domain)
 
     tlctr.fit(X, y_enc, sample_weight=weights)
 
@@ -258,30 +246,18 @@ def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
         md = np.average(X_rct[idx], axis=0, weights=weights_d)
         assert_array_almost_equal(md, np.zeros((n_ts)))
 
-    X_rct = tlctr.transform(X)
-    assert X_rct.shape == X.shape
-
-
-def test_tlcenter_tangentspace_transductive(rndstate):
-    """Test transductive transform on tangent vectors of an unseen domain"""
-    n_ts = 10
-    X, y_enc = make_classification_transfer_tangspace(
-        rndstate,
-        ["tgt", "src1", "src2"],
-        n_vectors_d=50,
-        n_ts=n_ts,
-    )
-    _, _, domain = decode_domains(X, y_enc)
-    heldout = domain == "tgt"
-    X_fit, X_heldout = X[~heldout], X[heldout]
-
-    tlctr = TLCenter(target_domain="transductive")
-    tlctr.fit(X_fit, y_enc[~heldout])
-    assert "tgt" not in tlctr.centers_
-
-    X_new = tlctr.transform(X_heldout)
-    assert X_new.shape == X_heldout.shape
-    assert_array_almost_equal(np.mean(X_new, axis=0), np.zeros(n_ts))
+    # Test transform: "transductive" recenters the whole input to its own
+    # recomputed mean, while "tgt"/"last" only guarantee that the target
+    # domain's own slice is centered
+    X_new = tlctr.transform(X)
+    assert X_new.shape == X.shape
+    if target_domain == "transductive":
+        assert_array_almost_equal(np.mean(X_new, axis=0), np.zeros(n_ts))
+    else:
+        idx = domain == "tgt"
+        weights_d = weights[idx] if weights is not None else None
+        md = np.average(X_new[idx], axis=0, weights=weights_d)
+        assert_array_almost_equal(md, np.zeros((n_ts)))
 
 
 @pytest.mark.parametrize("use_centered_data", [True, False])

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -205,6 +205,29 @@ def test_tlcenter_manifold_fit_transf(rndstate, get_weights,
         assert Md == pytest.approx(np.eye(2))
 
 
+@pytest.mark.parametrize("metric", ["riemann", "euclid"])
+def test_tlcenter_manifold_transductive(rndstate, metric):
+    """Test transductive transform on an unseen domain"""
+    X, y_enc = make_classification_transfer(
+        n_matrices=25,
+        random_state=rndstate,
+    )
+    _, _, domain = decode_domains(X, y_enc)
+    heldout = domain == np.unique(domain)[0]
+    X_fit, X_heldout = X[~heldout], X[heldout]
+
+    rct = TLCenter(target_domain="", metric=metric, transductive=True)
+    # fitted on domains that do NOT include the held-out one
+    rct.fit(X_fit, y_enc[~heldout])
+    assert np.unique(domain)[0] not in rct.centers_
+
+    # transform() must still work and recenter the held-out batch to its own
+    # mean, without ever looking up a stored center for it
+    X_new = rct.transform(X_heldout)
+    Md = gmean(X_new, metric=metric)
+    assert Md == pytest.approx(np.eye(2))
+
+
 @pytest.mark.parametrize("use_weight", [True, False])
 def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
     """Test centering tangent vectors to origin"""
@@ -237,6 +260,28 @@ def test_tlcenter_tangentspace(rndstate, get_weights, use_weight):
 
     X_rct = tlctr.transform(X)
     assert X_rct.shape == X.shape
+
+
+def test_tlcenter_tangentspace_transductive(rndstate):
+    """Test transductive transform on tangent vectors of an unseen domain"""
+    n_ts = 10
+    X, y_enc = make_classification_transfer_tangspace(
+        rndstate,
+        ["tgt", "src1", "src2"],
+        n_vectors_d=50,
+        n_ts=n_ts,
+    )
+    _, _, domain = decode_domains(X, y_enc)
+    heldout = domain == "tgt"
+    X_fit, X_heldout = X[~heldout], X[heldout]
+
+    tlctr = TLCenter(target_domain="", transductive=True)
+    tlctr.fit(X_fit, y_enc[~heldout])
+    assert "tgt" not in tlctr.centers_
+
+    X_new = tlctr.transform(X_heldout)
+    assert X_new.shape == X_heldout.shape
+    assert_array_almost_equal(np.mean(X_new, axis=0), np.zeros(n_ts))
 
 
 @pytest.mark.parametrize("use_centered_data", [True, False])


### PR DESCRIPTION
Add a transductive option that recenters a batch to its own recomputed mean instead, following a old idea in Barachant et al. (2013) for inter-session adaptation.

cc: @aquemy