### PR TITLE
Use namespace-native expand_dims instead of array-api-extra

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,10 @@ v0.13.dev
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
 
+- Update ``array-api-compat`` from >=1.11 to >=1.14, and replace the deprecated
+  ``array_api_extra.expand_dims`` by the namespace-native ``expand_dims``.
+  :pr:`478` by :user:`AmitSubhash`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/geometry/covariance.py
+++ b/pyriemann/geometry/covariance.py
@@ -2,7 +2,6 @@ from functools import wraps
 import warnings
 
 from array_api_compat import array_namespace as get_namespace, device as xpd
-from array_api_extra import expand_dims
 from scipy.stats import chi2
 
 from ._backend import (
@@ -317,7 +316,7 @@ def covariance_sch(X):
                  xp.sum(var_R, axis=(-2, -1)) / R2_sum),
         0, 1,
     )
-    gamma = expand_dims(gamma, axis=(-2, -1))
+    gamma = xp.expand_dims(gamma, axis=(-2, -1))
 
     sigma = (1. - gamma) * (n_times / (n_times - 1.)) * C_scm
 
@@ -971,7 +970,7 @@ def normalize(X, norm):
 
     if norm == "corr":
         stddev = xp.sqrt(xp.abs(xp.linalg.diagonal(X)))
-        denom = expand_dims(stddev, axis=-2) * stddev[..., None]
+        denom = xp.expand_dims(stddev, axis=-2) * stddev[..., None]
     elif norm == "trace":
         denom = xp.linalg.trace(X)
     elif norm == "determinant":
@@ -979,7 +978,7 @@ def normalize(X, norm):
     else:
         raise ValueError(f"{norm} is not a supported normalization")
 
-    denom = expand_dims(denom, axis=tuple(range(denom.ndim, X.ndim)))
+    denom = xp.expand_dims(denom, axis=tuple(range(denom.ndim, X.ndim)))
     Xn = X / denom
 
     if norm == "corr":

--- a/pyriemann/geometry/geodesic.py
+++ b/pyriemann/geometry/geodesic.py
@@ -1,7 +1,6 @@
 """Geodesics for SPD/HPD matrices."""
 
 from array_api_compat import array_namespace as get_namespace
-from array_api_extra import expand_dims
 
 from ._backend import diag_indices, tril_indices
 from ._check import check_function, check_matrix_pair
@@ -26,7 +25,7 @@ def _check_alpha(alpha, X, axis=(-2, -1)):
             raise ValueError(
                 f"alpha must have shape {expected_shape}, got {alpha.shape}."
             )
-        alpha = expand_dims(alpha, axis=axis)
+        alpha = xpa.expand_dims(alpha, axis=axis)
     else:
         raise ValueError(
             f"alpha must be a float or an array, got {type(alpha)}."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.25.0
 scipy
 scikit-learn>=0.24
-array-api-compat>=1.11
+array-api-compat>=1.14
 array-api-extra>=0.6
 joblib
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "numpy>=1.25.0",
         "scipy",
         "scikit-learn>=0.24",
-        "array-api-compat>=1.11",
+        "array-api-compat>=1.14",
         "array-api-extra>=0.6",
         "joblib",
         "matplotlib",


### PR DESCRIPTION
Part of #465.

`array_api_extra.expand_dims` is deprecated and will be removed in v1.0.0; tuple-of-int `axis` has been in the array API standard since v2025.12. `array-api-compat` 1.14 ships it, so this bumps the floor from 1.11 to 1.14 and swaps the four call sites in `geometry/covariance.py` and `geometry/geodesic.py` to the namespace-native version.

Tested at the 1.14 floor: suite passes and warnings drop from ~3540 to ~190.

Leaving the `*_indices` items (still unreleased in array-api-extra) and `cov` (#475).
