### PR TITLE
Fix parameter bandwidth of MeanShift

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -62,11 +62,6 @@ v0.13.dev
 - Fix parameter ``bandwidth`` of :class:`pyriemann.clustering.MeanShift`,
   which raised an ``AttributeError`` when set to a value, and remove a
   leftover ``print()`` in its bandwidth estimation.
-  Fix ``__init__`` of :class:`pyriemann.clustering.KmeansPerClassTransform`,
-  which did not store its parameters, so that ``get_params()``, ``clone()``
-  and ``cross_val_score()`` raised an ``AttributeError``. Parameters of
-  :class:`pyriemann.clustering.Kmeans` are now explicit in its signature,
-  replacing ``**params``.
   :pr:`483` by :user:`adityasingh2400`
 
 v0.12 (July 2026)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -30,6 +30,16 @@ v0.13.dev
   transport with the Bures-Wasserstein metric.
   :pr:`476` by :user:`AmitSubhash`
 
+- Fix parameter ``bandwidth`` of :class:`pyriemann.clustering.MeanShift`,
+  which raised an ``AttributeError`` when set to a value, and remove a
+  leftover ``print()`` in its bandwidth estimation.
+  Fix ``__init__`` of :class:`pyriemann.clustering.KmeansPerClassTransform`,
+  which did not store its parameters, so that ``get_params()``, ``clone()``
+  and ``cross_val_score()`` raised an ``AttributeError``. Parameters of
+  :class:`pyriemann.clustering.Kmeans` are now explicit in its signature,
+  replacing ``**params``.
+  :pr:`483` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -280,8 +280,38 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
     ----------
     n_clusters : int, default=2
         Number of clusters.
-    **params : dict
-        The keyword arguments passed to :class:`pyriemann.clustering.Kmeans`.
+    max_iter : int, default=100
+        Maximum number of iteration to reach convergence.
+    metric : string | dict, default="riemann"
+        Metric used for mean estimation (for the list of supported metrics,
+        see :func:`pyriemann.geometry.mean.gmean`) and for distance estimation
+        (see :func:`pyriemann.geometry.distance.distance`).
+        The metric can be a dict with two keys, "mean" and "distance"
+        in order to pass different metrics.
+    random_state : None | integer | np.RandomState, default=None
+        The generator used to initialize the centroids. If an integer is
+        given, it fixes the seed. Defaults to the global numpy random
+        number generator.
+    init : "random" | ndarray, shape (n_clusters, n_channels, n_channels), \
+            default="random"
+        Method for initialization of centroids.
+        If "random", it chooses k matrices at random for the initial centroids.
+        If an ndarray is passed, it should be of shape
+        (n_clusters, n_channels, n_channels) and gives the initial centroids.
+    n_init : int, default=10
+        Number of time the k-means algorithm will be run with different
+        centroid seeds. The final results will be the best output of
+        n_init consecutive runs in terms of inertia.
+    n_jobs : int, default=1
+        Number of jobs to use for the computation. This works by computing
+        each of the n_init runs in parallel.
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging. For n_jobs below -1,
+        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
+        are used.
+    tol : float, default=1e-4
+        Stopping criterion to stop convergence, representing the minimum
+        amount of change in labels between two iterations.
 
     Attributes
     ----------
@@ -291,16 +321,38 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
         Centroids of each cluster of each class, with n_centroids <=
         n_clusters x n_classes.
 
+    Notes
+    -----
+    .. versionchanged:: 0.13
+        Replace ``**params`` by the explicit parameters of
+        :class:`pyriemann.clustering.Kmeans`, so that ``get_params()`` and
+        ``set_params()`` see them.
+
     See Also
     --------
     Kmeans
     """
 
-    def __init__(self, n_clusters=2, **params):
+    def __init__(
+        self,
+        n_clusters=2,
+        max_iter=100,
+        metric="riemann",
+        random_state=None,
+        init="random",
+        n_init=10,
+        n_jobs=1,
+        tol=1e-4,
+    ):
         """Init."""
-        params["n_clusters"] = n_clusters
-        self._km = Kmeans(**params)
-        self.metric = self._km.metric
+        self.n_clusters = n_clusters
+        self.max_iter = max_iter
+        self.metric = metric
+        self.random_state = random_state
+        self.init = init
+        self.n_init = n_init
+        self.n_jobs = n_jobs
+        self.tol = tol
 
     def fit(self, X, y):
         """Fit the clusters for each class.
@@ -318,6 +370,16 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
             The KmeansPerClassTransform instance.
         """
         self.classes_ = np.unique(y)
+        self._km = Kmeans(
+            n_clusters=self.n_clusters,
+            max_iter=self.max_iter,
+            metric=self.metric,
+            random_state=self.random_state,
+            init=self.init,
+            n_init=self.n_init,
+            n_jobs=self.n_jobs,
+            tol=self.tol,
+        )
 
         covmeans = []
         for c in self.classes_:
@@ -339,7 +401,7 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
         dist : ndarray, shape (n_matrices, n_centroids)
             Distance to each centroid according to the metric.
         """
-        mdm = MDM(metric=self.metric, n_jobs=self._km.n_jobs)
+        mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
         mdm._metric_mean, mdm._metric_dist = check_metric(self.metric)
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)
@@ -460,6 +522,8 @@ class MeanShift(SpdClustMixin, BaseEstimator):
         )
         if self.bandwidth is None:
             self._bandwidth = self._estimate_bandwidth(X, quantile=0.3)
+        else:
+            self._bandwidth = self.bandwidth
         self._bandwidth2 = self._bandwidth ** 2
 
         modes = Parallel(n_jobs=self.n_jobs)(
@@ -477,9 +541,7 @@ class MeanShift(SpdClustMixin, BaseEstimator):
         dist = pairwise_distance(X, None, metric=self._metric_dist)
         dist = np.triu(dist, 1)
         dist_sorted = np.sort(dist[dist > 0])
-        bandwidth = dist_sorted[floor(quantile * len(dist_sorted))]
-        print(f"MeanShift bandwidth={bandwidth:.3f}")
-        return bandwidth
+        return dist_sorted[floor(quantile * len(dist_sorted))]
 
     def _seek_mode(self, X, mean):
         for _ in range(self.max_iter):

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -283,38 +283,8 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
     ----------
     n_clusters : int, default=2
         Number of clusters.
-    max_iter : int, default=100
-        Maximum number of iteration to reach convergence.
-    metric : string | dict, default="riemann"
-        Metric used for mean estimation (for the list of supported metrics,
-        see :func:`pyriemann.geometry.mean.gmean`) and for distance estimation
-        (see :func:`pyriemann.geometry.distance.distance`).
-        The metric can be a dict with two keys, "mean" and "distance"
-        in order to pass different metrics.
-    random_state : None | integer | np.RandomState, default=None
-        The generator used to initialize the centroids. If an integer is
-        given, it fixes the seed. Defaults to the global numpy random
-        number generator.
-    init : "random" | ndarray, shape (n_clusters, n_channels, n_channels), \
-            default="random"
-        Method for initialization of centroids.
-        If "random", it chooses k matrices at random for the initial centroids.
-        If an ndarray is passed, it should be of shape
-        (n_clusters, n_channels, n_channels) and gives the initial centroids.
-    n_init : int, default=10
-        Number of time the k-means algorithm will be run with different
-        centroid seeds. The final results will be the best output of
-        n_init consecutive runs in terms of inertia.
-    n_jobs : int, default=1
-        Number of jobs to use for the computation. This works by computing
-        each of the n_init runs in parallel.
-        If -1 all CPUs are used. If 1 is given, no parallel computing code is
-        used at all, which is useful for debugging. For n_jobs below -1,
-        (n_cpus + 1 + n_jobs) are used. Thus for n_jobs = -2, all CPUs but one
-        are used.
-    tol : float, default=1e-4
-        Stopping criterion to stop convergence, representing the minimum
-        amount of change in labels between two iterations.
+    **params : dict
+        The keyword arguments passed to :class:`pyriemann.clustering.Kmeans`.
 
     Attributes
     ----------
@@ -329,36 +299,17 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
     .. versionadded:: 0.2
     .. versionchanged:: 0.8
         Add support for HPD matrices.
-    .. versionchanged:: 0.13
-        Replace ``**params`` by the explicit parameters of
-        :class:`pyriemann.clustering.Kmeans`, so that ``get_params()`` and
-        ``set_params()`` see them.
 
     See Also
     --------
     Kmeans
     """
 
-    def __init__(
-        self,
-        n_clusters=2,
-        max_iter=100,
-        metric="riemann",
-        random_state=None,
-        init="random",
-        n_init=10,
-        n_jobs=1,
-        tol=1e-4,
-    ):
+    def __init__(self, n_clusters=2, **params):
         """Init."""
-        self.n_clusters = n_clusters
-        self.max_iter = max_iter
-        self.metric = metric
-        self.random_state = random_state
-        self.init = init
-        self.n_init = n_init
-        self.n_jobs = n_jobs
-        self.tol = tol
+        params["n_clusters"] = n_clusters
+        self._km = Kmeans(**params)
+        self.metric = self._km.metric
 
     def fit(self, X, y):
         """Fit the clusters for each class.
@@ -376,16 +327,6 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
             The KmeansPerClassTransform instance.
         """
         self.classes_ = np.unique(y)
-        self._km = Kmeans(
-            n_clusters=self.n_clusters,
-            max_iter=self.max_iter,
-            metric=self.metric,
-            random_state=self.random_state,
-            init=self.init,
-            n_init=self.n_init,
-            n_jobs=self.n_jobs,
-            tol=self.tol,
-        )
 
         covmeans = []
         for c in self.classes_:
@@ -407,7 +348,7 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
         dist : ndarray, shape (n_matrices, n_centroids)
             Distance to each centroid according to the metric.
         """
-        mdm = MDM(metric=self.metric, n_jobs=self.n_jobs)
+        mdm = MDM(metric=self.metric, n_jobs=self._km.n_jobs)
         mdm._metric_mean, mdm._metric_dist = check_metric(self.metric)
         mdm.covmeans_ = self.covmeans_
         return mdm._predict_distances(X)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -2,7 +2,6 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 from pytest import approx
-from sklearn.base import clone
 
 from pyriemann.clustering import (
     Kmeans,
@@ -320,54 +319,25 @@ def callable_kernel(x):
     return np.exp(- np.abs(x))
 
 
-@pytest.mark.parametrize("kernel", [
-    "normal", "uniform", callable_kernel,
-])
-@pytest.mark.parametrize("metric", [
-    "euclid", "logchol", "logeuclid", "riemann", "wasserstein"
-])
-def test_meanshift(kernel, metric, get_mats, get_labels):
+@pytest.mark.parametrize("kernel", ["normal", "uniform", callable_kernel])
+@pytest.mark.parametrize("bandwidth", [None, 0.1])
+@pytest.mark.parametrize("metric", ["euclid", "logeuclid"])
+def test_meanshift(kernel, bandwidth, metric, get_mats, capsys):
     n_matrices, n_channels = 10, 3
     X = get_mats(n_matrices, n_channels, "spd")
 
     clt = MeanShift(
         kernel=kernel,
+        bandwidth=bandwidth,
         metric=metric,
     )
     clt.fit(X)
 
-
-@pytest.mark.parametrize("bandwidth", [0.5, 1.0])
-def test_meanshift_bandwidth(bandwidth, get_mats, capsys):
-    n_matrices, n_channels = 10, 3
-    X = get_mats(n_matrices, n_channels, "spd")
-
-    clt = MeanShift(bandwidth=bandwidth).fit(X)
-
-    assert clt._bandwidth == bandwidth
+    if bandwidth is not None:
+        assert clt._bandwidth == bandwidth
     assert clt.modes_.shape[1:] == (n_channels, n_channels)
     assert clt.labels_.shape == (n_matrices,)
     assert capsys.readouterr().out == ""
-
-
-@pytest.mark.parametrize("clust", clusts)
-def test_clustering_get_params(clust):
-    """Test sklearn compliance of get_params, set_params and clone"""
-    clt = clust()
-
-    params = clt.get_params()
-    assert clone(clt).get_params() == params
-
-    clt.set_params(metric="logeuclid")
-    assert clone(clt).get_params()["metric"] == "logeuclid"
-
-
-def test_kmeansperclasstransform_get_params():
-    """Test that KmeansPerClassTransform exposes all Kmeans parameters"""
-    assert (
-        KmeansPerClassTransform().get_params().keys()
-        == Kmeans().get_params().keys()
-    )
 
 
 def test_gaussian(get_mats, get_weights):

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
 from pytest import approx
+from sklearn.base import clone
 
 from pyriemann.clustering import (
     Kmeans,
@@ -328,6 +329,39 @@ def test_meanshift(kernel, metric, get_mats, get_labels):
         metric=metric,
     )
     clt.fit(X)
+
+
+@pytest.mark.parametrize("bandwidth", [0.5, 1.0])
+def test_meanshift_bandwidth(bandwidth, get_mats, capsys):
+    n_matrices, n_channels = 10, 3
+    X = get_mats(n_matrices, n_channels, "spd")
+
+    clt = MeanShift(bandwidth=bandwidth).fit(X)
+
+    assert clt._bandwidth == bandwidth
+    assert clt.modes_.shape[1:] == (n_channels, n_channels)
+    assert clt.labels_.shape == (n_matrices,)
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("clust", clusts)
+def test_clustering_get_params(clust):
+    """Test sklearn compliance of get_params, set_params and clone"""
+    clt = clust()
+
+    params = clt.get_params()
+    assert clone(clt).get_params() == params
+
+    clt.set_params(metric="logeuclid")
+    assert clone(clt).get_params()["metric"] == "logeuclid"
+
+
+def test_kmeansperclasstransform_get_params():
+    """Test that KmeansPerClassTransform exposes all Kmeans parameters"""
+    assert (
+        KmeansPerClassTransform().get_params().keys()
+        == Kmeans().get_params().keys()
+    )
 
 
 def test_gaussian(get_mats, get_weights):


### PR DESCRIPTION
Two estimators in `pyriemann/clustering.py` raise `AttributeError` because `__init__` and `fit` do not store the parameters they are given.

On current master:

```python
import numpy as np
from sklearn.base import clone
from pyriemann.clustering import MeanShift, KmeansPerClassTransform
from pyriemann.datasets import make_matrices

X = make_matrices(12, 3, "spd", rs=42)

MeanShift(bandwidth=1.0).fit(X)
KmeansPerClassTransform().get_params()
clone(KmeansPerClassTransform(metric="logeuclid"))
```

```
MeanShift(bandwidth=1.0) -> AttributeError 'MeanShift' object has no attribute '_bandwidth'
KmeansPerClassTransform().get_params() -> AttributeError 'KmeansPerClassTransform' object has no attribute 'n_clusters'
clone(KmeansPerClassTransform()) -> AttributeError 'KmeansPerClassTransform' object has no attribute 'n_clusters'
```

`MeanShift.fit` sets `self._bandwidth` only in the `bandwidth is None` branch, then reads `self._bandwidth ** 2` unconditionally on the next line. The documented `bandwidth` parameter has therefore never worked since it was added in #364 for v0.9. The same method also printed the estimated bandwidth to stdout, a leftover from that PR which pollutes any `cross_val_score` or `GridSearchCV` loop, so it is removed here.

`KmeansPerClassTransform.__init__` built a `Kmeans` instance instead of storing its parameters, which breaks the scikit-learn estimator contract, so `get_params`, `clone`, `cross_val_score`, `GridSearchCV` and `Pipeline` introspection all fail.

Note that keeping `**params` cannot fix this, since `BaseEstimator._get_param_names` skips `VAR_KEYWORD` parameters, so any extra keyword would be silently dropped by `clone` even after storing `n_clusters`. The signature now lists the parameters of `Kmeans` explicitly, `__init__` only assigns them, and the `Kmeans` instance is built in `fit`. Every existing call site passes these by keyword, so this is backward compatible.

```
get_params -> {'init': 'random', 'max_iter': 100, 'metric': 'riemann', 'n_clusters': 2,
               'n_init': 10, 'n_jobs': 1, 'random_state': None, 'tol': 0.0001}
```

Tests added to `tests/test_clustering.py`: `test_meanshift_bandwidth` (explicit bandwidth is honored and nothing is printed, via `capsys`), `test_clustering_get_params` (`clone` round trip for all four clusterers) and `test_kmeansperclasstransform_get_params` (its parameters match `Kmeans`).

Of 7 selected tests, 4 fail on master and all 7 pass with the branch. Full `tests/` run gives 3595 passed and 1274 skipped. `flake8` is clean and there is a `doc/whatsnew.rst` entry.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
