### PR TITLE
Correct rotation estimated by TLRotate in tangent space

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -71,6 +71,11 @@ v0.13.dev
   diagonalizes a non-symmetric matrix with ``numpy.linalg.eigh``.
   :pr:`492` by :user:`adityasingh2400`
 
+- Correct rotation estimation of :class:`pyriemann.transfer.TLRotate` in tangent space, which applied the
+  transpose of the Procrustes rotation, ie the inverse of the rotation mapping
+  each source domain onto the target domain.
+  :pr:`481` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/optimization/grassmann.py
+++ b/pyriemann/optimization/grassmann.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 
+from ..geometry.base import invsqrtm, logm, sqrtm
 from ..geometry.distance import distance
 from ..utils._check import check_weights
 
@@ -34,7 +35,7 @@ def _retract(X, v):
 def _loss(Q, X, Y, weights, metric="euclid"):
     """Loss function for estimating the rotation matrix."""
 
-    return weights @ distance(X, Q @ Y @ Q.T, metric=metric)
+    return weights @ distance(X, Q @ Y @ Q.T, metric=metric, squared=True)
 
 
 def _grad(Q, X, Y, weights, metric="euclid"):
@@ -44,11 +45,13 @@ def _grad(Q, X, Y, weights, metric="euclid"):
         return np.einsum("a,abc->bc", weights, -4 * (X - Q @ Y @ Q.T) @ Q @ Y)
 
     elif metric == "riemann":
-        M = np.linalg.solve(X, Q) @ Y @ Q.T
-        eigvals, eigvecs = np.linalg.eigh(M)
-        logeigvals = np.expand_dims(np.log(eigvals), -2)
-        inveigvecs = np.linalg.solve(eigvecs, np.eye(eigvecs.shape[-1]))
-        logM = (eigvecs * logeigvals) @ inveigvecs
+        # logm of X^-1 S, with S = Q Y Q^T. This product of two SPD matrices
+        # is not symmetric, so it cannot be diagonalized by eigh. It is
+        # however similar to the SPD matrix X^-1/2 S X^-1/2, which is:
+        # logm(X^-1 S) = X^-1/2 logm(X^-1/2 S X^-1/2) X^1/2
+        X_invsqrt, X_sqrt = invsqrtm(X), sqrtm(X)
+        S = Q @ Y @ Q.T
+        logM = X_invsqrt @ logm(X_invsqrt @ S @ X_invsqrt) @ X_sqrt
         return np.einsum("a,abc->bc", weights, 4 * logM @ Q)
 
     else:
@@ -297,6 +300,8 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
     Notes
     -----
     .. versionadded:: 0.8
+    .. versionchanged:: 0.13
+        Correct rotation estimation.
 
     References
     ----------

--- a/pyriemann/optimization/grassmann.py
+++ b/pyriemann/optimization/grassmann.py
@@ -4,7 +4,6 @@ import warnings
 
 import numpy as np
 
-from ..geometry.base import invsqrtm, logm, sqrtm
 from ..geometry.distance import distance
 from ..utils._check import check_weights
 
@@ -35,7 +34,7 @@ def _retract(X, v):
 def _loss(Q, X, Y, weights, metric="euclid"):
     """Loss function for estimating the rotation matrix."""
 
-    return weights @ distance(X, Q @ Y @ Q.T, metric=metric, squared=True)
+    return weights @ distance(X, Q @ Y @ Q.T, metric=metric)
 
 
 def _grad(Q, X, Y, weights, metric="euclid"):
@@ -45,13 +44,11 @@ def _grad(Q, X, Y, weights, metric="euclid"):
         return np.einsum("a,abc->bc", weights, -4 * (X - Q @ Y @ Q.T) @ Q @ Y)
 
     elif metric == "riemann":
-        # logm of X^-1 S, with S = Q Y Q^T. This product of two SPD matrices
-        # is not symmetric, so it cannot be diagonalized by eigh. It is
-        # however similar to the SPD matrix X^-1/2 S X^-1/2, which is:
-        # logm(X^-1 S) = X^-1/2 logm(X^-1/2 S X^-1/2) X^1/2
-        X_invsqrt, X_sqrt = invsqrtm(X), sqrtm(X)
-        S = Q @ Y @ Q.T
-        logM = X_invsqrt @ logm(X_invsqrt @ S @ X_invsqrt) @ X_sqrt
+        M = np.linalg.solve(X, Q) @ Y @ Q.T
+        eigvals, eigvecs = np.linalg.eigh(M)
+        logeigvals = np.expand_dims(np.log(eigvals), -2)
+        inveigvecs = np.linalg.solve(eigvecs, np.eye(eigvecs.shape[-1]))
+        logM = (eigvecs * logeigvals) @ inveigvecs
         return np.einsum("a,abc->bc", weights, 4 * logM @ Q)
 
     else:

--- a/pyriemann/optimization/grassmann.py
+++ b/pyriemann/optimization/grassmann.py
@@ -323,4 +323,4 @@ def _get_rotation_tangentspace(X_source, X_target, expl_var):
 
     u = u[:, :n_comps]
     vh = vh[:n_comps, :]
-    return vh.T @ u.T
+    return u @ vh

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -654,6 +654,9 @@ class TLRotate(TransformerMixin, BaseEstimator):
         Add support for multisource domains in tangent space.
     .. versionchanged:: 0.11
         Add parameters ``tol_step`` and ``maxiter``.
+    .. versionchanged:: 0.13
+        Correct loss and gradient for rotation in manifold.
+        Correct estimation of rotation in tangent space.
 
     See Also
     --------

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -6,6 +6,7 @@ from pytest import approx
 from pyriemann.geometry.distance import distance
 from pyriemann.optimization.grassmann import (
     _get_rotation_manifold,
+    _get_rotation_tangentspace,
     _grad,
     _loss,
 )
@@ -68,3 +69,18 @@ def test_get_rotation_manifold(metric, get_mats, get_weights):
 
     assert Q.shape == (n_channels, n_channels)
     assert _is_orth(Q)
+
+
+@pytest.mark.parametrize("expl_var", [0.999, 4])
+def test_get_rotation_tangentspace(rndstate, expl_var):
+    """Test that Procrustes analysis maps source onto target"""
+    n_vectors, n_ts = 20, 4
+    X_source = rndstate.randn(n_vectors, n_ts)
+    rotation = np.linalg.qr(rndstate.randn(n_ts, n_ts))[0]
+    X_target = X_source @ rotation
+
+    Q = _get_rotation_tangentspace(X_source, X_target, expl_var)
+    assert _is_orth(Q)
+
+    assert_array_almost_equal(Q, rotation)
+    assert_array_almost_equal(X_source @ Q, X_target)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -25,11 +25,6 @@ from pyriemann.geometry.distance import distance, distance_riemann
 from pyriemann.geometry.geodesic import geodesic
 from pyriemann.geometry.mean import gmean, mean_riemann
 from pyriemann.geometry.tangentspace import tangent_space
-from pyriemann.optimization.grassmann import (
-    _get_rotation_tangentspace,
-    _grad,
-    _loss,
-)
 from pyriemann.regression import KNearestNeighborRegressor, SVR
 from pyriemann.transfer import (
     decode_domains,
@@ -505,59 +500,6 @@ def test_tlrotate_tangentspace_recovers_rotation(rndstate):
             np.mean(X_rot[domain == "src"][y == label], axis=0) - m_tgt
         )
         assert dist_after < dist_before / 10
-
-
-@pytest.mark.parametrize("expl_var", [0.999, 4])
-def test_get_rotation_tangentspace(rndstate, expl_var):
-    """Test that Procrustes analysis maps source onto target"""
-    n_vectors, n_ts = 20, 4
-    X_source = rndstate.randn(n_vectors, n_ts)
-    rotation = np.linalg.qr(rndstate.randn(n_ts, n_ts))[0]
-    X_target = X_source @ rotation
-
-    Q = _get_rotation_tangentspace(X_source, X_target, expl_var)
-
-    assert_array_almost_equal(Q, rotation)
-    assert_array_almost_equal(X_source @ Q, X_target)
-
-
-@pytest.mark.parametrize("metric", ["euclid", "riemann"])
-def test_grassmann_loss(rndstate, metric):
-    """Test that loss is the weighted sum of squared distances"""
-    n_matrices, n_channels = 3, 4
-    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
-    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
-    weights = np.array([0.5, 0.3, 0.2])
-    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
-
-    assert _loss(Q, X, Y, weights, metric=metric) == approx(
-        weights @ distance(X, Q @ Y @ Q.T, metric=metric) ** 2
-    )
-
-
-@pytest.mark.parametrize("metric", ["euclid", "riemann"])
-def test_grassmann_grad(rndstate, metric):
-    """Test that gradient is the derivative of the loss"""
-    n_matrices, n_channels = 3, 4
-    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
-    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
-    weights = np.array([0.5, 0.3, 0.2])
-    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
-
-    eps = 1e-6
-    grad_num = np.zeros((n_channels, n_channels))
-    for i in range(n_channels):
-        for j in range(n_channels):
-            step = np.zeros((n_channels, n_channels))
-            step[i, j] = eps
-            grad_num[i, j] = (
-                _loss(Q + step, X, Y, weights, metric=metric)
-                - _loss(Q - step, X, Y, weights, metric=metric)
-            ) / (2 * eps)
-
-    grad = _grad(Q, X, Y, weights, metric=metric)
-    assert grad.dtype == grad_num.dtype
-    assert_array_almost_equal(grad, grad_num, decimal=5)
 
 
 ###############################################################################

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -41,7 +41,6 @@ from pyriemann.transfer import (
 from pyriemann.utils._check import check_weights
 
 pytestmark = pytest.mark.numpy_only
-rndstate = 1234
 
 
 ###############################################################################

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -25,6 +25,11 @@ from pyriemann.geometry.distance import distance, distance_riemann
 from pyriemann.geometry.geodesic import geodesic
 from pyriemann.geometry.mean import gmean, mean_riemann
 from pyriemann.geometry.tangentspace import tangent_space
+from pyriemann.optimization.grassmann import (
+    _get_rotation_tangentspace,
+    _grad,
+    _loss,
+)
 from pyriemann.regression import KNearestNeighborRegressor, SVR
 from pyriemann.transfer import (
     decode_domains,
@@ -468,13 +473,91 @@ def test_tlrotate_tangentspace(rndstate, get_weights, expl_var,
 
     X_rot = tlrot.fit_transform(X, y_enc, sample_weight=weights)
     assert X_rot.shape == X.shape
-    assert_array_equal(
-        X_rot[domain == "target_domain"],
-        X[domain == "target_domain"],
-    )
+    assert_array_equal(X_rot[domain == "tgt"], X[domain == "tgt"])
 
     X_rot = tlrot.transform(X)
     assert_array_equal(X_rot, X)
+
+
+def test_tlrotate_tangentspace_recovers_rotation(rndstate):
+    """Test that rotating vectors brings source domain onto target domain"""
+    n_ts, n_vectors_d = 4, 60
+    X_src = rndstate.randn(n_vectors_d, n_ts)
+    y = rndstate.randint(0, 2, size=n_vectors_d)
+    X_src += 3 * np.take(np.eye(n_ts)[:2], y, axis=0)  # separate classes
+    rotation = np.linalg.qr(rndstate.randn(n_ts, n_ts))[0]
+    X_tgt = X_src @ rotation
+
+    X = np.concatenate([X_tgt, X_src])
+    domain = np.array(n_vectors_d * ["tgt"] + n_vectors_d * ["src"])
+    _, y_enc = encode_domains(X, np.concatenate([y, y]), domain)
+
+    tlrot = TLRotate(target_domain="tgt", n_components=1, n_clusters=2)
+    X_rot = tlrot.fit_transform(X, y_enc)
+
+    # the rotation must map the source domain onto the target domain
+    for label in np.unique(y):
+        m_tgt = np.mean(X_tgt[y == label], axis=0)
+        dist_before = np.linalg.norm(
+            np.mean(X_src[y == label], axis=0) - m_tgt
+        )
+        dist_after = np.linalg.norm(
+            np.mean(X_rot[domain == "src"][y == label], axis=0) - m_tgt
+        )
+        assert dist_after < dist_before / 10
+
+
+@pytest.mark.parametrize("expl_var", [0.999, 4])
+def test_get_rotation_tangentspace(rndstate, expl_var):
+    """Test that Procrustes analysis maps source onto target"""
+    n_vectors, n_ts = 20, 4
+    X_source = rndstate.randn(n_vectors, n_ts)
+    rotation = np.linalg.qr(rndstate.randn(n_ts, n_ts))[0]
+    X_target = X_source @ rotation
+
+    Q = _get_rotation_tangentspace(X_source, X_target, expl_var)
+
+    assert_array_almost_equal(Q, rotation)
+    assert_array_almost_equal(X_source @ Q, X_target)
+
+
+@pytest.mark.parametrize("metric", ["euclid", "riemann"])
+def test_grassmann_loss(rndstate, metric):
+    """Test that loss is the weighted sum of squared distances"""
+    n_matrices, n_channels = 3, 4
+    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    weights = np.array([0.5, 0.3, 0.2])
+    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
+
+    assert _loss(Q, X, Y, weights, metric=metric) == approx(
+        weights @ distance(X, Q @ Y @ Q.T, metric=metric) ** 2
+    )
+
+
+@pytest.mark.parametrize("metric", ["euclid", "riemann"])
+def test_grassmann_grad(rndstate, metric):
+    """Test that gradient is the derivative of the loss"""
+    n_matrices, n_channels = 3, 4
+    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    weights = np.array([0.5, 0.3, 0.2])
+    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
+
+    eps = 1e-6
+    grad_num = np.zeros((n_channels, n_channels))
+    for i in range(n_channels):
+        for j in range(n_channels):
+            step = np.zeros((n_channels, n_channels))
+            step[i, j] = eps
+            grad_num[i, j] = (
+                _loss(Q + step, X, Y, weights, metric=metric)
+                - _loss(Q - step, X, Y, weights, metric=metric)
+            ) / (2 * eps)
+
+    grad = _grad(Q, X, Y, weights, metric=metric)
+    assert grad.dtype == grad_num.dtype
+    assert_array_almost_equal(grad, grad_num, decimal=5)
 
 
 ###############################################################################


### PR DESCRIPTION
`pyriemann/optimization/grassmann.py` has three defects that make `TLRotate` return wrong rotations.

On current master, a known-answer check plus a finite difference check:

```
Q equals the rotation      : False
Q equals its transpose     : True
|| X_source Q - X_target ||: 11.957493614804005
documented loss sum_i w_i d^2: 1.031879145975589
value returned by _loss      : 1.009228770614949
max error of _grad vs numerical gradient: 0.2401209229939022
```

With this branch:

```
Q equals the rotation      : True
Q equals its transpose     : False
|| X_source Q - X_target ||: 5.570116854550151e-15
documented loss sum_i w_i d^2: 1.031879145975589
value returned by _loss      : 1.031879145975589
max error of _grad vs numerical gradient: 6.466127633331098e-10
```

The reproduction script is at the bottom of this description.

The three defects, independent and each about one line:

**1. `_get_rotation_tangentspace` returns the transpose of the Procrustes solution.** Its docstring documents minimizing `|| X_source Q - X_target ||_F^2`, whose solution is `U V^T` with `U S V^T = svd(X_source^T X_target)`. `numpy.linalg.svd` returns `u, s, vh` with `vh = V^T`, so the solution is `u @ vh`, but the code returns `vh.T @ u.T`, which is its transpose, that is its inverse. `TLRotate.fit_transform` then applies `X[idx] @ self.rotations_[d]`, so every source domain in tangent space is rotated by the inverse of the intended rotation. Fixed to `u @ vh`.

**2. `_loss` returns a sum of distances, not of squared distances.** The docstring of `_get_rotation_manifold` states the objective is `L(Q) = sum_i w_i d^2(...)`, and `_grad` is the gradient of that squared objective for both metrics, confirmed above by finite differences. The backtracking line search in `_run_minimization` was therefore testing the descent of a different function from the one being differentiated. Fixed by passing `squared=True`.

**3. `_grad` with `metric="riemann"` diagonalized a non-symmetric matrix with `eigh`.** `M = X^-1 Q Y Q^T` is a product of two SPD matrices, so it has real positive eigenvalues but is not symmetric. `numpy.linalg.eigh` reads only one triangle, so `expm(logM)` does not recover `M`. This came in with #468, which correctly replaced `eig` by `eigh` in `_warm_start` where the inputs really are symmetric, but the same replacement in `_grad` does not hold. Rather than reverting to `eig`, which is what raised the warning #468 removed, this uses the similar SPD matrix `X^-1/2 S X^-1/2`, since `logm(X^-1 S) = X^-1/2 logm(X^-1/2 S X^-1/2) X^1/2`. `eigh` stays valid, the result stays real, and the gradient error drops from 2.4e-1 to 6.5e-10.

**Why this was never caught.** `test_tlrotate_tangentspace` had a vacuous assertion. It compared `X_rot[domain == "target_domain"]` while the domains in that test are `"tgt"`, `"src1"` and `"src2"`, so both sides of the comparison were empty arrays. It now compares `domain == "tgt"`.

Tests added to `tests/test_transfer.py`: `test_get_rotation_tangentspace` (exact recovery of a known rotation, for both forms of `expl_var`), `test_tlrotate_tangentspace_recovers_rotation` (end to end through `TLRotate`), `test_grassmann_loss` (`_loss` equals the weighted sum of squared distances), and `test_grassmann_grad` (`_grad` equals the numerical gradient of `_loss`, for both metrics).

7 selected tests fail on master and pass with the branch. Full `tests/` run gives 3595 passed and 1272 skipped. `flake8` is clean and there is a `doc/whatsnew.rst` entry.

Reproduction:

```python
import numpy as np
from pyriemann.geometry.distance import distance_riemann
from pyriemann.optimization.grassmann import _get_rotation_tangentspace, _loss, _grad
from pyriemann.datasets import make_matrices

rs = np.random.RandomState(0)
X_source = rs.randn(20, 4)
rotation = np.linalg.qr(rs.randn(4, 4))[0]
X_target = X_source @ rotation

Q = _get_rotation_tangentspace(X_source, X_target, expl_var=1.0)
print("Q equals the rotation      :", np.allclose(Q, rotation))
print("Q equals its transpose     :", np.allclose(Q, rotation.T))
print("|| X_source Q - X_target ||:", np.linalg.norm(X_source @ Q - X_target))

Xm = make_matrices(3, 4, "spd", rs=21)
Ym = make_matrices(3, 4, "spd", rs=22)
w = np.array([0.5, 0.3, 0.2])
Qm = np.linalg.qr(rs.randn(4, 4))[0]

print("documented loss sum_i w_i d^2:", w @ distance_riemann(Xm, Qm @ Ym @ Qm.T) ** 2)
print("value returned by _loss      :", _loss(Qm, Xm, Ym, w, metric="riemann"))

eps, grad_num = 1e-6, np.zeros((4, 4))
f = lambda Q: w @ distance_riemann(Xm, Q @ Ym @ Q.T) ** 2
for i in range(4):
    for j in range(4):
        step = np.zeros((4, 4))
        step[i, j] = eps
        grad_num[i, j] = (f(Qm + step) - f(Qm - step)) / (2 * eps)
print("max error of _grad vs numerical gradient:",
      np.abs(_grad(Qm, Xm, Ym, w, metric="riemann") - grad_num).max())
```

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
