### PR TITLE
Add `transport_wasserstein` for Bures-Wasserstein parallel transport

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -822,6 +822,7 @@ Tangent Space
     transport_logchol
     transport_logeuclid
     transport_riemann
+    transport_wasserstein
 
 .. _base_api:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,6 +26,10 @@ v0.13.dev
 - Add Wasserstein inner product for Hermitian matrices :func:`pyriemann.geometry.tangentspace.innerproduct_wasserstein`.
   :pr:`455` by :user:`qbarthelemy`
 
+- Add :func:`pyriemann.geometry.tangentspace.transport_wasserstein` for parallel
+  transport with the Bures-Wasserstein metric.
+  :pr:`476` by :user:`AmitSubhash`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -1,6 +1,7 @@
 """Tangent space for SPD/HPD matrices."""
 
 import math
+import operator
 
 from array_api_compat import (
     array_namespace as get_namespace,
@@ -986,10 +987,10 @@ def innerproduct_wasserstein(X, Y, Cref):
         pp. 165-191.
     """
     xp = check_matrix_pair(X, Cref, require_square=True)
-    LX = xp.asarray(solve_continuous_lyapunov(Cref, xp.conj(X)))
+    LX = xp.asarray(solve_continuous_lyapunov(Cref, X))
     if Y is None:
         Y = X
-    G = 0.5 * xp.einsum("...ij,...ij->...", LX, Y).real
+    G = 0.5 * xp.einsum("...ij,...ji->...", LX, Y).real
     return _prepare_output(G, xp)
 
 
@@ -1311,15 +1312,112 @@ def transport_riemann(X, A, B):
     return X_new
 
 
+def transport_wasserstein(X, A, B, n_steps=100):
+    r"""Parallel transport for Wasserstein metric.
+
+    The parallel transport of matrices :math:`\mathbf{X}` in tangent space
+    from an initial SPD/HPD matrix :math:`\mathbf{A}` to a final SPD/HPD
+    matrix :math:`\mathbf{B}` according to the Levi-Civita connection of the
+    Bures-Wasserstein metric, described in Section 7.5 of [1]_.
+
+    Contrary to the other metrics, Bures-Wasserstein parallel transport has no
+    closed form in the general case [1]_ [2]_: it is defined by a linear
+    ordinary differential equation along the Wasserstein geodesic, integrated
+    here with a fixed-step Runge-Kutta scheme of order 4. A closed form exists
+    only when :math:`\mathbf{A}` and :math:`\mathbf{B}` commute.
+
+    Warning: this function must be applied to matrices :math:`\mathbf{X}`
+    already projected in tangent space with a logarithmic map at
+    :math:`\mathbf{A}`, not to SPD/HPD matrices in manifold.
+
+    Parameters
+    ----------
+    X : ndarray, shape (..., n, n)
+        Symmetric/Hermitian matrices in tangent space at A.
+    A : ndarray, shape (n, n)
+        Initial SPD/HPD matrix.
+    B : ndarray, shape (n, n)
+        Final SPD/HPD matrix.
+    n_steps : int, default=100
+        Number of Runge-Kutta steps used to integrate the transport equation.
+        Must be a positive integer; larger values increase accuracy at the
+        cost of computation.
+
+    Returns
+    -------
+    X_new : ndarray, shape (..., n, n)
+        Matrices in tangent space transported from A to B.
+
+    Notes
+    -----
+    .. versionadded:: 0.13
+
+    See Also
+    --------
+    transport
+
+    References
+    ----------
+    .. [1] `Wasserstein Riemannian geometry of Gaussian densities
+        <https://link.springer.com/article/10.1007/s41884-018-0014-4>`_
+        L. Malagò, L. Montrucchio, G. Pistone. Information Geometry, 2018, 1,
+        pp. 137–179.
+    .. [2] `O(n)-invariant Riemannian metrics on SPD matrices
+        <https://www.sciencedirect.com/science/article/pii/S0024379522004360>`_
+        Y. Thanwerdas & X. Pennec. Linear Algebra and its Applications, 2023.
+    """
+    try:
+        n_int = operator.index(n_steps)
+    except TypeError:
+        n_int = None
+    if isinstance(n_steps, bool) or n_int is None or n_int < 1:
+        raise ValueError(
+            f"n_steps must be a positive integer, got {n_steps!r}."
+        )
+    n_steps = n_int
+    xp = get_namespace(X, A, B)
+    n = A.shape[-1]
+    eye = xp.eye(n, dtype=A.dtype, device=xpd(A))
+
+    A12, A12inv = sqrtm(A), invsqrtm(A)
+    T = A12inv @ sqrtm(A12 @ B @ A12) @ A12inv
+    T = (T + ctranspose(T)) / 2
+    K = T - eye
+    AK, KA = A @ K, K @ A
+
+    # generator of the transported field: X0(t) solves X0 gamma + gamma X0 = X
+    X0 = xp.asarray(solve_continuous_lyapunov(A, X))
+
+    def _deriv(t, X0):
+        Mt = (1 - t) * eye + t * T
+        gamma = Mt @ A @ Mt
+        rhs = Mt @ AK @ X0 + X0 @ KA @ Mt
+        rhs = (rhs + ctranspose(rhs)) / 2
+        return -xp.asarray(solve_continuous_lyapunov(gamma, rhs))
+
+    h = 1 / n_steps
+    for i in range(n_steps):
+        t = i * h
+        k1 = _deriv(t, X0)
+        k2 = _deriv(t + h / 2, X0 + (h / 2) * k1)
+        k3 = _deriv(t + h / 2, X0 + (h / 2) * k2)
+        k4 = _deriv(t + h, X0 + h * k3)
+        X0 = X0 + (h / 6) * (k1 + 2 * k2 + 2 * k3 + k4)
+
+    X_new = B @ X0 + X0 @ B
+    return (X_new + ctranspose(X_new)) / 2
+
+
 transport_functions = {
     "euclid": transport_euclid,
     "logchol": transport_logchol,
     "logeuclid": transport_logeuclid,
     "riemann": transport_riemann,
+    "wasserstein": transport_wasserstein,
 }
 
 
-def transport(X, A, B, metric="riemann"):
+def transport(X, A, B, metric="riemann", **kwargs):
     r"""Parallel transport according to a specified metric.
 
     Parallel transport of matrices :math:`\mathbf{X}` in tangent space
@@ -1340,8 +1438,13 @@ def transport(X, A, B, metric="riemann"):
         Final SPD/HPD matrix.
     metric : string | callable, default="riemann"
         Metric used for parallel transport, can be:
-        "euclid", "logchol", "logeuclid", "riemann",
+        "euclid", "logchol", "logeuclid", "riemann", "wasserstein",
         or a callable function.
+    **kwargs : dict
+        Keyword arguments passed to the metric-specific transport function,
+        e.g. ``n_steps`` for the "wasserstein" metric.
+
+        .. versionadded:: 0.13
 
     Returns
     -------
@@ -1353,6 +1456,8 @@ def transport(X, A, B, metric="riemann"):
     .. versionadded:: 0.10
     .. versionchanged:: 0.12
         Add support for NumPy and PyTorch.
+    .. versionchanged:: 0.13
+        Add ``**kwargs`` forwarded to the metric-specific function.
 
     See Also
     --------
@@ -1360,6 +1465,7 @@ def transport(X, A, B, metric="riemann"):
     transport_logchol
     transport_logeuclid
     transport_riemann
+    transport_wasserstein
     """
     transport_function = check_function(metric, transport_functions)
-    return transport_function(X, A, B)
+    return transport_function(X, A, B, **kwargs)

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -1366,11 +1366,7 @@ def transport_wasserstein(X, A, B, n_steps=50):
         <https://www.sciencedirect.com/science/article/pii/S0024379522004360>`_
         Y. Thanwerdas & X. Pennec. Linear Algebra and its Applications, 2023.
     """
-    if (
-        isinstance(n_steps, bool)
-        or not isinstance(n_steps, numbers.Integral)
-        or n_steps < 1
-    ):
+    if not isinstance(n_steps, numbers.Integral) or n_steps < 1:
         raise ValueError(
             f"n_steps must be a positive integer, got {n_steps!r}."
         )

--- a/pyriemann/geometry/tangentspace.py
+++ b/pyriemann/geometry/tangentspace.py
@@ -1,7 +1,7 @@
 """Tangent space for SPD/HPD matrices."""
 
 import math
-import operator
+import numbers
 
 from array_api_compat import (
     array_namespace as get_namespace,
@@ -1312,7 +1312,7 @@ def transport_riemann(X, A, B):
     return X_new
 
 
-def transport_wasserstein(X, A, B, n_steps=100):
+def transport_wasserstein(X, A, B, n_steps=50):
     r"""Parallel transport for Wasserstein metric.
 
     The parallel transport of matrices :math:`\mathbf{X}` in tangent space
@@ -1320,11 +1320,10 @@ def transport_wasserstein(X, A, B, n_steps=100):
     matrix :math:`\mathbf{B}` according to the Levi-Civita connection of the
     Bures-Wasserstein metric, described in Section 7.5 of [1]_.
 
-    Contrary to the other metrics, Bures-Wasserstein parallel transport has no
-    closed form in the general case [1]_ [2]_: it is defined by a linear
-    ordinary differential equation along the Wasserstein geodesic, integrated
-    here with a fixed-step Runge-Kutta scheme of order 4. A closed form exists
-    only when :math:`\mathbf{A}` and :math:`\mathbf{B}` commute.
+    Bures-Wasserstein parallel transport is defined by a linear ordinary
+    differential equation along the Wasserstein geodesic [1]_, integrated here
+    with a fixed-step Runge-Kutta scheme of order 4. When :math:`\mathbf{A}`
+    and :math:`\mathbf{B}` commute, a closed form is available [2]_.
 
     Warning: this function must be applied to matrices :math:`\mathbf{X}`
     already projected in tangent space with a logarithmic map at
@@ -1338,10 +1337,11 @@ def transport_wasserstein(X, A, B, n_steps=100):
         Initial SPD/HPD matrix.
     B : ndarray, shape (n, n)
         Final SPD/HPD matrix.
-    n_steps : int, default=100
+    n_steps : int, default=50
         Number of Runge-Kutta steps used to integrate the transport equation.
-        Must be a positive integer; larger values increase accuracy at the
-        cost of computation.
+        Must be a positive integer. More steps are needed the further the
+        transport map between A and B is from identity, at a cost linear in
+        ``n_steps``.
 
     Returns
     -------
@@ -1366,15 +1366,14 @@ def transport_wasserstein(X, A, B, n_steps=100):
         <https://www.sciencedirect.com/science/article/pii/S0024379522004360>`_
         Y. Thanwerdas & X. Pennec. Linear Algebra and its Applications, 2023.
     """
-    try:
-        n_int = operator.index(n_steps)
-    except TypeError:
-        n_int = None
-    if isinstance(n_steps, bool) or n_int is None or n_int < 1:
+    if (
+        isinstance(n_steps, bool)
+        or not isinstance(n_steps, numbers.Integral)
+        or n_steps < 1
+    ):
         raise ValueError(
             f"n_steps must be a positive integer, got {n_steps!r}."
         )
-    n_steps = n_int
     xp = get_namespace(X, A, B)
     n = A.shape[-1]
     eye = xp.eye(n, dtype=A.dtype, device=xpd(A))

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -37,6 +37,7 @@ from pyriemann.geometry.tangentspace import (
     transport_logchol,
     transport_logeuclid,
     transport_riemann,
+    transport_wasserstein,
 )
 from pyriemann.geometry.test import is_hermitian, is_real
 from pyriemann.spatialfilters import Whitening
@@ -306,8 +307,6 @@ def test_innerproduct_broadcasting(finnerproduct, backend, get_mats):
 @pytest.mark.parametrize("metric", metrics)
 def test_innerproduct_property_distance(kindX, kindC, metric, get_mats):
     """Test d(C,exp_C(X))^2 = g_C(X,X) locally"""
-    if kindC == "hpd" and metric == "wasserstein":
-        pytest.skip()
     n_matrices, n_channels = 5, 3
     X = 0.1 * get_mats(n_matrices, n_channels, kindX)
     Cref = get_mats(1, n_channels, kindC)[0]
@@ -400,17 +399,18 @@ def test_innerproduct_riemann(kindX, kindC, get_mats):
     assert_array_almost_equal(G, G1)
 
 
-def test_innerproduct_wasserstein(get_mats):
+@pytest.mark.parametrize("kindX, kindC", [("sym", "spd"), ("herm", "hpd")])
+def test_innerproduct_wasserstein(kindX, kindC, get_mats):
     n_channels = 4
-    X, Y = get_mats(2, n_channels, "sym")
-    Cref = get_mats(1, n_channels, "spd")[0]
+    X, Y = get_mats(2, n_channels, kindX)
+    Cref = get_mats(1, n_channels, kindC)[0]
     G = innerproduct_wasserstein(X, Y, Cref)
     xp = get_namespace(X)
 
     # Eq(6) in [Malago2018]
     LX = xp.asarray(solve_continuous_lyapunov(Cref, X))
     LY = xp.asarray(solve_continuous_lyapunov(Cref, Y))
-    G1 = xp.trace(LX @ Cref @ LY)
+    G1 = xp.real(xp.trace(LX @ Cref @ LY))
     assert_array_almost_equal(G, G1)
 
 
@@ -442,6 +442,7 @@ def test_norm_properties(kindX, kindC, metric, backend, get_mats):
     transport_logchol,
     transport_logeuclid,
     transport_riemann,
+    transport_wasserstein,
 ])
 def test_transport_broadcasting(ftransport, get_mats):
     n_dim5, n_dim4, n_matrices, n_channels = 2, 4, 7, 3
@@ -473,6 +474,7 @@ def test_transport_broadcasting(ftransport, get_mats):
     "logchol",
     "logeuclid",
     "riemann",
+    "wasserstein",
 ])
 def test_transport_properties(kindX, kindAB, metric, get_mats, rndstate):
     n_matrices, n_channels = 10, 3
@@ -501,8 +503,8 @@ def test_transport_properties(kindX, kindAB, metric, get_mats, rndstate):
     xp = get_namespace(X)
     Xt_ABBC = transport(transport(X, A, B, metric), B, C, metric)
     alphas = np.linspace(0, 1, 5)
-    G_AB = [geodesic(A, B, alpha) for alpha in alphas]
-    G_BC = [geodesic(B, C, alpha) for alpha in alphas]
+    G_AB = [geodesic(A, B, alpha, metric=metric) for alpha in alphas]
+    G_BC = [geodesic(B, C, alpha, metric=metric) for alpha in alphas]
     G = xp.stack(G_AB + G_BC)
     Xt_AC = xp.asarray(X, copy=True)
     for i in range(len(G)-1):
@@ -529,3 +531,61 @@ def test_transport_riemann_vs_whitening(get_mats):
     Tt = transport(T, M, np.eye(n_channels), metric="riemann")
     Xt = exp_map_riemann(Tt, np.eye(n_channels), Cm12=True)
     assert Xw == approx(Xt)
+
+
+@pytest.mark.numpy_only
+@pytest.mark.parametrize("kindX, kindQ", [("sym", "orth"), ("herm", "unit")])
+def test_transport_wasserstein_commuting(kindX, kindQ, get_mats, rndstate):
+    """BW transport has a closed form for commuting endpoints."""
+    n_channels = 4
+    Q = get_mats(1, n_channels, kind=kindQ)[0]
+    d = rndstate.uniform(0.5, 3, n_channels)
+    delta = rndstate.uniform(0.5, 3, n_channels)
+    A = Q @ np.diag(d) @ Q.conj().T
+    B = Q @ np.diag(delta) @ Q.conj().T
+    X = get_mats(6, n_channels, kind=kindX)
+
+    Xt = transport(X, A, B, metric="wasserstein")
+
+    Xr = Q.conj().T @ X @ Q
+    fac = np.sqrt(np.add.outer(delta, delta) / np.add.outer(d, d))
+    expected = Q @ (fac * Xr) @ Q.conj().T
+    assert Xt == approx(expected)
+
+
+@pytest.mark.numpy_only
+@pytest.mark.parametrize("n_steps", [0, -1, 1.5, True])
+def test_transport_wasserstein_invalid_n_steps(n_steps, get_mats):
+    """transport_wasserstein rejects non-positive-integer n_steps."""
+    A, B = get_mats(2, 3, "spd")
+    X = get_mats(1, 3, "sym")[0]
+    with pytest.raises(ValueError):
+        transport_wasserstein(X, A, B, n_steps=n_steps)
+
+
+@pytest.mark.numpy_only
+def test_transport_wasserstein_accepts_numpy_int(get_mats):
+    """n_steps accepts integer-like scalars such as NumPy integers."""
+    A, B = get_mats(2, 3, "spd")
+    X = get_mats(1, 3, "sym")[0]
+    out_np = transport_wasserstein(X, A, B, n_steps=np.int64(20))
+    out_py = transport_wasserstein(X, A, B, n_steps=20)
+    assert out_np == approx(out_py)
+
+
+@pytest.mark.numpy_only
+def test_transport_wasserstein_dispatch_forwards_n_steps(get_mats):
+    """transport(metric='wasserstein') forwards n_steps."""
+    A, B = get_mats(2, 3, "spd")
+    X = get_mats(1, 3, "sym")[0]
+    coarse = transport(X, A, B, metric="wasserstein", n_steps=1)
+    assert coarse == approx(transport_wasserstein(X, A, B, n_steps=1))
+    # n_steps is actually used: a single RK4 step differs from the default
+    assert not np.allclose(
+        to_numpy(coarse),
+        to_numpy(transport(X, A, B, metric="wasserstein")),
+        atol=1e-6,
+    )
+    # integer-like kwargs (e.g. NumPy int) survive the dispatcher too
+    got = transport(X, A, B, metric="wasserstein", n_steps=np.int64(20))
+    assert got == approx(transport_wasserstein(X, A, B, n_steps=20))

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -538,8 +538,7 @@ def test_transport_riemann_vs_whitening(get_mats):
 def test_transport_wasserstein_commuting(kindX, kindQ, get_mats, rndstate):
     """BW transport has a closed form for commuting endpoints.
 
-    Table 7 of ref [2] in transport_wasserstein, proved in its Appendix A.
-    Stated there for real SPD; the HPD case here is the unitary analogue.
+    Table 7 of [Thanwerdas2023], proved in its Appendix A.
     """
     n_channels = 4
     Q = get_mats(1, n_channels, kind=kindQ)[0]
@@ -559,7 +558,7 @@ def test_transport_wasserstein_commuting(kindX, kindQ, get_mats, rndstate):
 
 
 @pytest.mark.numpy_only
-@pytest.mark.parametrize("n_steps", [0, -1, 1.5, True])
+@pytest.mark.parametrize("n_steps", [0, -1, 1.5])
 def test_transport_wasserstein_invalid_n_steps(n_steps, get_mats):
     """transport_wasserstein rejects non-positive-integer n_steps."""
     A, B = get_mats(2, 3, "spd")

--- a/tests/test_geometry_tangentspace.py
+++ b/tests/test_geometry_tangentspace.py
@@ -536,20 +536,25 @@ def test_transport_riemann_vs_whitening(get_mats):
 @pytest.mark.numpy_only
 @pytest.mark.parametrize("kindX, kindQ", [("sym", "orth"), ("herm", "unit")])
 def test_transport_wasserstein_commuting(kindX, kindQ, get_mats, rndstate):
-    """BW transport has a closed form for commuting endpoints."""
+    """BW transport has a closed form for commuting endpoints.
+
+    Table 7 of ref [2] in transport_wasserstein, proved in its Appendix A.
+    Stated there for real SPD; the HPD case here is the unitary analogue.
+    """
     n_channels = 4
     Q = get_mats(1, n_channels, kind=kindQ)[0]
+    Qh = Q.conj().T
     d = rndstate.uniform(0.5, 3, n_channels)
     delta = rndstate.uniform(0.5, 3, n_channels)
-    A = Q @ np.diag(d) @ Q.conj().T
-    B = Q @ np.diag(delta) @ Q.conj().T
+    A = Q @ np.diag(d) @ Qh
+    B = Q @ np.diag(delta) @ Qh
     X = get_mats(6, n_channels, kind=kindX)
 
     Xt = transport(X, A, B, metric="wasserstein")
 
-    Xr = Q.conj().T @ X @ Q
+    Xr = Qh @ X @ Q
     fac = np.sqrt(np.add.outer(delta, delta) / np.add.outer(d, d))
-    expected = Q @ (fac * Xr) @ Q.conj().T
+    expected = Q @ (fac * Xr) @ Qh
     assert Xt == approx(expected)
 
 
@@ -564,11 +569,12 @@ def test_transport_wasserstein_invalid_n_steps(n_steps, get_mats):
 
 
 @pytest.mark.numpy_only
-def test_transport_wasserstein_accepts_numpy_int(get_mats):
-    """n_steps accepts integer-like scalars such as NumPy integers."""
+@pytest.mark.parametrize("dtype", [np.int64, np.int32, np.uint8])
+def test_transport_wasserstein_accepts_numpy_int(dtype, get_mats):
+    """n_steps accepts NumPy integers of any width, not just np.int64."""
     A, B = get_mats(2, 3, "spd")
     X = get_mats(1, 3, "sym")[0]
-    out_np = transport_wasserstein(X, A, B, n_steps=np.int64(20))
+    out_np = transport_wasserstein(X, A, B, n_steps=dtype(20))
     out_py = transport_wasserstein(X, A, B, n_steps=20)
     assert out_np == approx(out_py)
 


### PR DESCRIPTION
Closes #418.

Adds Bures-Wasserstein parallel transport, integrating the transport ODE with a fixed-step RK4 scheme. Tests cover SPD/HPD inputs, batching, and the commuting closed form as an exact oracle.

Also fixes `innerproduct_wasserstein` for complex HPD inputs, which un-skips the HPD Wasserstein distance-property test.
