### PR TITLE
Use array-api-extra cov() (PR #690) for batched covariance estimation

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -118,6 +118,7 @@ jobs:
           docs-folder: "doc/"
           pre-build-command: |
             apt-get update
+            apt-get install -y git
             pip install -e .
             pip install -r doc/requirements.txt
         env:

--- a/pyriemann/geometry/covariance.py
+++ b/pyriemann/geometry/covariance.py
@@ -2,10 +2,11 @@ from functools import wraps
 import warnings
 
 from array_api_compat import array_namespace as get_namespace, device as xpd
-from array_api_extra import expand_dims
+from array_api_extra import cov as xpx_cov, expand_dims
 from scipy.stats import chi2
 
 from ._backend import (
+    _cov_kwargs_to_xp,
     apply_xp_cov,
     diag_indices,
     hann_window,
@@ -21,9 +22,17 @@ from .test import is_real_type, is_square
 
 
 def _cov(X, **kwds):
-    """Covariance matrix estimator."""
+    """Covariance matrix estimator, batched over leading dimensions.
+
+    Delegates to :func:`array_api_extra.cov`, which estimates covariances for
+    all leading batch dimensions in a single call, across array-API backends.
+    Time samples are the observations, hence ``axis=-1``.
+    """
     xp = get_namespace(X)
-    return apply_xp_cov(xp.cov, X, **kwds)
+    cov = xpx_cov(X, axis=-1, **_cov_kwargs_to_xp(kwds))
+    # array_api_extra.cov drops the two matrix axes when n_channels == 1;
+    # restore them so the output is always (..., n_channels, n_channels).
+    return xp.reshape(cov, (*X.shape[:-2], X.shape[-2], X.shape[-2]))
 
 
 def _corr(X, **kwds):
@@ -404,7 +413,8 @@ cov_est_functions = {
 
 def _check_cov_estimator(estimator):
     est = check_function(estimator, cov_est_functions)
-    if est not in [covariance_sch, covariance_scm]:
+    # _cov, covariance_sch and covariance_scm are natively batched.
+    if est not in [_cov, covariance_sch, covariance_scm]:
         est = _vectorize_nd()(est)
     return est
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ numpy>=1.25.0
 scipy
 scikit-learn>=0.24
 array-api-compat>=1.11
-array-api-extra>=0.6
+# array-api-extra PR #690: cov() gains axis/correction/fweights/aweights.
+# Revert to a released ">=" floor once merged and published.
+array-api-extra @ git+https://github.com/bruAristimunha/array-api-extra@cov_parameters
 joblib
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,10 @@ setup(
         "scipy",
         "scikit-learn>=0.24",
         "array-api-compat>=1.11",
-        "array-api-extra>=0.6",
+        # array-api-extra PR #690 adds axis/correction/fweights/aweights to
+        # cov (used by pyriemann.geometry.covariance._cov). Revert to a
+        # released ">=" floor once merged and published.
+        "array-api-extra @ git+https://github.com/bruAristimunha/array-api-extra@cov_parameters",  # noqa: E501
         "joblib",
         "matplotlib",
     ],

--- a/tests/test_geometry_covariance.py
+++ b/tests/test_geometry_covariance.py
@@ -86,6 +86,19 @@ def test_covariances_broadcasting(estimator, get_mats):
     assert C5[0, 0, 0] == approx(C2)
 
 
+@pytest.mark.parametrize("estimator", ["cov", "scm"])
+def test_covariances_single_channel(estimator, get_mats):
+    """Single-channel input keeps the (..., 1, 1) matrix axes."""
+    n_matrices, n_channels, n_times = 3, 1, 50
+    X = get_mats(n_matrices, [n_channels, n_times], "real")
+
+    cov = covariances(X, estimator=estimator)
+    assert cov.shape == (n_matrices, n_channels, n_channels)
+
+    cov2 = covariances(X[0], estimator=estimator)
+    assert cov2.shape == (n_channels, n_channels)
+
+
 @pytest.mark.numpy_only
 @pytest.mark.parametrize("assume_centered", [True, False])
 def test_covariance_scm_real(assume_centered, get_mats):


### PR DESCRIPTION
## What

Route the `"cov"` covariance estimator through
[`array_api_extra.cov`](https://data-apis.org/array-api-extra/), using the
new parameters added in **[data-apis/array-api-extra#690](https://github.com/data-apis/array-api-extra/pull/690)**
(`axis` / `correction` / `fweights` / `aweights`).

This is a small, concrete downstream consumer of that PR — see the
[motivating comment](https://github.com/data-apis/array-api-extra/pull/690#issuecomment-5057787560).

Solve a part of https://github.com/pyRiemann/pyRiemann/issues/465

## Why

`pyriemann.geometry.covariance._cov` used to:

1. hand-translate `bias`/`ddof` → `correction` (the `_cov_kwargs_to_xp` /
   `apply_xp_cov` shim in `_backend.py`) to paper over the NumPy-vs-PyTorch
   keyword split, and
2. loop over every leading batch dimension in Python (`_vectorize_nd`).

`array_api_extra.cov` now does **both** upstream: it takes the array-API
standard `correction` keyword and estimates covariances for all leading
batch dimensions in a single call, across backends. So for the `"cov"`
path we can delegate and drop the local machinery:

```python
def _cov(X, **kwds):
    xp = get_namespace(X)
    cov = xpx_cov(X, axis=-1, **_cov_kwargs_to_xp(kwds))
    return xp.reshape(cov, (*X.shape[:-2], X.shape[-2], X.shape[-2]))
```

Observations are the time samples, hence `axis=-1`. The reshape restores
the two matrix axes that `cov()` collapses when `n_channels == 1`, so the
output stays `(..., n_channels, n_channels)` in every case.

`_corr` still uses `apply_xp_cov(xp.corrcoef, ...)` — array-api-extra has no
`corrcoef` — so the shim stays for that estimator.

## Behavior

Output is **unchanged** for existing usage (`n_channels >= 2`): `xpx.cov`'s
defaults (`axis=-1, correction=1`) match `numpy.cov`, verified bit-for-bit
against a per-matrix `np.cov` loop up to 5-D batches, on both NumPy and
PyTorch. The only new coverage is the `n_channels == 1` shape guard.

## Tests

- `tests/test_geometry_covariance.py`: **all green** on NumPy + PyTorch.
- Added `test_covariances_single_channel` locking the `(..., 1, 1)` shape.

## Dependency

Needs array-api-extra #690, not yet released. `setup.py` and
`requirements.txt` temporarily pin the branch:

```
array-api-extra @ git+https://github.com/bruAristimunha/array-api-extra@cov_parameters
```

Marked as **draft** — revert the pin to a released `>=` floor once #690 is
merged and published.
