### PR TITLE
remove warning raised by pytest on zip used in parametrize

### DIFF
--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -93,22 +93,13 @@ def test_map_log_exp(kind, metric, get_mats):
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize(
-    "log_map_, exp_map_", zip(
-        [
-            log_map_euclid,
-            log_map_logchol,
-            log_map_logeuclid,
-            log_map_riemann,
-            log_map_wasserstein,
-        ],
-        [
-            exp_map_euclid,
-            exp_map_logchol,
-            exp_map_logeuclid,
-            exp_map_riemann,
-            exp_map_wasserstein,
-        ]
-    )
+    "log_map_, exp_map_", [
+        (log_map_euclid, exp_map_euclid),
+        (log_map_logchol, exp_map_logchol),
+        (log_map_logeuclid, exp_map_logeuclid),
+        (log_map_riemann, exp_map_riemann),
+        (log_map_wasserstein, exp_map_wasserstein),
+    ]
 )
 def test_maps_log_exp(kind, log_map_, exp_map_, get_mats):
     """Test log then exp maps should be identity"""


### PR DESCRIPTION
```
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/_pytest/python.py:124:
PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
Test: tests/test_geometry_tangentspace.py::test_maps_log_exp, argvalues type: zip
Please convert to a list or tuple.
See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)
```