### PR TITLE
Rename rjd into jade and transpose outputed diagonalizer

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -392,7 +392,7 @@ on SPD/HPD matrices, and
          <span class="api-card-tag tag-geometry">Geometry</span>
        </div>
        <div class="api-card-title">Approx. Joint Diag.</div>
-       <div class="api-card-desc">Pham, RJD, and UWEDGE algorithms for joint diagonalization.</div>
+       <div class="api-card-desc">Pham's AJD, JADE, and UWEDGE algorithms for joint diagonalization.</div>
        <div class="api-card-footer">4 functions</div>
      </a>
 
@@ -854,7 +854,7 @@ Aproximate Joint Diagonalization
 
     ajd
     ajd_pham
-    rjd
+    jade
     uwedge
 
 .. _mat_test_api:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,6 +10,13 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.13.dev
 ---------
 
+- Fix multiclass :class:`pyriemann.spatialfilters.CSP` with
+  ``ajd_method="rjd"``: ``rjd`` returns its diagonalizer in the transposed
+  convention of ``ajd_pham`` and ``uwedge``, so ``fit`` transposed it the wrong
+  way and produced spatial filters that did not jointly diagonalize the class
+  covariances.
+  :pr:`474` by :user:`gaoflow`
+
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
   :pr:`462` by :user:`qbarthelemy`
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -10,13 +10,6 @@ A catalog of new features, improvements, and bug-fixes in each release.
 v0.13.dev
 ---------
 
-- Fix multiclass :class:`pyriemann.spatialfilters.CSP` with
-  ``ajd_method="rjd"``: ``rjd`` returns its diagonalizer in the transposed
-  convention of ``ajd_pham`` and ``uwedge``, so ``fit`` transposed it the wrong
-  way and produced spatial filters that did not jointly diagonalize the class
-  covariances.
-  :pr:`474` by :user:`gaoflow`
-
 - Update pyRiemann from Python 3.10 - 3.12 to 3.11 - 3.13.
   :pr:`462` by :user:`qbarthelemy`
 
@@ -36,6 +29,8 @@ v0.13.dev
 - Add :func:`pyriemann.geometry.tangentspace.transport_wasserstein` for parallel
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
+- Deprecate ``rjd`` renamed into :func:`pyriemann.geometry.ajd.jade`, and transpose outputed diagonalizer.
+  :pr:`474` by :user:`gaoflow`
 
 v0.12 (July 2026)
 -----------------
@@ -436,7 +431,7 @@ v0.4 (Feb 2023)
   then used for ``transform()`` as well as for ``inverse_transform()``.
   :pr:`195` by :user:`qbarthelemy`
 
-- Enhance AJD: add ``init`` to :func:`pyriemann.geometry.ajd.ajd_pham` and :func:`pyriemann.geometry.ajd.rjd`,
+- Enhance AJD: add ``init`` to :func:`pyriemann.geometry.ajd.ajd_pham` and :func:`pyriemann.geometry.ajd.jade`,
   add ``warm_restart`` to :class:`pyriemann.spatialfilters.AJDC`.
   :pr:`196` by :user:`qbarthelemy`
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -29,6 +29,7 @@ v0.13.dev
 - Add :func:`pyriemann.geometry.tangentspace.transport_wasserstein` for parallel
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
+
 - Deprecate ``rjd`` renamed into :func:`pyriemann.geometry.ajd.jade`, and transpose outputed diagonalizer.
   :pr:`474` by :user:`gaoflow`
 

--- a/pyriemann/geometry/ajd.py
+++ b/pyriemann/geometry/ajd.py
@@ -371,6 +371,7 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
 ajd_functions = {
     "ajd_pham": ajd_pham,
+    "rjd": rjd,
     "jade": jade,
     "uwedge": uwedge,
 }

--- a/pyriemann/geometry/ajd.py
+++ b/pyriemann/geometry/ajd.py
@@ -6,6 +6,7 @@ from array_api_compat import array_namespace as get_namespace, device as xpd
 
 from ._backend import _add_to_diagonal
 from ._check import check_function, check_init, check_weights
+from ._docs import deprecated
 
 
 def _arange(*args):
@@ -20,7 +21,7 @@ def _reshape_output(X, n1, n2, xp):
     return xp.permute_dims(xp.reshape(X, (n1, n2, n1)), (1, 0, 2))
 
 
-def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
+def jade(X, *, init=None, eps=1e-8, n_iter_max=100):
     """Approximate joint diagonalization based on JADE.
 
     This is an implementation of the orthogonal AJD algorithm [1]_: joint
@@ -35,6 +36,8 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
         Set of symmetric matrices to diagonalize.
     init : None | ndarray, shape (n, n), default=None
         Initialization for the diagonalizer.
+
+        .. versionadded:: 0.4
     eps : float, default=1e-8
         Tolerance for stopping criterion.
     n_iter_max : int, default=100
@@ -45,13 +48,17 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
     V : ndarray, shape (n, n)
         The diagonalizer, an orthogonal matrix.
     D : ndarray, shape (n_matrices, n, n)
-        Set of quasi diagonal matrices, D = V^T X V.
+        Set of quasi diagonal matrices, D = V X V^T.
 
     Notes
     -----
     .. versionadded:: 0.2.4
+    .. versionchanged:: 0.4
+        Add parameter init.
     .. versionchanged:: 0.12
         Add support for NumPy and PyTorch.
+    .. versionchanged:: 0.13
+        Rename rjd into jade, and transpose outputed diagonalizer.
 
     See Also
     --------
@@ -112,7 +119,15 @@ def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
         warnings.warn("Convergence not reached")
 
     D = _reshape_output(A, n, n_matrices, xp)
-    return V, D
+    return V.mT, D
+
+
+@deprecated(
+    "rjd() is deprecated and will be removed in 0.15.0; please use jade()."
+    "Be careful, outputed diagonalizer is transposed."
+)
+def rjd(X, *, init=None, eps=1e-8, n_iter_max=100):
+    return jade(X, init=init, eps=eps, n_iter_max=n_iter_max)
 
 
 def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=20, sample_weight=None):
@@ -149,6 +164,10 @@ def ajd_pham(X, *, init=None, eps=1e-6, n_iter_max=20, sample_weight=None):
     Notes
     -----
     .. versionadded:: 0.2.4
+    .. versionchanged:: 0.2.7
+        Add parameter sample_weight.
+    .. versionchanged:: 0.4
+        Add parameter init.
     .. versionchanged:: 0.7
         Add support for HPD matrices.
     .. versionchanged:: 0.12
@@ -352,7 +371,7 @@ def uwedge(X, *, init=None, eps=1e-7, n_iter_max=100):
 
 ajd_functions = {
     "ajd_pham": ajd_pham,
-    "rjd": rjd,
+    "jade": jade,
     "uwedge": uwedge,
 }
 
@@ -368,7 +387,7 @@ def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
     X : ndarray, shape (n_matrices, n, n)
         Set of symmetric matrices to diagonalize.
     method : string | callable, default="ajd_pham"
-        Method for AJD, can be: "ajd_pham", "rjd", "uwedge", or a callable
+        Method for AJD, can be: "ajd_pham", "jade", "uwedge", or a callable
         function.
     init : None | ndarray, shape (n, n), default=None
         Initialization for the diagonalizer.
@@ -384,7 +403,7 @@ def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
     V : ndarray, shape (n, n)
         The diagonalizer.
     D : ndarray, shape (n_matrices, n, n)
-        Set of quasi diagonal matrices.
+        Set of quasi diagonal matrices, D = V X V^T.
 
     Notes
     -----
@@ -393,7 +412,7 @@ def ajd(X, method="ajd_pham", init=None, eps=1e-6, n_iter_max=100, **kwargs):
     See Also
     --------
     ajd_pham
-    rjd
+    jade
     uwedge
 
     References

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -6,7 +6,7 @@ from scipy.linalg import eigh, inv
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from . import estimation as est
-from .geometry.ajd import ajd, ajd_pham
+from .geometry.ajd import ajd, ajd_pham, rjd
 from .geometry.covariance import (
     normalize,
     get_nondiag_weight,
@@ -406,7 +406,10 @@ class CSP(BilinearFilter):
         elif len(classes) > 2:
             evecs, D = ajd(C, method=self.ajd_method)
             Ctot = gmean(C, metric=self.metric)
-            evecs = evecs.T
+            # rjd diagonalizes as D = V.T C V (filters are columns of V), while
+            # ajd_pham and uwedge use D = V C V.T (filters are rows of V)
+            if self.ajd_method not in ("rjd", rjd):
+                evecs = evecs.T
 
             # normalize
             for i in range(evecs.shape[1]):

--- a/pyriemann/spatialfilters.py
+++ b/pyriemann/spatialfilters.py
@@ -6,7 +6,7 @@ from scipy.linalg import eigh, inv
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from . import estimation as est
-from .geometry.ajd import ajd, ajd_pham, rjd
+from .geometry.ajd import ajd, ajd_pham
 from .geometry.covariance import (
     normalize,
     get_nondiag_weight,
@@ -307,8 +307,8 @@ class CSP(BilinearFilter):
         If true, return the log variance, otherwise return the spatially
         filtered covariance matrices.
     ajd_method : string | callable, default="ajd_pham"
-        Method for AJD, can be: "ajd_pham", "rjd", "uwedge", or a callable
-        function.
+        Method for AJD for multiclass CSP, can be:
+        "ajd_pham", "jade", "uwedge", or a callable function.
 
         .. versionadded:: 0.7
 
@@ -406,10 +406,7 @@ class CSP(BilinearFilter):
         elif len(classes) > 2:
             evecs, D = ajd(C, method=self.ajd_method)
             Ctot = gmean(C, metric=self.metric)
-            # rjd diagonalizes as D = V.T C V (filters are columns of V), while
-            # ajd_pham and uwedge use D = V C V.T (filters are rows of V)
-            if self.ajd_method not in ("rjd", rjd):
-                evecs = evecs.T
+            evecs = evecs.T
 
             # normalize
             for i in range(evecs.shape[1]):

--- a/tests/test_geometry_ajd.py
+++ b/tests/test_geometry_ajd.py
@@ -3,14 +3,14 @@ import numpy as np
 import pytest
 
 from conftest import approx, assert_array_equal
-from pyriemann.geometry.ajd import ajd, rjd, ajd_pham, uwedge
+from pyriemann.geometry.ajd import ajd, ajd_pham, jade, rjd, uwedge
 
 
 @pytest.mark.parametrize("kind", ["sym", "spd"])
 @pytest.mark.parametrize(
     "method, algo",
     [
-        ("rjd", rjd),
+        ("jade", jade),
         ("ajd_pham", ajd_pham),
         ("uwedge", uwedge),
         (uwedge, uwedge),
@@ -29,19 +29,18 @@ def test_ajd(kind, method, algo, get_mats):
     assert D.shape == (n_matrices, n_channels, n_channels)
 
     xp = get_namespace(X)
-    if method == "rjd":
-        assert D == approx(V.mT @ X @ V)
+    assert D == approx(V @ X @ V.mT)
+    if method == "jade":  # check diagonalizer orthogonality
         eye = xp.eye(n_channels, dtype=X.dtype, device=xpd(X))
-        assert V.mT @ V == approx(eye)  # check orthogonality
-    else:
-        assert D == approx(V @ X @ V.mT)
+        assert V.mT @ V == approx(eye)
+        assert V @ V.mT == approx(eye)
 
     V_, D_ = algo(X, eps=eps, n_iter_max=n_iter_max)
     assert_array_equal(V, V_)
     assert_array_equal(D, D_)
 
 
-@pytest.mark.parametrize("method", ["rjd", "ajd_pham", "uwedge"])
+@pytest.mark.parametrize("method", ["ajd_pham", "jade", "uwedge"])
 @pytest.mark.parametrize("use_init", [True, False])
 def test_ajd_init(method, use_init, get_mats_params):
     """Test init for ajd algos"""
@@ -104,3 +103,12 @@ def test_ajdpham_weight_zero(kind, get_mats, get_weights):
     Vw, Dw = ajd_pham(X, sample_weight=weights)
     assert V == approx(Vw, rel=1e-4, abs=1e-8)
     assert D == approx(Dw[1:], rel=1e-4, abs=1e-8)
+
+
+def test_rjd_deprecation(get_mats):
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rjd(get_mats(3, 2, "spd"))
+        assert len(w) >= 1
+        assert issubclass(w[-1].category, DeprecationWarning)

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_array_equal
 import pytest
 
 from pyriemann.spatialfilters import Xdawn, CSP, SPoC, BilinearFilter, AJDC
+from pyriemann.geometry.ajd import rjd
 
 
 pytestmark = pytest.mark.numpy_only
@@ -188,6 +189,32 @@ def test_csp(n_filters, metric, log, ajd_method, get_mats, get_labels):
         assert Xtr.shape == (n_matrices, n_components)
     else:
         assert Xtr.shape == (n_matrices, n_components, n_components)
+
+
+@pytest.mark.parametrize("ajd_method", ["ajd_pham", "rjd", "uwedge", rjd])
+def test_csp_multiclass_diagonalization(
+    ajd_method, get_mats_params, get_labels
+):
+    """Multiclass CSP filters must jointly diagonalize the class covariances,
+    whatever the ajd_method (rjd returns a transposed diagonalizer)."""
+    n_classes, n_matrices, n_channels = 3, 30, 4
+    # matrices sharing a common eigenbasis are exactly jointly diagonalizable,
+    # so any off-diagonal residual is a convention error, not an approximation
+    X, _, _ = get_mats_params(n_matrices, n_channels, "spd")
+    y = get_labels(n_matrices, n_classes)
+
+    csp = CSP(
+        nfilter=n_channels, metric="euclid", log=False, ajd_method=ajd_method
+    ).fit(X, y)
+    filters = csp.filters_
+    assert filters.shape == (n_channels, n_channels)
+
+    for c in np.unique(y):
+        cov = np.mean(X[y == c], axis=0)  # euclidean class mean
+        filt_cov = filters @ cov @ filters.T
+        offdiag = filt_cov - np.diag(np.diag(filt_cov))
+        ratio = np.sqrt(np.sum(offdiag ** 2) / np.sum(np.diag(filt_cov) ** 2))
+        assert ratio < 1e-4
 
 
 def test_bilinearfilter_errors(get_mats, get_labels):

--- a/tests/test_spatialfilters.py
+++ b/tests/test_spatialfilters.py
@@ -2,8 +2,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 
+from pyriemann.geometry.ajd import jade
 from pyriemann.spatialfilters import Xdawn, CSP, SPoC, BilinearFilter, AJDC
-from pyriemann.geometry.ajd import rjd
 
 
 pytestmark = pytest.mark.numpy_only
@@ -172,7 +172,7 @@ def test_xdawn_baselinecov(n_channels, use_baseline_cov, get_mats, get_labels):
 @pytest.mark.parametrize("n_filters", [3, 4, 5])
 @pytest.mark.parametrize("metric", ["euclid", "logeuclid", "riemann"])
 @pytest.mark.parametrize("log", [True, False])
-@pytest.mark.parametrize("ajd_method", ["ajd_pham", "rjd", "uwedge"])
+@pytest.mark.parametrize("ajd_method", ["ajd_pham", "jade", "uwedge"])
 def test_csp(n_filters, metric, log, ajd_method, get_mats, get_labels):
     n_classes, n_matrices, n_channels = 2, 6, 4
     X = get_mats(n_matrices, n_channels, "spd")
@@ -191,16 +191,13 @@ def test_csp(n_filters, metric, log, ajd_method, get_mats, get_labels):
         assert Xtr.shape == (n_matrices, n_components, n_components)
 
 
-@pytest.mark.parametrize("ajd_method", ["ajd_pham", "rjd", "uwedge", rjd])
-def test_csp_multiclass_diagonalization(
-    ajd_method, get_mats_params, get_labels
-):
-    """Multiclass CSP filters must jointly diagonalize the class covariances,
-    whatever the ajd_method (rjd returns a transposed diagonalizer)."""
+@pytest.mark.parametrize("ajd_method", ["ajd_pham", "jade", "uwedge", jade])
+def test_csp_multiclass(ajd_method, get_mats_params, get_labels):
+    """Multiclass CSP filters must jointly diagonalize the class covariances"""
     n_classes, n_matrices, n_channels = 3, 30, 4
     # matrices sharing a common eigenbasis are exactly jointly diagonalizable,
     # so any off-diagonal residual is a convention error, not an approximation
-    X, _, _ = get_mats_params(n_matrices, n_channels, "spd")
+    X = get_mats_params(n_matrices, n_channels, "spd")[0]
     y = get_labels(n_matrices, n_classes)
 
     csp = CSP(


### PR DESCRIPTION
`CSP(ajd_method="rjd")` on 3+ classes returns spatial filters that do not jointly diagonalize the class covariances.

The three AJD methods return the diagonalizer in two different conventions: `rjd` gives `D = V.T C V` (the joint eigenvectors are the **columns** of `V`), while `ajd_pham` and `uwedge` give `D = V C V.T` (eigenvectors are the **rows**). The multiclass branch of `CSP.fit` unconditionally does `evecs = evecs.T`, which is only correct for the row convention, so for `rjd` it selects the wrong vectors.

This slipped because the 2-class path uses `scipy.linalg.eigh` and never touches `ajd_method`, and `test_csp` only exercises `ajd_method` with 2 classes while asserting shapes — the multiclass `rjd` path was never covered. `ajd_method` was added to `CSP` in #313 but `rjd`'s convention was never reconciled in the consumer.

Repro:

```python
import numpy as np
from pyriemann.spatialfilters import CSP

n = 6
Q, _ = np.linalg.qr(np.random.randn(n, n))
Cs = [Q @ np.diag(np.random.uniform(0.5, 5, n)) @ Q.T for _ in range(3)]  # jointly diagonalizable
X = np.array([C for C in Cs for _ in range(10)])
y = np.array([c for c in range(3) for _ in range(10)])

for m in ("ajd_pham", "uwedge", "rjd"):
    W = CSP(nfilter=n, metric="euclid", ajd_method=m).fit(X, y).filters_
    r = [W @ C @ W.T for C in Cs]
    off = sum(np.sum((M - np.diag(np.diag(M))) ** 2) for M in r)
    dia = sum(np.sum(np.diag(np.diag(M)) ** 2) for M in r)
    print(m, np.sqrt(off / dia))
# ajd_pham 4e-11, uwedge 4e-16, rjd 4e-01   <- rjd filters do not diagonalize
```

Fix: skip the transpose for `rjd` (matching both the `"rjd"` string and the `rjd` callable, since `ajd_method` accepts a callable). `ajd_pham`/`uwedge` output is byte-identical to before.

The per-method convention is intentional and pinned by `test_geometry_ajd` (which also asserts `ajd(method="rjd")` returns exactly what `rjd()` returns), so the fix belongs in the consumer, not in `rjd`. I checked the other AJD consumers — `SPoC`/`AJDC` and the ALE mean hardcode `ajd_pham` — so `CSP` is the only one exposed to this. Added a multiclass regression test asserting the fitted filters jointly diagonalize the class means for every `ajd_method`; it fails on `rjd` (string and callable) before the fix and passes after.
