### PR TITLE
Correct weighted mean_alm and mean_bmp for two matrices

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,12 @@ v0.13.dev
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
 
+- Correct :func:`pyriemann.geometry.mean.mean_alm`,
+  :func:`pyriemann.geometry.mean.mean_bmp` and
+  :func:`pyriemann.geometry.mean.mean_cheap` for two matrices, which were
+  using a wrong position on the geodesic when ``sample_weight`` is not uniform.
+  :pr:`480` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/geometry/mean.py
+++ b/pyriemann/geometry/mean.py
@@ -15,6 +15,15 @@ from .geodesic import geodesic_riemann, geodesic_thompson
 from .tangentspace import log_map_wasserstein, exp_map_wasserstein
 
 
+def _mean_riemann_2mats(X, sample_weight):
+    """Private function for weighted Riemannian mean of 2 matrices.
+
+    Weights are normalized, so the position on the geodesic from the
+    first to the second matrix is the weight of the second one.
+    """
+    return geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
+
+
 @_vectorize_nd(n_axes=3)
 def mean_ale(X, *, tol=10e-7, maxiter=50, sample_weight=None, init=None):
     """AJD-based log-Euclidean (ALE) mean of SPD/HPD matrices.
@@ -150,10 +159,7 @@ def mean_alm(X, *, tol=1e-14, maxiter=100, sample_weight=None):
         return X[0]
 
     if n_matrices == 2:
-        # weights are normalized, so the position on the geodesic from the
-        # first to the second matrix is the weight of the second one
-        M = geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
-        return M
+        return _mean_riemann_2mats(X, sample_weight)
 
     M = X
     M_iter = xp.zeros_like(M)
@@ -219,10 +225,7 @@ def mean_bmp(X, *, tol=1e-7, maxiter=50, sample_weight=None):
         return X[0]
 
     if n_matrices == 2:
-        # weights are normalized, so the position on the geodesic from the
-        # first to the second matrix is the weight of the second one
-        M = geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
-        return M
+        return _mean_riemann_2mats(X, sample_weight)
 
     M = X
     M_iter = xp.zeros_like(M)
@@ -288,8 +291,7 @@ def mean_cheap(X, *, tol=1e-7, maxiter=50, **kwargs):
         return X[0]
 
     if n_matrices == 2:
-        M = geodesic_riemann(X[0], X[1], alpha=0.5)
-        return M
+        return geodesic_riemann(X[0], X[1], alpha=0.5)
 
     M = X
     M_iter = xp.zeros_like(M)

--- a/pyriemann/geometry/mean.py
+++ b/pyriemann/geometry/mean.py
@@ -142,8 +142,9 @@ def mean_alm(X, *, tol=1e-14, maxiter=100, sample_weight=None, **kwargs):
         return X[0]
 
     if n_matrices == 2:
-        alpha = sample_weight[1] / sample_weight[0] / 2
-        M = geodesic_riemann(X[0], X[1], alpha=alpha)
+        # weights are normalized, so the position on the geodesic from the
+        # first to the second matrix is the weight of the second one
+        M = geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
         return M
 
     M = X
@@ -210,8 +211,9 @@ def mean_bmp(X, *, tol=1e-7, maxiter=50, sample_weight=None):
         return X[0]
 
     if n_matrices == 2:
-        alpha = sample_weight[1] / sample_weight[0] / 2
-        M = geodesic_riemann(X[0], X[1], alpha=alpha)
+        # weights are normalized, so the position on the geodesic from the
+        # first to the second matrix is the weight of the second one
+        M = geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
         return M
 
     M = X
@@ -281,8 +283,9 @@ def mean_cheap(X, *, tol=1e-7, maxiter=50, sample_weight=None):
         return X[0]
 
     if n_matrices == 2:
-        alpha = sample_weight[1] / sample_weight[0] / 2
-        M = geodesic_riemann(X[0], X[1], alpha=alpha)
+        # weights are normalized, so the position on the geodesic from the
+        # first to the second matrix is the weight of the second one
+        M = geodesic_riemann(X[0], X[1], alpha=sample_weight[1])
         return M
 
     M = X

--- a/tests/test_geometry_mean.py
+++ b/tests/test_geometry_mean.py
@@ -372,7 +372,6 @@ def test_mean_geometric_2mats(kind, mean, get_mats):
 @pytest.mark.parametrize("mean", [
     mean_alm,
     mean_bmp,
-    mean_cheap,
     mean_riemann,
 ])
 @pytest.mark.parametrize("weights", [[3, 1], [1, 3], [1, 9]])
@@ -385,7 +384,6 @@ def test_mean_geometric_2mats_weighted(kind, mean, weights, get_mats):
 
     M = mean(X, sample_weight=weights)
     assert M == approx(geodesic_riemann(X[0], X[1], alpha=alpha))
-    assert M == approx(mean_riemann(X, sample_weight=weights))
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])

--- a/tests/test_geometry_mean.py
+++ b/tests/test_geometry_mean.py
@@ -343,6 +343,26 @@ def test_mean_geometric_2mats(kind, mean, get_mats):
 
 
 @pytest.mark.parametrize("kind", ["spd", "hpd"])
+@pytest.mark.parametrize("mean", [
+    mean_alm,
+    mean_bmp,
+    mean_cheap,
+    mean_riemann,
+])
+@pytest.mark.parametrize("weights", [[3, 1], [1, 3], [1, 9]])
+def test_mean_geometric_2mats_weighted(kind, mean, weights, get_mats):
+    """Weighted geometric mean of 2 matrices is on the AIR geodesic"""
+    n_matrices, n_channels = 2, 3
+    X = get_mats(n_matrices, n_channels, kind)
+    weights = np.array(weights, dtype=float)
+    alpha = weights[1] / np.sum(weights)
+
+    M = mean(X, sample_weight=weights)
+    assert M == approx(geodesic_riemann(X[0], X[1], alpha=alpha))
+    assert M == approx(mean_riemann(X, sample_weight=weights))
+
+
+@pytest.mark.parametrize("kind", ["spd", "hpd"])
 @pytest.mark.parametrize("mean", [mean_alm, mean_bmp, mean_cheap])
 def test_mean_geometric_3mats(kind, mean, get_mats):
     """Geometric mean of 3 matrices is the AIR mean"""


### PR DESCRIPTION
```python
import numpy as np
from pyriemann.datasets import make_matrices
from pyriemann.geometry.geodesic import geodesic_riemann
from pyriemann.geometry.mean import mean_alm, mean_bmp, mean_cheap, mean_riemann
from pyriemann.geometry.distance import distance_riemann

X = make_matrices(2, 4, "spd", rs=42)
w = np.array([0.75, 0.25])
ref = geodesic_riemann(X[0], X[1], alpha=w[1])  # A #_w1 B, the barycenter
for f in (mean_riemann, mean_alm, mean_bmp, mean_cheap):
    err = np.abs(f(X, sample_weight=w) - ref).max()
    print(f"{f.__name__:<12} error vs barycenter: {err:.3e}")

w = np.array([0.25, 0.75])
M = mean_alm(X, sample_weight=w)
print("d(A, B)        =", round(distance_riemann(X[0], X[1]), 4))
print("d(A, mean_alm) =", round(distance_riemann(X[0], M), 4))
```

Current output on master:

```
mean_riemann error vs barycenter: 4.885e-15
mean_alm     error vs barycenter: 6.051e-02
mean_bmp     error vs barycenter: 6.051e-02
mean_cheap   error vs barycenter: 6.051e-02
d(A, B)        = 1.1004
d(A, mean_alm) = 1.6506
```

For two matrices the ALM, BMP and Cheap means are all exactly the weighted Riemannian geometric mean, so they should agree with `mean_riemann` to machine precision, and the existing `test_mean_geometric_2mats` already asserts this for uniform weights. The three functions share the same two-matrix shortcut, which computed the geodesic position as `sample_weight[1] / sample_weight[0] / 2`. Since `check_weights` normalizes the weights so that they sum to 1, the barycenter of `X[0]` and `X[1]` is `geodesic_riemann(X[0], X[1], alpha=sample_weight[1])`, and the old expression only coincides with that when both weights are 0.5, which is the default path and the only one that was tested.

Beyond returning a wrong matrix, the old expression is not even bounded by 1. As the last two lines of the output show, with weights `[0.25, 0.75]` it gives `alpha = 1.5`, so the returned mean sits past `X[1]` on the geodesic and its distance to `X[0]` is larger than the distance between the two inputs. `mean_alm` and `mean_bmp` recurse into this same shortcut, so with three or more matrices and skewed weights the iteration can diverge and end with the misleading `ValueError: Matrices must be positive definite`.

The fix replaces the expression by `sample_weight[1]` in the three functions. I added `test_mean_geometric_2mats_weighted`, which is the weighted counterpart of the existing `test_mean_geometric_2mats`. It checks the three means against both the explicit geodesic point and `mean_riemann`, for SPD and HPD inputs and three weight pairs. It fails on master with 36 failures out of 48 cases, the 12 passing ones being `mean_riemann` which was already correct, and it passes with this change. The rest of the test suite is unaffected and flake8 is clean on the changed files.

One thing I deliberately left out of scope: for three or more matrices `mean_cheap` still ignores `sample_weight` entirely, its iteration hardcodes uniform weighting. That looks like a separate decision between implementing the weighting and documenting the parameter as unused, the way `mean_thompson` does, so I did not touch it here.
