### PR TITLE
Fix __init__ of KmeansPerClassTransform not storing its parameters

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -76,6 +76,12 @@ v0.13.dev
   each source domain onto the target domain.
   :pr:`481` by :user:`adityasingh2400`
 
+- Fix ``__init__`` of
+  :class:`pyriemann.clustering.KmeansPerClassTransform`, which did not store
+  its parameters, so that ``get_params()``, ``set_params()``, ``clone()`` and
+  ``cross_val_score()`` raised an ``AttributeError``.
+  :pr:`493` by :user:`adityasingh2400`
+
 v0.12 (July 2026)
 -----------------
 

--- a/pyriemann/clustering.py
+++ b/pyriemann/clustering.py
@@ -281,10 +281,11 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_clusters : int, default=2
-        Number of clusters.
     **params : dict
         The keyword arguments passed to :class:`pyriemann.clustering.Kmeans`.
+        They default to the defaults of :class:`pyriemann.clustering.Kmeans`,
+        and are exposed by ``get_params()`` and ``set_params()`` so that the
+        estimator can be cloned and used in a scikit-learn search.
 
     Attributes
     ----------
@@ -299,17 +300,55 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
     .. versionadded:: 0.2
     .. versionchanged:: 0.8
         Add support for HPD matrices.
+    .. versionchanged:: 0.13
+        Store the parameters so that ``get_params()``, ``set_params()`` and
+        ``clone()`` work.
 
     See Also
     --------
     Kmeans
     """
 
-    def __init__(self, n_clusters=2, **params):
+    def __init__(self, **params):
         """Init."""
-        params["n_clusters"] = n_clusters
-        self._km = Kmeans(**params)
-        self.metric = self._km.metric
+        defaults = Kmeans().get_params()
+        defaults.update(params)
+        self.params = defaults
+        for name, value in defaults.items():
+            setattr(self, name, value)
+
+    def get_params(self, deep=True):
+        """Get the parameters passed to :class:`pyriemann.clustering.Kmeans`.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            Unused, kept for scikit-learn compatibility.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        return self.params.copy()
+
+    def set_params(self, **params):
+        """Set the parameters passed to :class:`pyriemann.clustering.Kmeans`.
+
+        Parameters
+        ----------
+        **params : dict
+            Parameters to set.
+
+        Returns
+        -------
+        self : KmeansPerClassTransform instance
+            The KmeansPerClassTransform instance.
+        """
+        for name, value in params.items():
+            self.params[name] = value
+            setattr(self, name, value)
+        return self
 
     def fit(self, X, y):
         """Fit the clusters for each class.
@@ -327,6 +366,8 @@ class KmeansPerClassTransform(SpdTransfMixin, BaseEstimator):
             The KmeansPerClassTransform instance.
         """
         self.classes_ = np.unique(y)
+        self._km = Kmeans(**self.params)
+        self.metric = self._km.metric
 
         covmeans = []
         for c in self.classes_:

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
+from sklearn.base import clone
 from pytest import approx
 
 from pyriemann.clustering import (
@@ -338,6 +339,26 @@ def test_meanshift(kernel, bandwidth, metric, get_mats, capsys):
     assert clt.modes_.shape[1:] == (n_channels, n_channels)
     assert clt.labels_.shape == (n_matrices,)
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("clust", clusts)
+def test_clustering_get_params(clust):
+    """Test sklearn compliance of get_params, set_params and clone"""
+    clt = clust()
+
+    params = clt.get_params()
+    assert clone(clt).get_params() == params
+
+    clt.set_params(metric="logeuclid")
+    assert clone(clt).get_params()["metric"] == "logeuclid"
+
+
+def test_kmeansperclasstransform_get_params():
+    """Test that KmeansPerClassTransform exposes all Kmeans parameters"""
+    assert (
+        KmeansPerClassTransform().get_params().keys()
+        == Kmeans().get_params().keys()
+    )
 
 
 def test_gaussian(get_mats, get_weights):


### PR DESCRIPTION
Split out of #483 at @qbarthelemy's request. #483 now carries only the `MeanShift` bandwidth fix.

`KmeansPerClassTransform.__init__` built a `Kmeans` and kept only that, so the constructor arguments were never stored on the estimator. `BaseEstimator.get_params()` reads them back by attribute, so anything relying on it raised `AttributeError: 'KmeansPerClassTransform' object has no attribute 'n_clusters'`. That covers `get_params()`, `set_params()`, `clone()`, and therefore `cross_val_score()` and every scikit-learn search.

This uses the approach you suggested, which avoids restating the `Kmeans` signature:

```python
def __init__(self, **params):
    defaults = Kmeans().get_params()
    defaults.update(params)
    self.params = defaults
    for name, value in defaults.items():
        setattr(self, name, value)
```

with `get_params`/`set_params` reading and writing `self.params`, and `fit` constructing `Kmeans(**self.params)`. One consequence worth flagging: `n_clusters` is no longer an explicit keyword in the signature, it now comes from the `Kmeans` defaults like every other parameter. `KmeansPerClassTransform(n_clusters=3)` still works.

**Tests.** `test_clustering_get_params` checks `get_params`, `set_params` and `clone` round-trip for every clustering estimator, and `test_kmeansperclasstransform_get_params` pins the exposed keys to `Kmeans`'s. Both fail on unpatched `master` and pass here. Whole file is 62 passed, 60 skipped.

Checked end to end as well:

```
get_params keys == Kmeans keys: True
clone works: True
set_params: riemann
cross_val_score: [0.643 0.538 0.462]
```

https://claude.ai/code/session_0189zxefNUxZmXLRED6jPeMy
