### PR TITLE
Deprecate `probability` parameter and add `predict_proba()` in  `SVC`

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -22,6 +22,10 @@ v0.13.dev
   last fitted domain" behavior, deprecating the empty string ``""`` (which
   had the same meaning).
 
+- Deprecate ``probability`` parameter :class:`pyriemann.classification.SVC`.
+  Add ``predict_proba()`` which now works without this parameter.
+  :pr:`472` by :user:`qbarthelemy`
+
 v0.12 (July 2026)
 -----------------
 

--- a/examples/simulated/plot_classifier_comparison.py
+++ b/examples/simulated/plot_classifier_comparison.py
@@ -43,7 +43,10 @@ def get_proba(cov_00, cov_01, cov_11, clf):
     cov = np.array([[cov_00, cov_01], [cov_01, cov_11]])
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
-        return clf.predict_proba(cov[np.newaxis, ...])[0, 1]
+        try:
+            return clf.predict_proba(cov[np.newaxis, ...])[0, 1]
+        except ValueError:
+            return np.nan
 
 
 def plot_classifiers(metric):
@@ -187,7 +190,7 @@ names = [
 classifs = [
     MDM(),
     KNearestNeighbor(n_neighbors=3),
-    SVC(probability=True),
+    SVC(),
 ]
 n_classifs = len(classifs)
 

--- a/pyriemann/classification.py
+++ b/pyriemann/classification.py
@@ -1,5 +1,6 @@
 """Classification."""
 import functools
+import warnings
 
 from joblib import Parallel, delayed
 import numpy as np
@@ -565,8 +566,8 @@ class KNearestNeighbor(MDM):
 class SVC(sklearnSVC):
     """Classification by support-vector machine.
 
-    Support-vector machine (SVM) classification with precomputed Riemannian
-    kernel matrix according to different metrics as described in [1]_.
+    Support-vector machine (SVM) classification with a precomputed
+    kernel matrix [1]_, according to different metrics.
 
     Parameters
     ----------
@@ -593,11 +594,14 @@ class SVC(sklearnSVC):
         is a squared l2 penalty.
     shrinking : bool, default=True
         Whether to use the shrinking heuristic.
-    probability : bool, default=False
+    probability : bool, default="deprecated"
         Whether to enable probability estimates. This must be enabled prior
         to calling ``fit``, will slow down that method as it internally uses
         5-fold cross-validation, and ``predict_proba`` may be inconsistent with
         ``predict``.
+
+        .. deprecated:: 0.13
+            This parameter is deprecated and will be removed in version 0.15.0.
     tol : float, default=1e-3
         Tolerance for stopping criterion.
     cache_size : float, default=200
@@ -636,6 +640,8 @@ class SVC(sklearnSVC):
     Notes
     -----
     .. versionadded:: 0.3
+    .. versionchanged:: 0.13
+        Deprecate ``probability`` parameter and add ``predict_proba()``.
 
     References
     ----------
@@ -656,7 +662,7 @@ class SVC(sklearnSVC):
         Cref=None,
         C=1.0,
         shrinking=True,
-        probability=False,
+        probability="deprecated",
         tol=1e-3,
         cache_size=200,
         class_weight=None,
@@ -667,6 +673,15 @@ class SVC(sklearnSVC):
         random_state=None
     ):
         """Init."""
+        if probability != "deprecated":
+            warnings.warn(
+                "probability parameter is deprecated and will be removed in "
+                "version 0.15.0. Use predict_proba() directly instead, "
+                "which now works without this parameter.",
+                FutureWarning,
+                stacklevel=2
+            )
+
         self.Cref = Cref
         self.metric = metric
         self.Cref_ = None
@@ -675,7 +690,7 @@ class SVC(sklearnSVC):
             kernel="precomputed",
             C=C,
             shrinking=shrinking,
-            probability=probability,
+            probability="deprecated",
             tol=tol,
             cache_size=cache_size,
             class_weight=class_weight,
@@ -741,6 +756,28 @@ class SVC(sklearnSVC):
                 "kernel_fct must be None, 'precomputed' or callable, is "
                 f"{self.kernel}."
             )
+
+    def predict_proba(self, X):
+        """Predict class probabilities using decision function.
+
+        This method computes probability estimates using the decision function
+        and applying softmax calibration.
+
+        Parameters
+        ----------
+        X : ndarray, shape (n_matrices, n_channels, n_channels)
+            Set of SPD matrices.
+
+        Returns
+        -------
+        prob : ndarray, shape (n_matrices, n_classes)
+            Class probabilities for each matrix.
+        """
+        decision = self.decision_function(X)
+        if len(decision.shape) == 1:
+            decision = np.vstack([-decision, decision]).T
+        prob = softmax(decision)
+        return prob
 
 
 class MeanField(SpdClassifMixin, SpdTransfMixin, BaseEstimator):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -79,10 +79,10 @@ def test_classifier(kind, n_classes, classif,
             classif in [FgMDM, TSClassifier, SVC, NearestConvexHull]:
         pytest.skip()
     if n_classes == 2:
-        n_matrices, n_channels = 6, 3
+        n_matrices, n_channels = 10, 3
     else:
         assert n_classes == 3
-        n_matrices, n_channels = 9, 3
+        n_matrices, n_channels = 15, 3
     X = get_mats(n_matrices, n_channels, kind)
     y = get_labels(n_matrices, n_classes)
     weights = get_weights(n_matrices)
@@ -108,7 +108,6 @@ def clf_fit(classif, X, y, weights):
     clf = classif().fit(X, y)
     assert clf.classes_.shape == (n_classes,)
     assert_array_equal(clf.classes_, np.unique(y))
-
     clf.fit(X, y, sample_weight=weights)
 
 
@@ -122,8 +121,6 @@ def clf_predict(classif, X, y):
 def clf_predict_proba(classif, X, y):
     n_matrices, n_classes = len(y), len(np.unique(y))
     clf = classif()
-    if hasattr(clf, "probability"):
-        clf.set_params(**{"probability": True})
     prob = clf.fit(X, y).predict_proba(X)
     assert prob.shape == (n_matrices, n_classes)
     assert prob.sum(axis=1) == approx(np.ones(n_matrices))
@@ -176,12 +173,7 @@ def clf_tsupdate(classif, X, y):
 def clf_pipeline(classif, labels, get_mats):
     n_matrices, n_channels, n_times = len(labels), 3, 100
     X = get_mats(n_matrices, [n_channels, n_times], "real")
-
-    clf = classif()
-    if hasattr(clf, "probability"):
-        clf.set_params(**{"probability": True})
-
-    pip = make_pipeline(Covariances(estimator="scm"), clf)
+    pip = make_pipeline(Covariances(estimator="scm"), classif())
     pip.fit(X, labels)
     pip.predict(X)
     pip.predict_proba(X)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -561,8 +561,6 @@ def test_tlclassifier_tangentspace(rndstate, clf, domains_weight):
 def tlclassifier(clf, X, y_enc, domains_weight, n_classes=2):
     n_inputs = X.shape[0]
 
-    if hasattr(clf, "probability"):
-        clf.set_params(**{"probability": True})
     tlclf = TLClassifier(
         target_domain="target_domain",
         estimator=clf,


### PR DESCRIPTION
Deprecate `probability` parameter in `SVC`, and add `predict_proba()` which now works without this parameter.

Related to https://github.com/scikit-learn/scikit-learn/pull/32050