### PR TITLE
Fix TLScale modifying input matrices in-place

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,11 @@ v0.13.dev
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
 
+- Fix ``fit_transform()`` of :class:`pyriemann.transfer.TLScale`, which
+  modified the input matrices in-place, so that two identical calls on the
+  same array returned different outputs.
+  :pr:`482` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/transfer/_estimators.py
+++ b/pyriemann/transfer/_estimators.py
@@ -542,12 +542,13 @@ class TLScale(TransformerMixin, BaseEstimator):
             idx = domains == d
 
             if X.ndim == 3:
+                X_d = X[idx]
                 if not self.centered_data:  # re-center matrices to identity
-                    X[idx] = self._center(X[idx], self._means[d])
+                    X_d = self._center(X_d, self._means[d])
 
                 # stretch
                 X_new[idx] = self._strech(
-                    X[idx], self.scales_[d], self.final_dispersion
+                    X_d, self.scales_[d], self.final_dispersion
                 )
 
                 if not self.centered_data:  # re-center back to previous mean

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -345,6 +345,31 @@ def test_tlscale_tangentspace(rndstate, get_weights, use_weight):
     assert X_new.shape == X.shape
 
 
+@pytest.mark.parametrize("estimator", [TLCenter, TLScale, TLRotate])
+@pytest.mark.parametrize("use_vectors", [True, False])
+def test_transformer_does_not_modify_inputs(rndstate, estimator, use_vectors):
+    """Test that fit_transform does not modify the inputs"""
+    if use_vectors:
+        X, y_enc = make_classification_transfer_tangspace(
+            rndstate, ["tgt", "src"], n_vectors_d=20, n_ts=4,
+        )
+    else:
+        X, y_enc = make_classification_transfer(
+            n_matrices=20, random_state=rndstate,
+        )
+        _, y, domain = decode_domains(X, y_enc)
+        domain = np.where(domain == "target_domain", "tgt", "src")
+        _, y_enc = encode_domains(X, y, domain)
+    X_copy = X.copy()
+
+    X_new = estimator(target_domain="tgt").fit_transform(X, y_enc)
+
+    assert_array_equal(X, X_copy)
+    # calling fit_transform twice on the same inputs gives the same outputs
+    X_new2 = estimator(target_domain="tgt").fit_transform(X, y_enc)
+    assert_array_equal(X_new, X_new2)
+
+
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
 @pytest.mark.parametrize("use_weight", [True, False])
 def test_tlrotate_manifold(rndstate, get_weights, metric, use_weight):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -111,6 +111,30 @@ def test_tlsplitter(rndstate, cv):
 ###############################################################################
 
 
+@pytest.mark.parametrize("estimator", [TLCenter, TLScale, TLRotate])
+@pytest.mark.parametrize("use_vectors", [True, False])
+def test_tltransformer_fittransform(estimator, use_vectors, rndstate):
+    """Test that fit_transform does not modify the inputs"""
+    if use_vectors:
+        X, y_enc = make_classification_transfer_tangspace(
+            rndstate, ["tgt", "src"], n_vectors_d=20, n_ts=4,
+        )
+    else:
+        X, y_enc = make_classification_transfer(
+            n_matrices=20, random_state=rndstate,
+            domain_names=["tgt", "src"]
+        )
+    X_copy = X.copy()
+
+    # calling fit_transform does not modify inputs
+    X_new = estimator(target_domain="tgt").fit_transform(X, y_enc)
+    assert_array_equal(X, X_copy)
+
+    # calling fit_transform twice on the same inputs gives the same outputs
+    X_new2 = estimator(target_domain="tgt").fit_transform(X, y_enc)
+    assert_array_equal(X_new, X_new2)
+
+
 @pytest.mark.parametrize("space", ["manifold", "tangentspace"])
 def test_tldummy(rndstate, space):
     X, y_enc = make_classification_transfer(
@@ -343,31 +367,6 @@ def test_tlscale_tangentspace(rndstate, get_weights, use_weight):
 
     X_new = tlscl.transform(X)
     assert X_new.shape == X.shape
-
-
-@pytest.mark.parametrize("estimator", [TLCenter, TLScale, TLRotate])
-@pytest.mark.parametrize("use_vectors", [True, False])
-def test_transformer_does_not_modify_inputs(rndstate, estimator, use_vectors):
-    """Test that fit_transform does not modify the inputs"""
-    if use_vectors:
-        X, y_enc = make_classification_transfer_tangspace(
-            rndstate, ["tgt", "src"], n_vectors_d=20, n_ts=4,
-        )
-    else:
-        X, y_enc = make_classification_transfer(
-            n_matrices=20, random_state=rndstate,
-        )
-        _, y, domain = decode_domains(X, y_enc)
-        domain = np.where(domain == "target_domain", "tgt", "src")
-        _, y_enc = encode_domains(X, y, domain)
-    X_copy = X.copy()
-
-    X_new = estimator(target_domain="tgt").fit_transform(X, y_enc)
-
-    assert_array_equal(X, X_copy)
-    # calling fit_transform twice on the same inputs gives the same outputs
-    X_new2 = estimator(target_domain="tgt").fit_transform(X, y_enc)
-    assert_array_equal(X_new, X_new2)
 
 
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])


### PR DESCRIPTION
`TLScale.fit_transform` writes into the array given by the caller, so calling it twice on the same matrices gives two different results.

On current master:

```python
import numpy as np
from pyriemann.datasets import make_classification_transfer
from pyriemann.transfer import TLScale

X, y_enc = make_classification_transfer(n_matrices=10, random_state=42)
X_copy = X.copy()

X_new = TLScale(target_domain="target_domain").fit_transform(X, y_enc)
print("input matrices left untouched:", np.array_equal(X, X_copy))

X_new2 = TLScale(target_domain="target_domain").fit_transform(X, y_enc)
print("same call, same result       :", np.array_equal(X_new, X_new2))
print("max difference between them  :", np.abs(X_new - X_new2).max())
```

```
input matrices left untouched: False
same call, same result       : False
max difference between them  : 3.6974495398852905
```

The cause is `X[idx] = self._center(X[idx], self._means[d])` in `fit_transform`. The second run sees data that is already centered on each domain mean, so it scales the wrong thing.

`TLCenter`, `TLRotate` and `TLScale.transform` all rebind a local name instead, so the fix follows that same pattern with a local `X_d`. The returned `X_new` is unchanged bit for bit, only the caller's array is left alone.

Test added to `tests/test_transfer.py`: `test_transformer_does_not_modify_inputs`, parametrized over `TLCenter`, `TLScale` and `TLRotate` and over matrix and vector inputs, checking both that the input is untouched and that two identical calls agree.

Of 6 selected cases, 1 fails on master (the `TLScale` matrix branch) and all 6 pass with the branch. Full `tests/` run gives 3594 passed and 1272 skipped. `flake8` is clean and there is a `doc/whatsnew.rst` entry.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
