### PR TITLE
Correct loss and gradient minimized by TLRotate in manifold

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -64,7 +64,7 @@ v0.13.dev
   sum of squared distances it is documented to minimize and that the gradient
   is derived from, and the gradient for ``metric="riemann"`` no longer
   diagonalizes a non-symmetric matrix with ``numpy.linalg.eigh``.
-  :pr:`484` by :user:`adityasingh2400`
+  :pr:`492` by :user:`adityasingh2400`
 
 v0.12 (July 2026)
 -----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -59,6 +59,13 @@ v0.13.dev
   for two matrices, which were using a wrong position on the geodesic when ``sample_weight`` is not uniform.
   :pr:`480` by :user:`adityasingh2400`
 
+- Fix the loss and the gradient minimized by
+  :class:`pyriemann.transfer.TLRotate` in manifold: the loss now returns the
+  sum of squared distances it is documented to minimize and that the gradient
+  is derived from, and the gradient for ``metric="riemann"`` no longer
+  diagonalizes a non-symmetric matrix with ``numpy.linalg.eigh``.
+  :pr:`484` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/optimization/grassmann.py
+++ b/pyriemann/optimization/grassmann.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 
+from ..geometry.base import invsqrtm, logm, sqrtm
 from ..geometry.distance import distance
 from ..utils._check import check_weights
 
@@ -34,7 +35,7 @@ def _retract(X, v):
 def _loss(Q, X, Y, weights, metric="euclid"):
     """Loss function for estimating the rotation matrix."""
 
-    return weights @ distance(X, Q @ Y @ Q.T, metric=metric)
+    return weights @ distance(X, Q @ Y @ Q.T, metric=metric, squared=True)
 
 
 def _grad(Q, X, Y, weights, metric="euclid"):
@@ -44,11 +45,13 @@ def _grad(Q, X, Y, weights, metric="euclid"):
         return np.einsum("a,abc->bc", weights, -4 * (X - Q @ Y @ Q.T) @ Q @ Y)
 
     elif metric == "riemann":
-        M = np.linalg.solve(X, Q) @ Y @ Q.T
-        eigvals, eigvecs = np.linalg.eigh(M)
-        logeigvals = np.expand_dims(np.log(eigvals), -2)
-        inveigvecs = np.linalg.solve(eigvecs, np.eye(eigvecs.shape[-1]))
-        logM = (eigvecs * logeigvals) @ inveigvecs
+        # logm of X^-1 S, with S = Q Y Q^T. This product of two SPD matrices
+        # is not symmetric, so it cannot be diagonalized by eigh. It is
+        # however similar to the SPD matrix X^-1/2 S X^-1/2, which is:
+        # logm(X^-1 S) = X^-1/2 logm(X^-1/2 S X^-1/2) X^1/2
+        X_invsqrt, X_sqrt = invsqrtm(X), sqrtm(X)
+        S = Q @ Y @ Q.T
+        logM = X_invsqrt @ logm(X_invsqrt @ S @ X_invsqrt) @ X_sqrt
         return np.einsum("a,abc->bc", weights, 4 * logM @ Q)
 
     else:

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -7,6 +7,9 @@ from pyriemann.geometry.distance import distance
 from pyriemann.optimization.grassmann import _grad, _loss
 
 
+pytestmark = pytest.mark.numpy_only
+
+
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
 def test_grassmann_loss(metric, get_mats, get_weights):
     """Test that loss is the weighted sum of squared distances"""

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,47 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+import pytest
+from pytest import approx
+
+from pyriemann.datasets.simulated import make_matrices
+from pyriemann.geometry.distance import distance
+from pyriemann.optimization.grassmann import _grad, _loss
+
+
+@pytest.mark.parametrize("metric", ["euclid", "riemann"])
+def test_grassmann_loss(rndstate, metric):
+    """Test that loss is the weighted sum of squared distances"""
+    n_matrices, n_channels = 3, 4
+    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    weights = np.array([0.5, 0.3, 0.2])
+    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
+
+    assert _loss(Q, X, Y, weights, metric=metric) == approx(
+        weights @ distance(X, Q @ Y @ Q.T, metric=metric) ** 2
+    )
+
+
+@pytest.mark.parametrize("metric", ["euclid", "riemann"])
+def test_grassmann_grad(rndstate, metric):
+    """Test that gradient is the derivative of the loss"""
+    n_matrices, n_channels = 3, 4
+    X = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    Y = make_matrices(n_matrices, n_channels, "spd", rs=rndstate)
+    weights = np.array([0.5, 0.3, 0.2])
+    Q = np.linalg.qr(rndstate.randn(n_channels, n_channels))[0]
+
+    eps = 1e-6
+    grad_num = np.zeros((n_channels, n_channels))
+    for i in range(n_channels):
+        for j in range(n_channels):
+            step = np.zeros((n_channels, n_channels))
+            step[i, j] = eps
+            grad_num[i, j] = (
+                _loss(Q + step, X, Y, weights, metric=metric)
+                - _loss(Q - step, X, Y, weights, metric=metric)
+            ) / (2 * eps)
+
+    grad = _grad(Q, X, Y, weights, metric=metric)
+    assert grad.dtype == grad_num.dtype
+    assert_array_almost_equal(grad, grad_num, decimal=5)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -14,6 +14,10 @@ from pyriemann.optimization.grassmann import (
 pytestmark = pytest.mark.numpy_only
 
 
+def _is_orth(X):
+    return X @ X.T == approx(np.eye(X.shape[0]))
+
+
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
 def test_grassmann_loss(metric, get_mats, get_weights):
     """Test that loss is the weighted sum of squared distances"""
@@ -31,7 +35,7 @@ def test_grassmann_loss(metric, get_mats, get_weights):
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
 def test_grassmann_grad(metric, get_mats, get_weights):
     """Test that gradient is the derivative of the loss"""
-    n_matrices, n_channels = 3, 4
+    n_matrices, n_channels = 5, 3
     X = get_mats(n_matrices, n_channels, "spd")
     Y = get_mats(n_matrices, n_channels, "spd")
     weights = get_weights(n_matrices)
@@ -53,14 +57,9 @@ def test_grassmann_grad(metric, get_mats, get_weights):
     assert_array_almost_equal(grad, grad_num, decimal=5)
 
 
-def _is_orth(X):
-    return X @ X.T == approx(np.eye(X.shape[0]))
-
-
 @pytest.mark.parametrize("metric", ["euclid", "riemann"])
 def test_get_rotation_manifold(metric, get_mats, get_weights):
-    """Test that the rotation is a rotation matrix"""
-    n_matrices, n_channels = 3, 4
+    n_matrices, n_channels = 5, 4
     X_source = get_mats(n_matrices, n_channels, "spd")
     X_target = get_mats(n_matrices, n_channels, "spd")
     weights = get_weights(n_matrices)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -4,7 +4,11 @@ import pytest
 from pytest import approx
 
 from pyriemann.geometry.distance import distance
-from pyriemann.optimization.grassmann import _grad, _loss
+from pyriemann.optimization.grassmann import (
+    _get_rotation_manifold,
+    _grad,
+    _loss,
+)
 
 
 pytestmark = pytest.mark.numpy_only
@@ -47,3 +51,21 @@ def test_grassmann_grad(metric, get_mats, get_weights):
     grad = _grad(Q, X, Y, weights, metric=metric)
     assert grad.dtype == grad_num.dtype
     assert_array_almost_equal(grad, grad_num, decimal=5)
+
+
+def _is_orth(X):
+    return X @ X.T == approx(np.eye(X.shape[0]))
+
+
+@pytest.mark.parametrize("metric", ["euclid", "riemann"])
+def test_get_rotation_manifold(metric, get_mats, get_weights):
+    """Test that the rotation is a rotation matrix"""
+    n_matrices, n_channels = 3, 4
+    X_source = get_mats(n_matrices, n_channels, "spd")
+    X_target = get_mats(n_matrices, n_channels, "spd")
+    weights = get_weights(n_matrices)
+
+    Q = _get_rotation_manifold(X_source, X_target, weights, metric=metric)
+
+    assert Q.shape == (n_channels, n_channels)
+    assert _is_orth(Q)


### PR DESCRIPTION
Split out of #481 at @qbarthelemy's request, so that the tangent-space rotation and the manifold loss/gradient are reviewed separately. #481 now carries only the tangent-space fix.

Two problems in `pyriemann/optimization/grassmann.py`, both in the manifold branch of `TLRotate`.

**`_loss` did not return what it documents.** `TLRotate` in manifold minimizes the weighted sum of *squared* distances, and `_grad` is the derivative of that. `_loss` returned unsquared distances, so the value it reported was not the quantity being minimized and did not match its own gradient.

**`_grad` diagonalized a non-symmetric matrix with `eigh` for `metric="riemann"`.** It computed `M = X^-1 Q Y Q^T` and passed it to `numpy.linalg.eigh`. `M` is a product of two SPD matrices, which is generally not symmetric, and `eigh` reads only one triangle, so the result was the log of a different matrix. The fix uses the standard similarity transform:

```
logm(X^-1 S) = X^-1/2 logm(X^-1/2 S X^-1/2) X^1/2
```

where `X^-1/2 S X^-1/2` is SPD and safe to diagonalize.

**Tests.** `tests/test_optimization.py` gets `test_grassmann_loss`, which pins the loss to the weighted sum of squared distances, and `test_grassmann_grad`, which checks `_grad` against a central finite difference of `_loss` for both metrics. Against unpatched `master` all 4 parametrizations fail. With the fix the file is 4 passed, and `tests/test_transfer.py` plus `tests/test_optimization.py` together are 196 passed, 127 skipped.

https://claude.ai/code/session_0189zxefNUxZmXLRED6jPeMy
